### PR TITLE
DLL export changes

### DIFF
--- a/examples/basic.c
+++ b/examples/basic.c
@@ -31,7 +31,7 @@ int main()
     init_micro_buffer(&reader, buffer, BUFFER_LENGTH);
 
     // Serialize data
-    char input[16] = "Hello microCDR!"; //16 characters
+    char input[16] = "Hello MicroCDR!"; //16 characters
     serialize_array_char(&writer, input, 16);
 
     // Deserialize data

--- a/include/microcdr/common.h
+++ b/include/microcdr/common.h
@@ -19,8 +19,8 @@
 extern "C" {
 #endif
 
-#include <microcdr/microcdr_dll.h>
-#include <microcdr/config.h.in>
+#include <microcdr/dll.h>
+#include <microcdr/config.h>
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -45,28 +45,28 @@ typedef struct MicroBuffer
 
 } MicroBuffer;
 
-microcdr_DllAPI extern const Endianness MACHINE_ENDIANNESS;
+MCDLLAPI extern const Endianness MACHINE_ENDIANNESS;
 
 // ------------------------------------------------
 //              Main library functions
 // ------------------------------------------------
-microcdr_DllAPI void init_micro_buffer               (MicroBuffer* mb, uint8_t* data, const uint32_t size);
-microcdr_DllAPI void init_micro_buffer_offset        (MicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset);
-microcdr_DllAPI void init_micro_buffer_offset_endian (MicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, Endianness endianness);
-microcdr_DllAPI void copy_micro_buffer               (MicroBuffer* mb_dest, const MicroBuffer* mb_source);
+MCDLLAPI void init_micro_buffer               (MicroBuffer* mb, uint8_t* data, const uint32_t size);
+MCDLLAPI void init_micro_buffer_offset        (MicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset);
+MCDLLAPI void init_micro_buffer_offset_endian (MicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, Endianness endianness);
+MCDLLAPI void copy_micro_buffer               (MicroBuffer* mb_dest, const MicroBuffer* mb_source);
 
-microcdr_DllAPI void reset_micro_buffer        (MicroBuffer* mb);
-microcdr_DllAPI void reset_micro_buffer_offset (MicroBuffer* mb, const uint32_t offset);
+MCDLLAPI void reset_micro_buffer        (MicroBuffer* mb);
+MCDLLAPI void reset_micro_buffer_offset (MicroBuffer* mb, const uint32_t offset);
 
-microcdr_DllAPI void     align_to            (MicroBuffer* mb, const uint32_t alignment);
-microcdr_DllAPI uint32_t get_alignment       (uint32_t buffer_position, const uint32_t data_size); //change name
-microcdr_DllAPI uint32_t get_alignment_offset(const MicroBuffer* mb, const uint32_t data_size); //change name
+MCDLLAPI void     align_to            (MicroBuffer* mb, const uint32_t alignment);
+MCDLLAPI uint32_t get_alignment       (uint32_t buffer_position, const uint32_t data_size); //change name
+MCDLLAPI uint32_t get_alignment_offset(const MicroBuffer* mb, const uint32_t data_size); //change name
 
-microcdr_DllAPI size_t     micro_buffer_size      (const MicroBuffer* mb);
-microcdr_DllAPI size_t     micro_buffer_length    (const MicroBuffer* mb);
-microcdr_DllAPI size_t     micro_buffer_remaining (const MicroBuffer* mb);
-microcdr_DllAPI Endianness micro_buffer_endianness(const MicroBuffer* mb);
-microcdr_DllAPI bool       micro_buffer_has_error (const MicroBuffer* mb);
+MCDLLAPI size_t     micro_buffer_size      (const MicroBuffer* mb);
+MCDLLAPI size_t     micro_buffer_length    (const MicroBuffer* mb);
+MCDLLAPI size_t     micro_buffer_remaining (const MicroBuffer* mb);
+MCDLLAPI Endianness micro_buffer_endianness(const MicroBuffer* mb);
+MCDLLAPI bool       micro_buffer_has_error (const MicroBuffer* mb);
 
 #ifdef __cplusplus
 }

--- a/include/microcdr/dll.h
+++ b/include/microcdr/dll.h
@@ -13,23 +13,21 @@
 // limitations under the License.
 
 
-#ifndef _MICROCDR_MICROCDR_DLL_H_
-#define _MICROCDR_MICROCDR_DLL_H_
-
-#include <microcdr/config.h>
+#ifndef _MICROCDR_DLL_H_
+#define _MICROCDR_DLL_H_
 
 #if defined(_WIN32)
 #if defined(microcdr_SHARED)
 #if defined(microcdr_EXPORTS)
-#define microcdr_DllAPI __declspec( dllexport )
+#define MCDLLAPI __declspec( dllexport )
 #else
-#define microcdr_DllAPI __declspec( dllimport )
+#define MCDLLAPI __declspec( dllimport )
 #endif // microcdr_EXPORTS
 #else
-#define microcdr_DllAPI
+#define MCDLLAPI
 #endif // BUILDING_SHARED_LIBS
 #else
-#define microcdr_DllAPI
+#define MCDLLAPI
 #endif // _WIN32
 
-#endif // _MICROCDR_MICROCDR_DLL_H_
+#endif // _MICROCDR_DLL_H_

--- a/include/microcdr/types/array.h
+++ b/include/microcdr/types/array.h
@@ -25,49 +25,49 @@ extern "C" {
 //                   PUBLIC SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
 
-microcdr_DllAPI bool serialize_array_char(MicroBuffer* mb, const char* array, const uint32_t size);
-microcdr_DllAPI bool serialize_array_bool(MicroBuffer* mb, const bool* array, const uint32_t size);
-microcdr_DllAPI bool serialize_array_uint8_t(MicroBuffer* mb, const uint8_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_array_uint16_t(MicroBuffer* mb, const uint16_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_array_uint32_t(MicroBuffer* mb, const uint32_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_array_uint64_t(MicroBuffer* mb, const uint64_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_array_int8_t(MicroBuffer* mb, const int8_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_array_int16_t(MicroBuffer* mb, const int16_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_array_int32_t(MicroBuffer* mb, const int32_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_array_int64_t(MicroBuffer* mb, const int64_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_array_float(MicroBuffer* mb, const float* array, const uint32_t size);
-microcdr_DllAPI bool serialize_array_double(MicroBuffer* mb, const double* array, const uint32_t size);
+MCDLLAPI bool serialize_array_char(MicroBuffer* mb, const char* array, const uint32_t size);
+MCDLLAPI bool serialize_array_bool(MicroBuffer* mb, const bool* array, const uint32_t size);
+MCDLLAPI bool serialize_array_uint8_t(MicroBuffer* mb, const uint8_t* array, const uint32_t size);
+MCDLLAPI bool serialize_array_uint16_t(MicroBuffer* mb, const uint16_t* array, const uint32_t size);
+MCDLLAPI bool serialize_array_uint32_t(MicroBuffer* mb, const uint32_t* array, const uint32_t size);
+MCDLLAPI bool serialize_array_uint64_t(MicroBuffer* mb, const uint64_t* array, const uint32_t size);
+MCDLLAPI bool serialize_array_int8_t(MicroBuffer* mb, const int8_t* array, const uint32_t size);
+MCDLLAPI bool serialize_array_int16_t(MicroBuffer* mb, const int16_t* array, const uint32_t size);
+MCDLLAPI bool serialize_array_int32_t(MicroBuffer* mb, const int32_t* array, const uint32_t size);
+MCDLLAPI bool serialize_array_int64_t(MicroBuffer* mb, const int64_t* array, const uint32_t size);
+MCDLLAPI bool serialize_array_float(MicroBuffer* mb, const float* array, const uint32_t size);
+MCDLLAPI bool serialize_array_double(MicroBuffer* mb, const double* array, const uint32_t size);
 
-microcdr_DllAPI bool deserialize_array_char(MicroBuffer* mb, char* array, const uint32_t size);
-microcdr_DllAPI bool deserialize_array_bool(MicroBuffer* mb, bool* array, const uint32_t size);
-microcdr_DllAPI bool deserialize_array_uint8_t(MicroBuffer* mb, uint8_t* array, const uint32_t size);
-microcdr_DllAPI bool deserialize_array_uint16_t(MicroBuffer* mb, uint16_t* array, const uint32_t size);
-microcdr_DllAPI bool deserialize_array_uint32_t(MicroBuffer* mb, uint32_t* array, const uint32_t size);
-microcdr_DllAPI bool deserialize_array_uint64_t(MicroBuffer* mb, uint64_t* array, const uint32_t size);
-microcdr_DllAPI bool deserialize_array_int8_t(MicroBuffer* mb, int8_t* array, const uint32_t size);
-microcdr_DllAPI bool deserialize_array_int16_t(MicroBuffer* mb, int16_t* array, const uint32_t size);
-microcdr_DllAPI bool deserialize_array_int32_t(MicroBuffer* mb, int32_t* array, const uint32_t size);
-microcdr_DllAPI bool deserialize_array_int64_t(MicroBuffer* mb, int64_t* array, const uint32_t size);
-microcdr_DllAPI bool deserialize_array_float(MicroBuffer* mb, float* array, const uint32_t size);
-microcdr_DllAPI bool deserialize_array_double(MicroBuffer* mb, double* array, const uint32_t size);
+MCDLLAPI bool deserialize_array_char(MicroBuffer* mb, char* array, const uint32_t size);
+MCDLLAPI bool deserialize_array_bool(MicroBuffer* mb, bool* array, const uint32_t size);
+MCDLLAPI bool deserialize_array_uint8_t(MicroBuffer* mb, uint8_t* array, const uint32_t size);
+MCDLLAPI bool deserialize_array_uint16_t(MicroBuffer* mb, uint16_t* array, const uint32_t size);
+MCDLLAPI bool deserialize_array_uint32_t(MicroBuffer* mb, uint32_t* array, const uint32_t size);
+MCDLLAPI bool deserialize_array_uint64_t(MicroBuffer* mb, uint64_t* array, const uint32_t size);
+MCDLLAPI bool deserialize_array_int8_t(MicroBuffer* mb, int8_t* array, const uint32_t size);
+MCDLLAPI bool deserialize_array_int16_t(MicroBuffer* mb, int16_t* array, const uint32_t size);
+MCDLLAPI bool deserialize_array_int32_t(MicroBuffer* mb, int32_t* array, const uint32_t size);
+MCDLLAPI bool deserialize_array_int64_t(MicroBuffer* mb, int64_t* array, const uint32_t size);
+MCDLLAPI bool deserialize_array_float(MicroBuffer* mb, float* array, const uint32_t size);
+MCDLLAPI bool deserialize_array_double(MicroBuffer* mb, double* array, const uint32_t size);
 
-microcdr_DllAPI bool serialize_endian_array_uint16_t(MicroBuffer* mb, Endianness endianness, const uint16_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_endian_array_uint32_t(MicroBuffer* mb, Endianness endianness, const uint32_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_endian_array_uint64_t(MicroBuffer* mb, Endianness endianness, const uint64_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_endian_array_int16_t(MicroBuffer* mb, Endianness endianness, const int16_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_endian_array_int32_t(MicroBuffer* mb, Endianness endianness, const int32_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_endian_array_int64_t(MicroBuffer* mb, Endianness endianness, const int64_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_endian_array_float(MicroBuffer* mb, Endianness endianness, const float* array, const uint32_t size);
-microcdr_DllAPI bool serialize_endian_array_double(MicroBuffer* mb, Endianness endianness, const double* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_array_uint16_t(MicroBuffer* mb, Endianness endianness, const uint16_t* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_array_uint32_t(MicroBuffer* mb, Endianness endianness, const uint32_t* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_array_uint64_t(MicroBuffer* mb, Endianness endianness, const uint64_t* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_array_int16_t(MicroBuffer* mb, Endianness endianness, const int16_t* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_array_int32_t(MicroBuffer* mb, Endianness endianness, const int32_t* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_array_int64_t(MicroBuffer* mb, Endianness endianness, const int64_t* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_array_float(MicroBuffer* mb, Endianness endianness, const float* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_array_double(MicroBuffer* mb, Endianness endianness, const double* array, const uint32_t size);
 
-microcdr_DllAPI bool deserialize_endian_array_uint16_t(MicroBuffer* mb, Endianness endianness, uint16_t* array, const uint32_t size);
-microcdr_DllAPI bool deserialize_endian_array_uint32_t(MicroBuffer* mb, Endianness endianness, uint32_t* array, const uint32_t size);
-microcdr_DllAPI bool deserialize_endian_array_uint64_t(MicroBuffer* mb, Endianness endianness, uint64_t* array, const uint32_t size);
-microcdr_DllAPI bool deserialize_endian_array_int16_t(MicroBuffer* mb, Endianness endianness, int16_t* array, const uint32_t size);
-microcdr_DllAPI bool deserialize_endian_array_int32_t(MicroBuffer* mb, Endianness endianness, int32_t* array, const uint32_t size);
-microcdr_DllAPI bool deserialize_endian_array_int64_t(MicroBuffer* mb, Endianness endianness, int64_t* array, const uint32_t size);
-microcdr_DllAPI bool deserialize_endian_array_float(MicroBuffer* mb, Endianness endianness, float* array, const uint32_t size);
-microcdr_DllAPI bool deserialize_endian_array_double(MicroBuffer* mb, Endianness endianness, double* array, const uint32_t size);
+MCDLLAPI bool deserialize_endian_array_uint16_t(MicroBuffer* mb, Endianness endianness, uint16_t* array, const uint32_t size);
+MCDLLAPI bool deserialize_endian_array_uint32_t(MicroBuffer* mb, Endianness endianness, uint32_t* array, const uint32_t size);
+MCDLLAPI bool deserialize_endian_array_uint64_t(MicroBuffer* mb, Endianness endianness, uint64_t* array, const uint32_t size);
+MCDLLAPI bool deserialize_endian_array_int16_t(MicroBuffer* mb, Endianness endianness, int16_t* array, const uint32_t size);
+MCDLLAPI bool deserialize_endian_array_int32_t(MicroBuffer* mb, Endianness endianness, int32_t* array, const uint32_t size);
+MCDLLAPI bool deserialize_endian_array_int64_t(MicroBuffer* mb, Endianness endianness, int64_t* array, const uint32_t size);
+MCDLLAPI bool deserialize_endian_array_float(MicroBuffer* mb, Endianness endianness, float* array, const uint32_t size);
+MCDLLAPI bool deserialize_endian_array_double(MicroBuffer* mb, Endianness endianness, double* array, const uint32_t size);
 
 #ifdef __cplusplus
 }

--- a/include/microcdr/types/basic.h
+++ b/include/microcdr/types/basic.h
@@ -25,49 +25,49 @@ extern "C" {
 //                   PUBLIC SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
 
-microcdr_DllAPI bool serialize_char(MicroBuffer* mb, const char value);
-microcdr_DllAPI bool serialize_bool(MicroBuffer* mb, const bool value);
-microcdr_DllAPI bool serialize_uint8_t(MicroBuffer* mb, const uint8_t value);
-microcdr_DllAPI bool serialize_uint16_t(MicroBuffer* mb, const uint16_t value);
-microcdr_DllAPI bool serialize_uint32_t(MicroBuffer* mb, const uint32_t value);
-microcdr_DllAPI bool serialize_uint64_t(MicroBuffer* mb, const uint64_t value);
-microcdr_DllAPI bool serialize_int8_t(MicroBuffer* mb, const int8_t value);
-microcdr_DllAPI bool serialize_int16_t(MicroBuffer* mb, const int16_t value);
-microcdr_DllAPI bool serialize_int32_t(MicroBuffer* mb, const int32_t value);
-microcdr_DllAPI bool serialize_int64_t(MicroBuffer* mb, const int64_t value);
-microcdr_DllAPI bool serialize_float(MicroBuffer* mb, const float value);
-microcdr_DllAPI bool serialize_double(MicroBuffer* mb, const double value);
+MCDLLAPI bool serialize_char(MicroBuffer* mb, const char value);
+MCDLLAPI bool serialize_bool(MicroBuffer* mb, const bool value);
+MCDLLAPI bool serialize_uint8_t(MicroBuffer* mb, const uint8_t value);
+MCDLLAPI bool serialize_uint16_t(MicroBuffer* mb, const uint16_t value);
+MCDLLAPI bool serialize_uint32_t(MicroBuffer* mb, const uint32_t value);
+MCDLLAPI bool serialize_uint64_t(MicroBuffer* mb, const uint64_t value);
+MCDLLAPI bool serialize_int8_t(MicroBuffer* mb, const int8_t value);
+MCDLLAPI bool serialize_int16_t(MicroBuffer* mb, const int16_t value);
+MCDLLAPI bool serialize_int32_t(MicroBuffer* mb, const int32_t value);
+MCDLLAPI bool serialize_int64_t(MicroBuffer* mb, const int64_t value);
+MCDLLAPI bool serialize_float(MicroBuffer* mb, const float value);
+MCDLLAPI bool serialize_double(MicroBuffer* mb, const double value);
 
-microcdr_DllAPI bool deserialize_char(MicroBuffer* mb, char* value);
-microcdr_DllAPI bool deserialize_bool(MicroBuffer* mb, bool* value);
-microcdr_DllAPI bool deserialize_uint8_t(MicroBuffer* mb, uint8_t* value);
-microcdr_DllAPI bool deserialize_uint16_t(MicroBuffer* mb, uint16_t* value);
-microcdr_DllAPI bool deserialize_uint32_t(MicroBuffer* mb, uint32_t* value);
-microcdr_DllAPI bool deserialize_uint64_t(MicroBuffer* mb, uint64_t* value);
-microcdr_DllAPI bool deserialize_int8_t(MicroBuffer* mb, int8_t* value);
-microcdr_DllAPI bool deserialize_int16_t(MicroBuffer* mb, int16_t* value);
-microcdr_DllAPI bool deserialize_int32_t(MicroBuffer* mb, int32_t* value);
-microcdr_DllAPI bool deserialize_int64_t(MicroBuffer* mb, int64_t* value);
-microcdr_DllAPI bool deserialize_float(MicroBuffer* mb, float* value);
-microcdr_DllAPI bool deserialize_double(MicroBuffer* mb, double* value);
+MCDLLAPI bool deserialize_char(MicroBuffer* mb, char* value);
+MCDLLAPI bool deserialize_bool(MicroBuffer* mb, bool* value);
+MCDLLAPI bool deserialize_uint8_t(MicroBuffer* mb, uint8_t* value);
+MCDLLAPI bool deserialize_uint16_t(MicroBuffer* mb, uint16_t* value);
+MCDLLAPI bool deserialize_uint32_t(MicroBuffer* mb, uint32_t* value);
+MCDLLAPI bool deserialize_uint64_t(MicroBuffer* mb, uint64_t* value);
+MCDLLAPI bool deserialize_int8_t(MicroBuffer* mb, int8_t* value);
+MCDLLAPI bool deserialize_int16_t(MicroBuffer* mb, int16_t* value);
+MCDLLAPI bool deserialize_int32_t(MicroBuffer* mb, int32_t* value);
+MCDLLAPI bool deserialize_int64_t(MicroBuffer* mb, int64_t* value);
+MCDLLAPI bool deserialize_float(MicroBuffer* mb, float* value);
+MCDLLAPI bool deserialize_double(MicroBuffer* mb, double* value);
 
-microcdr_DllAPI bool serialize_endian_uint16_t(MicroBuffer* mb, Endianness endianness, const uint16_t value);
-microcdr_DllAPI bool serialize_endian_uint32_t(MicroBuffer* mb, Endianness endianness, const uint32_t value);
-microcdr_DllAPI bool serialize_endian_uint64_t(MicroBuffer* mb, Endianness endianness, const uint64_t value);
-microcdr_DllAPI bool serialize_endian_int16_t(MicroBuffer* mb, Endianness endianness, const int16_t value);
-microcdr_DllAPI bool serialize_endian_int32_t(MicroBuffer* mb, Endianness endianness, const int32_t value);
-microcdr_DllAPI bool serialize_endian_int64_t(MicroBuffer* mb, Endianness endianness, const int64_t value);
-microcdr_DllAPI bool serialize_endian_float(MicroBuffer* mb, Endianness endianness, const float value);
-microcdr_DllAPI bool serialize_endian_double(MicroBuffer* mb, Endianness endianness, const double value);
+MCDLLAPI bool serialize_endian_uint16_t(MicroBuffer* mb, Endianness endianness, const uint16_t value);
+MCDLLAPI bool serialize_endian_uint32_t(MicroBuffer* mb, Endianness endianness, const uint32_t value);
+MCDLLAPI bool serialize_endian_uint64_t(MicroBuffer* mb, Endianness endianness, const uint64_t value);
+MCDLLAPI bool serialize_endian_int16_t(MicroBuffer* mb, Endianness endianness, const int16_t value);
+MCDLLAPI bool serialize_endian_int32_t(MicroBuffer* mb, Endianness endianness, const int32_t value);
+MCDLLAPI bool serialize_endian_int64_t(MicroBuffer* mb, Endianness endianness, const int64_t value);
+MCDLLAPI bool serialize_endian_float(MicroBuffer* mb, Endianness endianness, const float value);
+MCDLLAPI bool serialize_endian_double(MicroBuffer* mb, Endianness endianness, const double value);
 
-microcdr_DllAPI bool deserialize_endian_uint16_t(MicroBuffer* mb, Endianness endianness, uint16_t* value);
-microcdr_DllAPI bool deserialize_endian_uint32_t(MicroBuffer* mb, Endianness endianness, uint32_t *value);
-microcdr_DllAPI bool deserialize_endian_uint64_t(MicroBuffer* mb, Endianness endianness, uint64_t* value);
-microcdr_DllAPI bool deserialize_endian_int16_t(MicroBuffer* mb, Endianness endianness, int16_t* value);
-microcdr_DllAPI bool deserialize_endian_int32_t(MicroBuffer* mb, Endianness endianness, int32_t* value);
-microcdr_DllAPI bool deserialize_endian_int64_t(MicroBuffer* mb, Endianness endianness, int64_t* value);
-microcdr_DllAPI bool deserialize_endian_float(MicroBuffer* mb, Endianness endianness, float* value);
-microcdr_DllAPI bool deserialize_endian_double(MicroBuffer* mb, Endianness endianness, double* value);
+MCDLLAPI bool deserialize_endian_uint16_t(MicroBuffer* mb, Endianness endianness, uint16_t* value);
+MCDLLAPI bool deserialize_endian_uint32_t(MicroBuffer* mb, Endianness endianness, uint32_t *value);
+MCDLLAPI bool deserialize_endian_uint64_t(MicroBuffer* mb, Endianness endianness, uint64_t* value);
+MCDLLAPI bool deserialize_endian_int16_t(MicroBuffer* mb, Endianness endianness, int16_t* value);
+MCDLLAPI bool deserialize_endian_int32_t(MicroBuffer* mb, Endianness endianness, int32_t* value);
+MCDLLAPI bool deserialize_endian_int64_t(MicroBuffer* mb, Endianness endianness, int64_t* value);
+MCDLLAPI bool deserialize_endian_float(MicroBuffer* mb, Endianness endianness, float* value);
+MCDLLAPI bool deserialize_endian_double(MicroBuffer* mb, Endianness endianness, double* value);
 
 #ifdef __cplusplus
 }

--- a/include/microcdr/types/sequence.h
+++ b/include/microcdr/types/sequence.h
@@ -25,57 +25,57 @@ extern "C" {
 //                   PUBLIC SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
 
-microcdr_DllAPI bool serialize_sequence_char(MicroBuffer* mb, const char* array, const uint32_t size);
-microcdr_DllAPI bool serialize_sequence_bool(MicroBuffer* mb, const bool* array, const uint32_t size);
-microcdr_DllAPI bool serialize_sequence_uint8_t(MicroBuffer* mb, const uint8_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_sequence_uint16_t(MicroBuffer* mb, const uint16_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_sequence_uint32_t(MicroBuffer* mb, const uint32_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_sequence_uint64_t(MicroBuffer* mb, const uint64_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_sequence_int8_t(MicroBuffer* mb, const int8_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_sequence_int16_t(MicroBuffer* mb, const int16_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_sequence_int32_t(MicroBuffer* mb, const int32_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_sequence_int64_t(MicroBuffer* mb, const int64_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_sequence_float(MicroBuffer* mb, const float* array, const uint32_t size);
-microcdr_DllAPI bool serialize_sequence_double(MicroBuffer* mb, const double* array, const uint32_t size);
+MCDLLAPI bool serialize_sequence_char(MicroBuffer* mb, const char* array, const uint32_t size);
+MCDLLAPI bool serialize_sequence_bool(MicroBuffer* mb, const bool* array, const uint32_t size);
+MCDLLAPI bool serialize_sequence_uint8_t(MicroBuffer* mb, const uint8_t* array, const uint32_t size);
+MCDLLAPI bool serialize_sequence_uint16_t(MicroBuffer* mb, const uint16_t* array, const uint32_t size);
+MCDLLAPI bool serialize_sequence_uint32_t(MicroBuffer* mb, const uint32_t* array, const uint32_t size);
+MCDLLAPI bool serialize_sequence_uint64_t(MicroBuffer* mb, const uint64_t* array, const uint32_t size);
+MCDLLAPI bool serialize_sequence_int8_t(MicroBuffer* mb, const int8_t* array, const uint32_t size);
+MCDLLAPI bool serialize_sequence_int16_t(MicroBuffer* mb, const int16_t* array, const uint32_t size);
+MCDLLAPI bool serialize_sequence_int32_t(MicroBuffer* mb, const int32_t* array, const uint32_t size);
+MCDLLAPI bool serialize_sequence_int64_t(MicroBuffer* mb, const int64_t* array, const uint32_t size);
+MCDLLAPI bool serialize_sequence_float(MicroBuffer* mb, const float* array, const uint32_t size);
+MCDLLAPI bool serialize_sequence_double(MicroBuffer* mb, const double* array, const uint32_t size);
 
-microcdr_DllAPI bool deserialize_sequence_char(MicroBuffer* mb, char* array, const uint32_t array_capacity, uint32_t* size);
-microcdr_DllAPI bool deserialize_sequence_bool(MicroBuffer* mb, bool* array, const uint32_t array_capacity, uint32_t* size);
-microcdr_DllAPI bool deserialize_sequence_uint8_t(MicroBuffer* mb, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
-microcdr_DllAPI bool deserialize_sequence_uint16_t(MicroBuffer* mb, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
-microcdr_DllAPI bool deserialize_sequence_uint32_t(MicroBuffer* mb, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
-microcdr_DllAPI bool deserialize_sequence_uint64_t(MicroBuffer* mb, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
-microcdr_DllAPI bool deserialize_sequence_int8_t(MicroBuffer* mb, int8_t* array, const uint32_t array_capacity, uint32_t* size);
-microcdr_DllAPI bool deserialize_sequence_int16_t(MicroBuffer* mb, int16_t* array, const uint32_t array_capacity, uint32_t* size);
-microcdr_DllAPI bool deserialize_sequence_int32_t(MicroBuffer* mb, int32_t* array, const uint32_t array_capacity, uint32_t* size);
-microcdr_DllAPI bool deserialize_sequence_int64_t(MicroBuffer* mb, int64_t* array, const uint32_t array_capacity, uint32_t* size);
-microcdr_DllAPI bool deserialize_sequence_float(MicroBuffer* mb, float* array, const uint32_t array_capacity, uint32_t* size);
-microcdr_DllAPI bool deserialize_sequence_double(MicroBuffer* mb, double* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_sequence_char(MicroBuffer* mb, char* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_sequence_bool(MicroBuffer* mb, bool* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_sequence_uint8_t(MicroBuffer* mb, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_sequence_uint16_t(MicroBuffer* mb, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_sequence_uint32_t(MicroBuffer* mb, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_sequence_uint64_t(MicroBuffer* mb, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_sequence_int8_t(MicroBuffer* mb, int8_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_sequence_int16_t(MicroBuffer* mb, int16_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_sequence_int32_t(MicroBuffer* mb, int32_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_sequence_int64_t(MicroBuffer* mb, int64_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_sequence_float(MicroBuffer* mb, float* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_sequence_double(MicroBuffer* mb, double* array, const uint32_t array_capacity, uint32_t* size);
 
-microcdr_DllAPI bool serialize_endian_sequence_char(MicroBuffer* mb, Endianness endianness, const char* array, const uint32_t size);
-microcdr_DllAPI bool serialize_endian_sequence_bool(MicroBuffer* mb, Endianness endianness, const bool* array, const uint32_t size);
-microcdr_DllAPI bool serialize_endian_sequence_uint8_t(MicroBuffer* mb, Endianness endianness, const uint8_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_endian_sequence_uint16_t(MicroBuffer* mb, Endianness endianness, const uint16_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_endian_sequence_uint32_t(MicroBuffer* mb, Endianness endianness, const uint32_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_endian_sequence_uint64_t(MicroBuffer* mb, Endianness endianness, const uint64_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_endian_sequence_int8_t(MicroBuffer* mb, Endianness endianness, const int8_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_endian_sequence_int16_t(MicroBuffer* mb, Endianness endianness, const int16_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_endian_sequence_int32_t(MicroBuffer* mb, Endianness endianness, const int32_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_endian_sequence_int64_t(MicroBuffer* mb, Endianness endianness, const int64_t* array, const uint32_t size);
-microcdr_DllAPI bool serialize_endian_sequence_float(MicroBuffer* mb, Endianness endianness, const float* array, const uint32_t size);
-microcdr_DllAPI bool serialize_endian_sequence_double(MicroBuffer* mb, Endianness endianness, const double* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_sequence_char(MicroBuffer* mb, Endianness endianness, const char* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_sequence_bool(MicroBuffer* mb, Endianness endianness, const bool* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_sequence_uint8_t(MicroBuffer* mb, Endianness endianness, const uint8_t* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_sequence_uint16_t(MicroBuffer* mb, Endianness endianness, const uint16_t* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_sequence_uint32_t(MicroBuffer* mb, Endianness endianness, const uint32_t* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_sequence_uint64_t(MicroBuffer* mb, Endianness endianness, const uint64_t* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_sequence_int8_t(MicroBuffer* mb, Endianness endianness, const int8_t* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_sequence_int16_t(MicroBuffer* mb, Endianness endianness, const int16_t* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_sequence_int32_t(MicroBuffer* mb, Endianness endianness, const int32_t* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_sequence_int64_t(MicroBuffer* mb, Endianness endianness, const int64_t* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_sequence_float(MicroBuffer* mb, Endianness endianness, const float* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_sequence_double(MicroBuffer* mb, Endianness endianness, const double* array, const uint32_t size);
 
-microcdr_DllAPI bool deserialize_endian_sequence_char(MicroBuffer* mb, Endianness endianness, char* array, const uint32_t array_capacity, uint32_t* size);
-microcdr_DllAPI bool deserialize_endian_sequence_bool(MicroBuffer* mb, Endianness endianness, bool* array, const uint32_t array_capacity, uint32_t* size);
-microcdr_DllAPI bool deserialize_endian_sequence_uint8_t(MicroBuffer* mb, Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
-microcdr_DllAPI bool deserialize_endian_sequence_uint16_t(MicroBuffer* mb, Endianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
-microcdr_DllAPI bool deserialize_endian_sequence_uint32_t(MicroBuffer* mb, Endianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
-microcdr_DllAPI bool deserialize_endian_sequence_uint64_t(MicroBuffer* mb, Endianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
-microcdr_DllAPI bool deserialize_endian_sequence_int8_t(MicroBuffer* mb, Endianness endianness, int8_t* array, const uint32_t array_capacity, uint32_t* size);
-microcdr_DllAPI bool deserialize_endian_sequence_int16_t(MicroBuffer* mb, Endianness endianness, int16_t* array, const uint32_t array_capacity, uint32_t* size);
-microcdr_DllAPI bool deserialize_endian_sequence_int32_t(MicroBuffer* mb, Endianness endianness, int32_t* array, const uint32_t array_capacity, uint32_t* size);
-microcdr_DllAPI bool deserialize_endian_sequence_int64_t(MicroBuffer* mb, Endianness endianness, int64_t* array, const uint32_t array_capacity, uint32_t* size);
-microcdr_DllAPI bool deserialize_endian_sequence_float(MicroBuffer* mb, Endianness endianness, float* array, const uint32_t array_capacity, uint32_t* size);
-microcdr_DllAPI bool deserialize_endian_sequence_double(MicroBuffer* mb, Endianness endianness, double* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_endian_sequence_char(MicroBuffer* mb, Endianness endianness, char* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_endian_sequence_bool(MicroBuffer* mb, Endianness endianness, bool* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_endian_sequence_uint8_t(MicroBuffer* mb, Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_endian_sequence_uint16_t(MicroBuffer* mb, Endianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_endian_sequence_uint32_t(MicroBuffer* mb, Endianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_endian_sequence_uint64_t(MicroBuffer* mb, Endianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_endian_sequence_int8_t(MicroBuffer* mb, Endianness endianness, int8_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_endian_sequence_int16_t(MicroBuffer* mb, Endianness endianness, int16_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_endian_sequence_int32_t(MicroBuffer* mb, Endianness endianness, int32_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_endian_sequence_int64_t(MicroBuffer* mb, Endianness endianness, int64_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_endian_sequence_float(MicroBuffer* mb, Endianness endianness, float* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_endian_sequence_double(MicroBuffer* mb, Endianness endianness, double* array, const uint32_t array_capacity, uint32_t* size);
 
 #ifdef __cplusplus
 }

--- a/include/microcdr/types/string.h
+++ b/include/microcdr/types/string.h
@@ -28,11 +28,11 @@ extern "C" {
 //                   PUBLIC SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
 
-microcdr_DllAPI bool serialize_string(MicroBuffer* mb, const char* string);
-microcdr_DllAPI bool deserialize_string(MicroBuffer* mb, char* string, const uint32_t string_capacity);
+MCDLLAPI bool serialize_string(MicroBuffer* mb, const char* string);
+MCDLLAPI bool deserialize_string(MicroBuffer* mb, char* string, const uint32_t string_capacity);
 
-microcdr_DllAPI bool serialize_endian_string(MicroBuffer* mb, Endianness endianness, const char* string);
-microcdr_DllAPI bool deserialize_endian_string(MicroBuffer* mb, Endianness endianness, char* string, const uint32_t string_capacity);
+MCDLLAPI bool serialize_endian_string(MicroBuffer* mb, Endianness endianness, const char* string);
+MCDLLAPI bool deserialize_endian_string(MicroBuffer* mb, Endianness endianness, char* string, const uint32_t string_capacity);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- Fix minnor bug at includes.
- Change export tag name to be according to *Micro RTPS* products. (More readable too).