### PR TITLE
Added mc prefix to MicroCDR

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This library is focused on embedded and resource-limited systems.
 
 ## Usage examples
 This is a code example showing the serialization and deserialization of a string.
-As *MicroCDR* uses a static buffer, that means the user has to provide a defined buffer and its size during the *mcMicroBuffer* creation.
+As *MicroCDR* uses a static buffer, that means the user has to provide a defined buffer and its size during the *mcBuffer* creation.
 
 ```c
     #include <microcdr/microcdr.h>
@@ -23,8 +23,8 @@ As *MicroCDR* uses a static buffer, that means the user has to provide a defined
         uint8_t buffer[BUFFER_LENGTH];
 
         // Structs for handle the buffer.
-        mcMicroBuffer writer;
-        mcMicroBuffer reader;
+        mcBuffer writer;
+        mcBuffer reader;
 
         // Initialize the MicroBuffers for working with an user-managed buffer.
         mc_init_micro_buffer(&writer, buffer, BUFFER_LENGTH);
@@ -48,45 +48,45 @@ As *MicroCDR* uses a static buffer, that means the user has to provide a defined
 ## API functions
 
 ```c
-void mc_init_micro_buffer        (mcMicroBuffer* mb, uint8_t* data, const uint32_t size);
-void mc_init_micro_buffer_offset (mcMicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset);
+void mc_init_micro_buffer        (mcBuffer* mb, uint8_t* data, const uint32_t size);
+void mc_init_micro_buffer_offset (mcBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset);
 ```
-Initialize a `mcMicroBuffer` structure, the main struct of *MicroCDR*.
-- `mb`: the `mcMicroBuffer` struct
-- `data`: the buffer that the `mcMicroBuffer` will use.
-- `size`: the size of the buffer that the `mcMicroBuffer` will use.
+Initialize a `mcBuffer` structure, the main struct of *MicroCDR*.
+- `mb`: the `mcBuffer` struct
+- `data`: the buffer that the `mcBuffer` will use.
+- `size`: the size of the buffer that the `mcBuffer` will use.
 - `offset`: where the serialization/deserialization will start.
 Initially, the serialization/deserialization starts at the beginning of the buffer.
 
 ---
 
 ```c
-void mc_copy_micro_buffer (mcMicroBuffer* mb_dest, const mcMicroBuffer* mb_source);
+void mc_copy_micro_buffer (mcBuffer* mb_dest, const mcBuffer* mb_source);
 ```
-Copy a `mcMicroBuffer` structure data to another `mcMicroBuffer` structure.
-- `mb_dest`: the destination `mcMicroBuffer` struct.
-- `mb_source`: the origin initialized `mcMicroBuffer` struct.
+Copy a `mcBuffer` structure data to another `mcBuffer` structure.
+- `mb_dest`: the destination `mcBuffer` struct.
+- `mb_source`: the origin initialized `mcBuffer` struct.
 
 ---
 
 ```c
-void mc_reset_micro_buffer       (mcMicroBuffer* mb);
-void mc_reset_micro_buffer_offset(mcMicroBuffer* mb, const uint32_t offset);
+void mc_reset_micro_buffer       (mcBuffer* mb);
+void mc_reset_micro_buffer_offset(mcBuffer* mb, const uint32_t offset);
 ```
-Reset the `mcMicroBuffer` as the same state that it was created.
-- `mb`: the `mcMicroBuffer` struct.
+Reset the `mcBuffer` as the same state that it was created.
+- `mb`: the `mcBuffer` struct.
 - `offset`: where the serialization/deserialization will start.
 Initially, the serialization/deserialization starts at the beginning of the buffer.
 
 ---
 
 ```c
-void mc_align_to (mcMicroBuffer* mb, const uint32_t alignment);
+void mc_align_to (mcBuffer* mb, const uint32_t alignment);
 ```
-Align the mcMicroBuffer to an `alignment` position.
-After call this function, the serialization pointer will be moved only if the current `mcMicroBuffer` was not aligment to the passed value.
+Align the mcBuffer to an `alignment` position.
+After call this function, the serialization pointer will be moved only if the current `mcBuffer` was not aligment to the passed value.
 
-- `mb`: the `mcMicroBuffer` struct
+- `mb`: the `mcBuffer` struct
 - `alignment`: the alignment value used.
 
 ---
@@ -96,57 +96,57 @@ uint32_t mc_aligment(uint32_t buffer_position, const uint32_t data_size);
 ```
 Returns the aligment necessary to serialize/deserialize a type with `data_size` size.
 
-- `buffer_position`: the current serialization/deserialization position of the `mcMicroBuffer`. (Typically  `mb->iterator - mb->init`).
+- `buffer_position`: the current serialization/deserialization position of the `mcBuffer`. (Typically  `mb->iterator - mb->init`).
 - `data_size`: the bytes of the data that you are asking for.
 
 ---
 
 ```c
-uint32_t mc_micro_buffer_alignment(const mcMicroBuffer* mb, const uint32_t data_size);
+uint32_t mc_micro_buffer_alignment(const mcBuffer* mb, const uint32_t data_size);
 ```
-Returns the aligment necessary to serialize/deserialize a type with `data_size` size into the `mcMicroBuffer` given.
+Returns the aligment necessary to serialize/deserialize a type with `data_size` size into the `mcBuffer` given.
 
-- `mb`: the `mcMicroBuffer` struct to ask the alignment.
+- `mb`: the `mcBuffer` struct to ask the alignment.
 - `data_size`: the bytes of the data that you are asking for.
 ---
 
 ```c
-size_t mc_micro_buffer_size(const mcMicroBuffer* mb);
+size_t mc_micro_buffer_size(const mcBuffer* mb);
 ```
 Returns the memory size of the buffer.
-- `mb`: the `mcMicroBuffer` struct
+- `mb`: the `mcBuffer` struct
 
 ---
 
 ```c
-size_t mc_micro_buffer_length(const mcMicroBuffer* mb);
+size_t mc_micro_buffer_length(const mcBuffer* mb);
 ```
 Returns the size of the serialized/deserialized data.
-- `mb`: the `mcMicroBuffer` struct
+- `mb`: the `mcBuffer` struct
 
 ---
 
 ```c
-size_t mc_micro_buffer_remaining(const mcMicroBuffer* mb);
+size_t mc_micro_buffer_remaining(const mcBuffer* mb);
 ```
 Returns the remaining size for the serializing/deserializing.
-- `mb`: the `mcMicroBuffer` struct
+- `mb`: the `mcBuffer` struct
 
 ---
 
 ```c
-mrEndianness mc_micro_buffer_endianness(const mcMicroBuffer* mb);
+mrEndianness mc_micro_buffer_endianness(const mcBuffer* mb);
 ```
 Returns the serialization/deserialization endianness.
-- `mb`: the `mcMicroBuffer` struct
+- `mb`: the `mcBuffer` struct
 
 ---
 
 ```c
-bool mc_micro_buffer_error(const mcMicroBuffer* mb);
+bool mc_micro_buffer_error(const mcBuffer* mb);
 ```
-Returns the status error of the `mcMicroBuffer`.
-- `mb`: the `mcMicroBuffer` struct
+Returns the status error of the `mcBuffer`.
+- `mb`: the `mcBuffer` struct
 
 
 ### Serialization/deserialization functions
@@ -160,20 +160,20 @@ Adding to this, there is a big set of functions for deserialize and deserialize 
 The configuration can be done by cmake with the cmake `__BIG_ENDIAN__` variable.
 A `0` value implies that the serialization will performed into a little endian machine, and `1` into a big endian machine.
 
-The default endianness serialization can be choosen by setting the `endianness` parameter of a `mcMicroBuffer`  to `MC_BIG_ENDIANNESS` or `MC_LITTLE_ENDIANNESS`.
+The default endianness serialization can be choosen by setting the `endianness` parameter of a `mcBuffer`  to `MC_BIG_ENDIANNESS` or `MC_LITTLE_ENDIANNESS`.
 Also, there are a functions that allow to force an endianness in their serialization/deserialization.
 These functions contains the name `endiannness` in their signature.
 
 ### Error
 All serialization/deserialization functions return a boolean indicating the result of their operations.
 When a serialization/deserialization could not be possible (the type can not be serialized, or the capacity of the destination buffer is not enough),
-an status error is setted into the `mcMicroBuffer`.
-If a `mcMicroBuffer` has an error state, the next serialization/deserialization operations will not works and will return `false` in their execution.
+an status error is setted into the `mcBuffer`.
+If a `mcBuffer` has an error state, the next serialization/deserialization operations will not works and will return `false` in their execution.
 A buffer marked with an error can be used, but any serialization/deserialization operation over it will not produce any effect.
 
-If is kwown that an operation can fails over a `mcMicroBuffer`, and its necessary to continue with the serialization/deserialization if it happens,
-the `mcMicroBuffer` state can be saved using the `copy_micro_buffer` function.
-After the application of the wrong serialization/deserialization, only the `mcMicroBuffer` that performed the operation will have a dirty state.
+If is kwown that an operation can fails over a `mcBuffer`, and its necessary to continue with the serialization/deserialization if it happens,
+the `mcBuffer` state can be saved using the `copy_micro_buffer` function.
+After the application of the wrong serialization/deserialization, only the `mcBuffer` that performed the operation will have a dirty state.
 
 ## Serialization/deserialization list
 The available modes of serialization/deserializations in *MicroCDR* are shown in the following table.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Returns the remaining size for the serializing/deserializing.
 ---
 
 ```c
-Endianness micro_buffer_endianness(const mcMicroBuffer* mb);
+mrEndianness micro_buffer_endianness(const mcMicroBuffer* mb);
 ```
 Returns the serialization/deserialization endianness.
 - `mb`: the `mcMicroBuffer` struct
@@ -152,7 +152,7 @@ Adding to this, there is a big set of functions for deserialize and deserialize 
 The configuration can be done by cmake with the cmake `__BIG_ENDIAN__` variable.
 A `0` value implies that the serialization will performed into a little endian machine, and `1` into a big endian machine.
 
-The default endianness serialization can be choosen by setting the `endianness` parameter of a `mcMicroBuffer`  to `BIG_ENDIANNESS` or `LITTLE_ENDIANNESS`.
+The default endianness serialization can be choosen by setting the `endianness` parameter of a `mcMicroBuffer`  to `MC_BIG_ENDIANNESS` or `MC_LITTLE_ENDIANNESS`.
 Also, there are a functions that allow to force an endianness in their serialization/deserialization.
 These functions contains the name `endiannness` in their signature.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This library is focused on embedded and resource-limited systems.
 
 ## Usage examples
 This is a code example showing the serialization and deserialization of a string.
-As *MicroCDR* uses a static buffer, that means the user has to provide a defined buffer and its size during the *MicroBuffer* creation.
+As *MicroCDR* uses a static buffer, that means the user has to provide a defined buffer and its size during the *mcMicroBuffer* creation.
 
 ```c
     #include <microcdr/microcdr.h>
@@ -23,8 +23,8 @@ As *MicroCDR* uses a static buffer, that means the user has to provide a defined
         uint8_t buffer[BUFFER_LENGTH];
 
         // Structs for handle the buffer.
-        MicroBuffer writer;
-        MicroBuffer reader;
+        mcMicroBuffer writer;
+        mcMicroBuffer reader;
 
         // Initialize the MicroBuffers for working with an user-managed buffer.
         init_micro_buffer(&writer, buffer, BUFFER_LENGTH);
@@ -48,45 +48,45 @@ As *MicroCDR* uses a static buffer, that means the user has to provide a defined
 ## API functions
 
 ```c
-void init_micro_buffer        (MicroBuffer* mb, uint8_t* data, const uint32_t size);
-void init_micro_buffer_offset (MicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset);
+void init_micro_buffer        (mcMicroBuffer* mb, uint8_t* data, const uint32_t size);
+void init_micro_buffer_offset (mcMicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset);
 ```
-Initialize a `MicroBuffer` structure, the main struct of *MicroCDR*.
-- `mb`: the `MicroBuffer` struct
-- `data`: the buffer that the `MicroBuffer` will use.
-- `size`: the size of the buffer that the `MicroBuffer` will use.
+Initialize a `mcMicroBuffer` structure, the main struct of *MicroCDR*.
+- `mb`: the `mcMicroBuffer` struct
+- `data`: the buffer that the `mcMicroBuffer` will use.
+- `size`: the size of the buffer that the `mcMicroBuffer` will use.
 - `offset`: where the serialization/deserialization will start.
 Initially, the serialization/deserialization starts at the beginning of the buffer.
 
 ---
 
 ```c
-void copy_micro_buffer (MicroBuffer* mb_dest, const MicroBuffer* mb_source);
+void copy_micro_buffer (mcMicroBuffer* mb_dest, const mcMicroBuffer* mb_source);
 ```
-Copy a `MicroBuffer` structure data to another `MicroBuffer` structure.
-- `mb_dest`: the destination `MicroBuffer` struct.
-- `mb_source`: the origin initialized `MicroBuffer` struct.
+Copy a `mcMicroBuffer` structure data to another `mcMicroBuffer` structure.
+- `mb_dest`: the destination `mcMicroBuffer` struct.
+- `mb_source`: the origin initialized `mcMicroBuffer` struct.
 
 ---
 
 ```c
-void reset_micro_buffer       (MicroBuffer* mb);
-void reset_micro_buffer_offset(MicroBuffer* mb, const uint32_t offset);
+void reset_micro_buffer       (mcMicroBuffer* mb);
+void reset_micro_buffer_offset(mcMicroBuffer* mb, const uint32_t offset);
 ```
-Reset the `MicroBuffer` as the same state that it was created.
-- `mb`: the `MicroBuffer` struct.
+Reset the `mcMicroBuffer` as the same state that it was created.
+- `mb`: the `mcMicroBuffer` struct.
 - `offset`: where the serialization/deserialization will start.
 Initially, the serialization/deserialization starts at the beginning of the buffer.
 
 ---
 
 ```c
-void align_to         (MicroBuffer* mb, const uint32_t alignment);
+void align_to         (mcMicroBuffer* mb, const uint32_t alignment);
 ```
-Align the MicroBuffer to an `alignment` position.
-After call this function, the serialization pointer will be moved only if the current `MicroBuffer` was not aligment to the passed value.
+Align the mcMicroBuffer to an `alignment` position.
+After call this function, the serialization pointer will be moved only if the current `mcMicroBuffer` was not aligment to the passed value.
 
-- `mb`: the `MicroBuffer` struct
+- `mb`: the `mcMicroBuffer` struct
 - `alignment`: the alignment value used.
 
 ---
@@ -96,49 +96,49 @@ uint32_t get_alignment(uint32_t buffer_position, const uint32_t data_size);
 ```
 Returns the aligment necessary to serialize/deserialize a type with `data_size` size.
 
-- `buffer_position`: the current serialization/deserialization position of the `MicroBuffer`. (Typically  `mb->iterator - mb->init`).
+- `buffer_position`: the current serialization/deserialization position of the `mcMicroBuffer`. (Typically  `mb->iterator - mb->init`).
 - `data_size`: the bytes of the data that you are asking for.
 
 ---
 
 ```c
-size_t micro_buffer_size(const MicroBuffer* mb);
+size_t micro_buffer_size(const mcMicroBuffer* mb);
 ```
 Returns the memory size of the buffer.
-- `mb`: the `MicroBuffer` struct
+- `mb`: the `mcMicroBuffer` struct
 
 ---
 
 ```c
-size_t micro_buffer_length(const MicroBuffer* mb);
+size_t micro_buffer_length(const mcMicroBuffer* mb);
 ```
 Returns the size of the serialized/deserialized data.
-- `mb`: the `MicroBuffer` struct
+- `mb`: the `mcMicroBuffer` struct
 
 ---
 
 ```c
-size_t micro_buffer_remaining(const MicroBuffer* mb);
+size_t micro_buffer_remaining(const mcMicroBuffer* mb);
 ```
 Returns the remaining size for the serializing/deserializing.
-- `mb`: the `MicroBuffer` struct
+- `mb`: the `mcMicroBuffer` struct
 
 
 ---
 
 ```c
-Endianness micro_buffer_endianness(const MicroBuffer* mb);
+Endianness micro_buffer_endianness(const mcMicroBuffer* mb);
 ```
 Returns the serialization/deserialization endianness.
-- `mb`: the `MicroBuffer` struct
+- `mb`: the `mcMicroBuffer` struct
 
 ---
 
 ```c
-bool micro_buffer_error(const MicroBuffer* mb);
+bool micro_buffer_error(const mcMicroBuffer* mb);
 ```
-Returns the status error of the `MicroBuffer`.
-- `mb`: the `MicroBuffer` struct
+Returns the status error of the `mcMicroBuffer`.
+- `mb`: the `mcMicroBuffer` struct
 
 
 ### Serialization/deserialization functions
@@ -152,20 +152,20 @@ Adding to this, there is a big set of functions for deserialize and deserialize 
 The configuration can be done by cmake with the cmake `__BIG_ENDIAN__` variable.
 A `0` value implies that the serialization will performed into a little endian machine, and `1` into a big endian machine.
 
-The default endianness serialization can be choosen by setting the `endianness` parameter of a `MicroBuffer`  to `BIG_ENDIANNESS` or `LITTLE_ENDIANNESS`.
+The default endianness serialization can be choosen by setting the `endianness` parameter of a `mcMicroBuffer`  to `BIG_ENDIANNESS` or `LITTLE_ENDIANNESS`.
 Also, there are a functions that allow to force an endianness in their serialization/deserialization.
 These functions contains the name `endiannness` in their signature.
 
 ### Error
 All serialization/deserialization functions return a boolean indicating the result of their operations.
 When a serialization/deserialization could not be possible (the type can not be serialized, or the capacity of the destination buffer is not enough),
-an status error is setted into the `MicroBuffer`.
-If a `MicroBuffer` has an error state, the next serialization/deserialization operations will not works and will return `false` in their execution.
+an status error is setted into the `mcMicroBuffer`.
+If a `mcMicroBuffer` has an error state, the next serialization/deserialization operations will not works and will return `false` in their execution.
 A buffer marked with an error can be used, but any serialization/deserialization operation over it will not produce any effect.
 
-If is kwown that an operation can fails over a `MicroBuffer`, and its necessary to continue with the serialization/deserialization if it happens,
-the `MicroBuffer` state can be saved using the `copy_micro_buffer` function.
-After the application of the wrong serialization/deserialization, only the `MicroBuffer` that performed the operation will have a dirty state.
+If is kwown that an operation can fails over a `mcMicroBuffer`, and its necessary to continue with the serialization/deserialization if it happens,
+the `mcMicroBuffer` state can be saved using the `copy_micro_buffer` function.
+After the application of the wrong serialization/deserialization, only the `mcMicroBuffer` that performed the operation will have a dirty state.
 
 ## Serialization/deserialization list
 The available modes of serialization/deserializations in *MicroCDR* are shown in the following table.

--- a/README.md
+++ b/README.md
@@ -27,16 +27,16 @@ As *MicroCDR* uses a static buffer, that means the user has to provide a defined
         mcMicroBuffer reader;
 
         // Initialize the MicroBuffers for working with an user-managed buffer.
-        init_micro_buffer(&writer, buffer, BUFFER_LENGTH);
-        init_micro_buffer(&reader, buffer, BUFFER_LENGTH);
+        mc_init_micro_buffer(&writer, buffer, BUFFER_LENGTH);
+        mc_init_micro_buffer(&reader, buffer, BUFFER_LENGTH);
 
         // Serialize data
         char input[16] = "Hello MicroCDR!"; //16 characters
-        serialize_array_char(&writer, input, 16);
+        mc_serialize_array_char(&writer, input, 16);
 
         // Deserialize data
         char output[16];
-        deserialize_array_char(&reader, output, 16);
+        mc_deserialize_array_char(&reader, output, 16);
 
         printf("Input: %s\n", input);
         printf("Output: %s\n", output);
@@ -48,8 +48,8 @@ As *MicroCDR* uses a static buffer, that means the user has to provide a defined
 ## API functions
 
 ```c
-void init_micro_buffer        (mcMicroBuffer* mb, uint8_t* data, const uint32_t size);
-void init_micro_buffer_offset (mcMicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset);
+void mc_init_micro_buffer        (mcMicroBuffer* mb, uint8_t* data, const uint32_t size);
+void mc_init_micro_buffer_offset (mcMicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset);
 ```
 Initialize a `mcMicroBuffer` structure, the main struct of *MicroCDR*.
 - `mb`: the `mcMicroBuffer` struct
@@ -61,7 +61,7 @@ Initially, the serialization/deserialization starts at the beginning of the buff
 ---
 
 ```c
-void copy_micro_buffer (mcMicroBuffer* mb_dest, const mcMicroBuffer* mb_source);
+void mc_copy_micro_buffer (mcMicroBuffer* mb_dest, const mcMicroBuffer* mb_source);
 ```
 Copy a `mcMicroBuffer` structure data to another `mcMicroBuffer` structure.
 - `mb_dest`: the destination `mcMicroBuffer` struct.
@@ -70,8 +70,8 @@ Copy a `mcMicroBuffer` structure data to another `mcMicroBuffer` structure.
 ---
 
 ```c
-void reset_micro_buffer       (mcMicroBuffer* mb);
-void reset_micro_buffer_offset(mcMicroBuffer* mb, const uint32_t offset);
+void mc_reset_micro_buffer       (mcMicroBuffer* mb);
+void mc_reset_micro_buffer_offset(mcMicroBuffer* mb, const uint32_t offset);
 ```
 Reset the `mcMicroBuffer` as the same state that it was created.
 - `mb`: the `mcMicroBuffer` struct.
@@ -81,7 +81,7 @@ Initially, the serialization/deserialization starts at the beginning of the buff
 ---
 
 ```c
-void align_to         (mcMicroBuffer* mb, const uint32_t alignment);
+void mc_align_to (mcMicroBuffer* mb, const uint32_t alignment);
 ```
 Align the mcMicroBuffer to an `alignment` position.
 After call this function, the serialization pointer will be moved only if the current `mcMicroBuffer` was not aligment to the passed value.
@@ -92,7 +92,7 @@ After call this function, the serialization pointer will be moved only if the cu
 ---
 
 ```c
-uint32_t get_alignment(uint32_t buffer_position, const uint32_t data_size);
+uint32_t mc_aligment(uint32_t buffer_position, const uint32_t data_size);
 ```
 Returns the aligment necessary to serialize/deserialize a type with `data_size` size.
 
@@ -102,7 +102,16 @@ Returns the aligment necessary to serialize/deserialize a type with `data_size` 
 ---
 
 ```c
-size_t micro_buffer_size(const mcMicroBuffer* mb);
+uint32_t mc_micro_buffer_alignment(const mcMicroBuffer* mb, const uint32_t data_size);
+```
+Returns the aligment necessary to serialize/deserialize a type with `data_size` size into the `mcMicroBuffer` given.
+
+- `mb`: the `mcMicroBuffer` struct to ask the alignment.
+- `data_size`: the bytes of the data that you are asking for.
+---
+
+```c
+size_t mc_micro_buffer_size(const mcMicroBuffer* mb);
 ```
 Returns the memory size of the buffer.
 - `mb`: the `mcMicroBuffer` struct
@@ -110,7 +119,7 @@ Returns the memory size of the buffer.
 ---
 
 ```c
-size_t micro_buffer_length(const mcMicroBuffer* mb);
+size_t mc_micro_buffer_length(const mcMicroBuffer* mb);
 ```
 Returns the size of the serialized/deserialized data.
 - `mb`: the `mcMicroBuffer` struct
@@ -118,16 +127,15 @@ Returns the size of the serialized/deserialized data.
 ---
 
 ```c
-size_t micro_buffer_remaining(const mcMicroBuffer* mb);
+size_t mc_micro_buffer_remaining(const mcMicroBuffer* mb);
 ```
 Returns the remaining size for the serializing/deserializing.
 - `mb`: the `mcMicroBuffer` struct
 
-
 ---
 
 ```c
-mrEndianness micro_buffer_endianness(const mcMicroBuffer* mb);
+mrEndianness mc_micro_buffer_endianness(const mcMicroBuffer* mb);
 ```
 Returns the serialization/deserialization endianness.
 - `mb`: the `mcMicroBuffer` struct
@@ -135,7 +143,7 @@ Returns the serialization/deserialization endianness.
 ---
 
 ```c
-bool micro_buffer_error(const mcMicroBuffer* mb);
+bool mc_micro_buffer_error(const mcMicroBuffer* mb);
 ```
 Returns the status error of the `mcMicroBuffer`.
 - `mb`: the `mcMicroBuffer` struct

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ As *MicroCDR* uses a static buffer, that means the user has to provide a defined
 
 ```c
 void mc_init_micro_buffer        (mcBuffer* mb, uint8_t* data, const uint32_t size);
-void mc_init_micro_buffer_offset (mcBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset);
+void mc_init_buffer_offset (mcBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset);
 ```
 Initialize a `mcBuffer` structure, the main struct of *MicroCDR*.
 - `mb`: the `mcBuffer` struct
@@ -71,7 +71,7 @@ Copy a `mcBuffer` structure data to another `mcBuffer` structure.
 
 ```c
 void mc_reset_micro_buffer       (mcBuffer* mb);
-void mc_reset_micro_buffer_offset(mcBuffer* mb, const uint32_t offset);
+void mc_reset_buffer_offset(mcBuffer* mb, const uint32_t offset);
 ```
 Reset the `mcBuffer` as the same state that it was created.
 - `mb`: the `mcBuffer` struct.
@@ -102,7 +102,7 @@ Returns the aligment necessary to serialize/deserialize a type with `data_size` 
 ---
 
 ```c
-uint32_t mc_micro_buffer_alignment(const mcBuffer* mb, const uint32_t data_size);
+uint32_t mc_buffer_alignment(const mcBuffer* mb, const uint32_t data_size);
 ```
 Returns the aligment necessary to serialize/deserialize a type with `data_size` size into the `mcBuffer` given.
 
@@ -111,7 +111,7 @@ Returns the aligment necessary to serialize/deserialize a type with `data_size` 
 ---
 
 ```c
-size_t mc_micro_buffer_size(const mcBuffer* mb);
+size_t mc_buffer_size(const mcBuffer* mb);
 ```
 Returns the memory size of the buffer.
 - `mb`: the `mcBuffer` struct
@@ -119,7 +119,7 @@ Returns the memory size of the buffer.
 ---
 
 ```c
-size_t mc_micro_buffer_length(const mcBuffer* mb);
+size_t mc_buffer_length(const mcBuffer* mb);
 ```
 Returns the size of the serialized/deserialized data.
 - `mb`: the `mcBuffer` struct
@@ -127,7 +127,7 @@ Returns the size of the serialized/deserialized data.
 ---
 
 ```c
-size_t mc_micro_buffer_remaining(const mcBuffer* mb);
+size_t mc_buffer_remaining(const mcBuffer* mb);
 ```
 Returns the remaining size for the serializing/deserializing.
 - `mb`: the `mcBuffer` struct
@@ -135,7 +135,7 @@ Returns the remaining size for the serializing/deserializing.
 ---
 
 ```c
-mrEndianness mc_micro_buffer_endianness(const mcBuffer* mb);
+mrEndianness mc_buffer_endianness(const mcBuffer* mb);
 ```
 Returns the serialization/deserialization endianness.
 - `mb`: the `mcBuffer` struct
@@ -143,7 +143,7 @@ Returns the serialization/deserialization endianness.
 ---
 
 ```c
-bool mc_micro_buffer_error(const mcBuffer* mb);
+bool mc_buffer_error(const mcBuffer* mb);
 ```
 Returns the status error of the `mcBuffer`.
 - `mb`: the `mcBuffer` struct

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Returns the remaining size for the serializing/deserializing.
 ---
 
 ```c
-mrEndianness mc_buffer_endianness(const mcBuffer* mb);
+mcEndianness mc_buffer_endianness(const mcBuffer* mb);
 ```
 Returns the serialization/deserialization endianness.
 - `mb`: the `mcBuffer` struct
@@ -172,7 +172,7 @@ If a `mcBuffer` has an error state, the next serialization/deserialization opera
 A buffer marked with an error can be used, but any serialization/deserialization operation over it will not produce any effect.
 
 If is kwown that an operation can fails over a `mcBuffer`, and its necessary to continue with the serialization/deserialization if it happens,
-the `mcBuffer` state can be saved using the `copy_buffer` function.
+the `mcBuffer` state can be saved using the `mc_copy_buffer` function.
 After the application of the wrong serialization/deserialization, only the `mcBuffer` that performed the operation will have a dirty state.
 
 ## Serialization/deserialization list

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ As *MicroCDR* uses a static buffer, that means the user has to provide a defined
         mcBuffer reader;
 
         // Initialize the MicroBuffers for working with an user-managed buffer.
-        mc_init_micro_buffer(&writer, buffer, BUFFER_LENGTH);
-        mc_init_micro_buffer(&reader, buffer, BUFFER_LENGTH);
+        mc_init_buffer(&writer, buffer, BUFFER_LENGTH);
+        mc_init_buffer(&reader, buffer, BUFFER_LENGTH);
 
         // Serialize data
         char input[16] = "Hello MicroCDR!"; //16 characters
@@ -48,7 +48,7 @@ As *MicroCDR* uses a static buffer, that means the user has to provide a defined
 ## API functions
 
 ```c
-void mc_init_micro_buffer        (mcBuffer* mb, uint8_t* data, const uint32_t size);
+void mc_init_buffer        (mcBuffer* mb, uint8_t* data, const uint32_t size);
 void mc_init_buffer_offset (mcBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset);
 ```
 Initialize a `mcBuffer` structure, the main struct of *MicroCDR*.
@@ -61,7 +61,7 @@ Initially, the serialization/deserialization starts at the beginning of the buff
 ---
 
 ```c
-void mc_copy_micro_buffer (mcBuffer* mb_dest, const mcBuffer* mb_source);
+void mc_copy_buffer (mcBuffer* mb_dest, const mcBuffer* mb_source);
 ```
 Copy a `mcBuffer` structure data to another `mcBuffer` structure.
 - `mb_dest`: the destination `mcBuffer` struct.
@@ -70,7 +70,7 @@ Copy a `mcBuffer` structure data to another `mcBuffer` structure.
 ---
 
 ```c
-void mc_reset_micro_buffer       (mcBuffer* mb);
+void mc_reset_buffer       (mcBuffer* mb);
 void mc_reset_buffer_offset(mcBuffer* mb, const uint32_t offset);
 ```
 Reset the `mcBuffer` as the same state that it was created.
@@ -172,7 +172,7 @@ If a `mcBuffer` has an error state, the next serialization/deserialization opera
 A buffer marked with an error can be used, but any serialization/deserialization operation over it will not produce any effect.
 
 If is kwown that an operation can fails over a `mcBuffer`, and its necessary to continue with the serialization/deserialization if it happens,
-the `mcBuffer` state can be saved using the `copy_micro_buffer` function.
+the `mcBuffer` state can be saved using the `copy_buffer` function.
 After the application of the wrong serialization/deserialization, only the `mcBuffer` that performed the operation will have a dirty state.
 
 ## Serialization/deserialization list

--- a/examples/basic.c
+++ b/examples/basic.c
@@ -27,8 +27,8 @@ int main()
     mcBuffer reader;
 
     // Initialize the MicroBuffers for working with an user-managed buffer.
-    mc_init_micro_buffer(&writer, buffer, BUFFER_LENGTH);
-    mc_init_micro_buffer(&reader, buffer, BUFFER_LENGTH);
+    mc_init_buffer(&writer, buffer, BUFFER_LENGTH);
+    mc_init_buffer(&reader, buffer, BUFFER_LENGTH);
 
     // Serialize data
     char input[16] = "Hello MicroCDR!"; //16 characters

--- a/examples/basic.c
+++ b/examples/basic.c
@@ -36,7 +36,7 @@ int main()
 
     // Deserialize data
     char output[16];
-    deserialize_array_char(&reader, output, 16);
+    mc_deserialize_array_char(&reader, output, 16);
 
     printf("Input: %s\n", input);
     printf("Output: %s\n", output);

--- a/examples/basic.c
+++ b/examples/basic.c
@@ -27,8 +27,8 @@ int main()
     mcMicroBuffer reader;
 
     // Initialize the MicroBuffers for working with an user-managed buffer.
-    init_micro_buffer(&writer, buffer, BUFFER_LENGTH);
-    init_micro_buffer(&reader, buffer, BUFFER_LENGTH);
+    mc_init_micro_buffer(&writer, buffer, BUFFER_LENGTH);
+    mc_init_micro_buffer(&reader, buffer, BUFFER_LENGTH);
 
     // Serialize data
     char input[16] = "Hello MicroCDR!"; //16 characters

--- a/examples/basic.c
+++ b/examples/basic.c
@@ -23,8 +23,8 @@ int main()
     uint8_t buffer[BUFFER_LENGTH];
 
     // Structs for handle the buffer.
-    MicroBuffer writer;
-    MicroBuffer reader;
+    mcMicroBuffer writer;
+    mcMicroBuffer reader;
 
     // Initialize the MicroBuffers for working with an user-managed buffer.
     init_micro_buffer(&writer, buffer, BUFFER_LENGTH);

--- a/examples/basic.c
+++ b/examples/basic.c
@@ -32,7 +32,7 @@ int main()
 
     // Serialize data
     char input[16] = "Hello MicroCDR!"; //16 characters
-    serialize_array_char(&writer, input, 16);
+    mc_serialize_array_char(&writer, input, 16);
 
     // Deserialize data
     char output[16];

--- a/examples/basic.c
+++ b/examples/basic.c
@@ -23,8 +23,8 @@ int main()
     uint8_t buffer[BUFFER_LENGTH];
 
     // Structs for handle the buffer.
-    mcMicroBuffer writer;
-    mcMicroBuffer reader;
+    mcBuffer writer;
+    mcBuffer reader;
 
     // Initialize the MicroBuffers for working with an user-managed buffer.
     mc_init_micro_buffer(&writer, buffer, BUFFER_LENGTH);

--- a/include/microcdr/common.h
+++ b/include/microcdr/common.h
@@ -26,11 +26,11 @@ extern "C" {
 #include <stdbool.h>
 #include <stddef.h>
 
-typedef enum mrEndianness {
+typedef enum mcEndianness {
     MC_BIG_ENDIANNESS,
     MC_LITTLE_ENDIANNESS
 
-} mrEndianness;
+} mcEndianness;
 
 typedef struct mcBuffer
 {
@@ -38,21 +38,21 @@ typedef struct mcBuffer
     uint8_t *final;
     uint8_t *iterator;
 
-    mrEndianness endianness;
+    mcEndianness endianness;
     uint32_t last_data_size;
 
     bool error;
 
 } mcBuffer;
 
-MCDLLAPI extern const mrEndianness MC_MACHINE_ENDIANNESS;
+MCDLLAPI extern const mcEndianness MC_MACHINE_ENDIANNESS;
 
 // ------------------------------------------------
 //              Main library functions
 // ------------------------------------------------
 MCDLLAPI void mc_init_buffer               (mcBuffer* mb, uint8_t* data, const uint32_t size);
 MCDLLAPI void mc_init_buffer_offset        (mcBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset);
-MCDLLAPI void mc_init_buffer_offset_endian (mcBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, mrEndianness endianness);
+MCDLLAPI void mc_init_buffer_offset_endian (mcBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, mcEndianness endianness);
 MCDLLAPI void mc_copy_buffer               (mcBuffer* mb_dest, const mcBuffer* mb_source);
 
 MCDLLAPI void mc_reset_buffer        (mcBuffer* mb);
@@ -65,7 +65,7 @@ MCDLLAPI uint32_t mc_buffer_alignment(const mcBuffer* mb, const uint32_t data_si
 MCDLLAPI size_t     mc_buffer_size      (const mcBuffer* mb);
 MCDLLAPI size_t     mc_buffer_length    (const mcBuffer* mb);
 MCDLLAPI size_t     mc_buffer_remaining (const mcBuffer* mb);
-MCDLLAPI mrEndianness mc_buffer_endianness(const mcBuffer* mb);
+MCDLLAPI mcEndianness mc_buffer_endianness(const mcBuffer* mb);
 MCDLLAPI bool       mc_buffer_has_error (const mcBuffer* mb);
 
 #ifdef __cplusplus

--- a/include/microcdr/common.h
+++ b/include/microcdr/common.h
@@ -50,23 +50,23 @@ MCDLLAPI extern const Endianness MACHINE_ENDIANNESS;
 // ------------------------------------------------
 //              Main library functions
 // ------------------------------------------------
-MCDLLAPI void init_micro_buffer               (mcMicroBuffer* mb, uint8_t* data, const uint32_t size);
-MCDLLAPI void init_micro_buffer_offset        (mcMicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset);
-MCDLLAPI void init_micro_buffer_offset_endian (mcMicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, Endianness endianness);
-MCDLLAPI void copy_micro_buffer               (mcMicroBuffer* mb_dest, const mcMicroBuffer* mb_source);
+MCDLLAPI void mc_init_micro_buffer               (mcMicroBuffer* mb, uint8_t* data, const uint32_t size);
+MCDLLAPI void mc_init_micro_buffer_offset        (mcMicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset);
+MCDLLAPI void mc_init_micro_buffer_offset_endian (mcMicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, Endianness endianness);
+MCDLLAPI void mc_copy_micro_buffer               (mcMicroBuffer* mb_dest, const mcMicroBuffer* mb_source);
 
-MCDLLAPI void reset_micro_buffer        (mcMicroBuffer* mb);
-MCDLLAPI void reset_micro_buffer_offset (mcMicroBuffer* mb, const uint32_t offset);
+MCDLLAPI void mc_reset_micro_buffer        (mcMicroBuffer* mb);
+MCDLLAPI void mc_reset_micro_buffer_offset (mcMicroBuffer* mb, const uint32_t offset);
 
-MCDLLAPI void     align_to            (mcMicroBuffer* mb, const uint32_t alignment);
-MCDLLAPI uint32_t get_alignment       (uint32_t buffer_position, const uint32_t data_size); //change name
-MCDLLAPI uint32_t get_alignment_offset(const mcMicroBuffer* mb, const uint32_t data_size); //change name
+MCDLLAPI void     mc_align_to              (mcMicroBuffer* mb, const uint32_t alignment);
+MCDLLAPI uint32_t mc_alignment             (uint32_t buffer_position, const uint32_t data_size); //change name
+MCDLLAPI uint32_t mc_micro_buffer_alignment(const mcMicroBuffer* mb, const uint32_t data_size); //change name
 
-MCDLLAPI size_t     micro_buffer_size      (const mcMicroBuffer* mb);
-MCDLLAPI size_t     micro_buffer_length    (const mcMicroBuffer* mb);
-MCDLLAPI size_t     micro_buffer_remaining (const mcMicroBuffer* mb);
-MCDLLAPI Endianness micro_buffer_endianness(const mcMicroBuffer* mb);
-MCDLLAPI bool       micro_buffer_has_error (const mcMicroBuffer* mb);
+MCDLLAPI size_t     mc_micro_buffer_size      (const mcMicroBuffer* mb);
+MCDLLAPI size_t     mc_micro_buffer_length    (const mcMicroBuffer* mb);
+MCDLLAPI size_t     mc_micro_buffer_remaining (const mcMicroBuffer* mb);
+MCDLLAPI Endianness mc_micro_buffer_endianness(const mcMicroBuffer* mb);
+MCDLLAPI bool       mc_micro_buffer_has_error (const mcMicroBuffer* mb);
 
 #ifdef __cplusplus
 }

--- a/include/microcdr/common.h
+++ b/include/microcdr/common.h
@@ -26,11 +26,11 @@ extern "C" {
 #include <stdbool.h>
 #include <stddef.h>
 
-typedef enum Endianness {
-    BIG_ENDIANNESS,
-    LITTLE_ENDIANNESS
+typedef enum mrEndianness {
+    MC_BIG_ENDIANNESS,
+    MC_LITTLE_ENDIANNESS
 
-} Endianness;
+} mrEndianness;
 
 typedef struct mcMicroBuffer
 {
@@ -38,21 +38,21 @@ typedef struct mcMicroBuffer
     uint8_t *final;
     uint8_t *iterator;
 
-    Endianness endianness;
+    mrEndianness endianness;
     uint32_t last_data_size;
 
     bool error;
 
 } mcMicroBuffer;
 
-MCDLLAPI extern const Endianness MACHINE_ENDIANNESS;
+MCDLLAPI extern const mrEndianness MC_MACHINE_ENDIANNESS;
 
 // ------------------------------------------------
 //              Main library functions
 // ------------------------------------------------
 MCDLLAPI void mc_init_micro_buffer               (mcMicroBuffer* mb, uint8_t* data, const uint32_t size);
 MCDLLAPI void mc_init_micro_buffer_offset        (mcMicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset);
-MCDLLAPI void mc_init_micro_buffer_offset_endian (mcMicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, Endianness endianness);
+MCDLLAPI void mc_init_micro_buffer_offset_endian (mcMicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, mrEndianness endianness);
 MCDLLAPI void mc_copy_micro_buffer               (mcMicroBuffer* mb_dest, const mcMicroBuffer* mb_source);
 
 MCDLLAPI void mc_reset_micro_buffer        (mcMicroBuffer* mb);
@@ -65,7 +65,7 @@ MCDLLAPI uint32_t mc_micro_buffer_alignment(const mcMicroBuffer* mb, const uint3
 MCDLLAPI size_t     mc_micro_buffer_size      (const mcMicroBuffer* mb);
 MCDLLAPI size_t     mc_micro_buffer_length    (const mcMicroBuffer* mb);
 MCDLLAPI size_t     mc_micro_buffer_remaining (const mcMicroBuffer* mb);
-MCDLLAPI Endianness mc_micro_buffer_endianness(const mcMicroBuffer* mb);
+MCDLLAPI mrEndianness mc_micro_buffer_endianness(const mcMicroBuffer* mb);
 MCDLLAPI bool       mc_micro_buffer_has_error (const mcMicroBuffer* mb);
 
 #ifdef __cplusplus

--- a/include/microcdr/common.h
+++ b/include/microcdr/common.h
@@ -32,7 +32,7 @@ typedef enum mrEndianness {
 
 } mrEndianness;
 
-typedef struct mcMicroBuffer
+typedef struct mcBuffer
 {
     uint8_t *init;
     uint8_t *final;
@@ -43,30 +43,30 @@ typedef struct mcMicroBuffer
 
     bool error;
 
-} mcMicroBuffer;
+} mcBuffer;
 
 MCDLLAPI extern const mrEndianness MC_MACHINE_ENDIANNESS;
 
 // ------------------------------------------------
 //              Main library functions
 // ------------------------------------------------
-MCDLLAPI void mc_init_micro_buffer               (mcMicroBuffer* mb, uint8_t* data, const uint32_t size);
-MCDLLAPI void mc_init_micro_buffer_offset        (mcMicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset);
-MCDLLAPI void mc_init_micro_buffer_offset_endian (mcMicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, mrEndianness endianness);
-MCDLLAPI void mc_copy_micro_buffer               (mcMicroBuffer* mb_dest, const mcMicroBuffer* mb_source);
+MCDLLAPI void mc_init_micro_buffer               (mcBuffer* mb, uint8_t* data, const uint32_t size);
+MCDLLAPI void mc_init_micro_buffer_offset        (mcBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset);
+MCDLLAPI void mc_init_micro_buffer_offset_endian (mcBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, mrEndianness endianness);
+MCDLLAPI void mc_copy_micro_buffer               (mcBuffer* mb_dest, const mcBuffer* mb_source);
 
-MCDLLAPI void mc_reset_micro_buffer        (mcMicroBuffer* mb);
-MCDLLAPI void mc_reset_micro_buffer_offset (mcMicroBuffer* mb, const uint32_t offset);
+MCDLLAPI void mc_reset_micro_buffer        (mcBuffer* mb);
+MCDLLAPI void mc_reset_micro_buffer_offset (mcBuffer* mb, const uint32_t offset);
 
-MCDLLAPI void     mc_align_to              (mcMicroBuffer* mb, const uint32_t alignment);
+MCDLLAPI void     mc_align_to              (mcBuffer* mb, const uint32_t alignment);
 MCDLLAPI uint32_t mc_alignment             (uint32_t buffer_position, const uint32_t data_size);
-MCDLLAPI uint32_t mc_micro_buffer_alignment(const mcMicroBuffer* mb, const uint32_t data_size);
+MCDLLAPI uint32_t mc_micro_buffer_alignment(const mcBuffer* mb, const uint32_t data_size);
 
-MCDLLAPI size_t     mc_micro_buffer_size      (const mcMicroBuffer* mb);
-MCDLLAPI size_t     mc_micro_buffer_length    (const mcMicroBuffer* mb);
-MCDLLAPI size_t     mc_micro_buffer_remaining (const mcMicroBuffer* mb);
-MCDLLAPI mrEndianness mc_micro_buffer_endianness(const mcMicroBuffer* mb);
-MCDLLAPI bool       mc_micro_buffer_has_error (const mcMicroBuffer* mb);
+MCDLLAPI size_t     mc_micro_buffer_size      (const mcBuffer* mb);
+MCDLLAPI size_t     mc_micro_buffer_length    (const mcBuffer* mb);
+MCDLLAPI size_t     mc_micro_buffer_remaining (const mcBuffer* mb);
+MCDLLAPI mrEndianness mc_micro_buffer_endianness(const mcBuffer* mb);
+MCDLLAPI bool       mc_micro_buffer_has_error (const mcBuffer* mb);
 
 #ifdef __cplusplus
 }

--- a/include/microcdr/common.h
+++ b/include/microcdr/common.h
@@ -51,22 +51,22 @@ MCDLLAPI extern const mrEndianness MC_MACHINE_ENDIANNESS;
 //              Main library functions
 // ------------------------------------------------
 MCDLLAPI void mc_init_micro_buffer               (mcBuffer* mb, uint8_t* data, const uint32_t size);
-MCDLLAPI void mc_init_micro_buffer_offset        (mcBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset);
-MCDLLAPI void mc_init_micro_buffer_offset_endian (mcBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, mrEndianness endianness);
+MCDLLAPI void mc_init_buffer_offset        (mcBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset);
+MCDLLAPI void mc_init_buffer_offset_endian (mcBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, mrEndianness endianness);
 MCDLLAPI void mc_copy_micro_buffer               (mcBuffer* mb_dest, const mcBuffer* mb_source);
 
 MCDLLAPI void mc_reset_micro_buffer        (mcBuffer* mb);
-MCDLLAPI void mc_reset_micro_buffer_offset (mcBuffer* mb, const uint32_t offset);
+MCDLLAPI void mc_reset_buffer_offset (mcBuffer* mb, const uint32_t offset);
 
 MCDLLAPI void     mc_align_to              (mcBuffer* mb, const uint32_t alignment);
 MCDLLAPI uint32_t mc_alignment             (uint32_t buffer_position, const uint32_t data_size);
-MCDLLAPI uint32_t mc_micro_buffer_alignment(const mcBuffer* mb, const uint32_t data_size);
+MCDLLAPI uint32_t mc_buffer_alignment(const mcBuffer* mb, const uint32_t data_size);
 
-MCDLLAPI size_t     mc_micro_buffer_size      (const mcBuffer* mb);
-MCDLLAPI size_t     mc_micro_buffer_length    (const mcBuffer* mb);
-MCDLLAPI size_t     mc_micro_buffer_remaining (const mcBuffer* mb);
-MCDLLAPI mrEndianness mc_micro_buffer_endianness(const mcBuffer* mb);
-MCDLLAPI bool       mc_micro_buffer_has_error (const mcBuffer* mb);
+MCDLLAPI size_t     mc_buffer_size      (const mcBuffer* mb);
+MCDLLAPI size_t     mc_buffer_length    (const mcBuffer* mb);
+MCDLLAPI size_t     mc_buffer_remaining (const mcBuffer* mb);
+MCDLLAPI mrEndianness mc_buffer_endianness(const mcBuffer* mb);
+MCDLLAPI bool       mc_buffer_has_error (const mcBuffer* mb);
 
 #ifdef __cplusplus
 }

--- a/include/microcdr/common.h
+++ b/include/microcdr/common.h
@@ -32,7 +32,7 @@ typedef enum Endianness {
 
 } Endianness;
 
-typedef struct MicroBuffer
+typedef struct mcMicroBuffer
 {
     uint8_t *init;
     uint8_t *final;
@@ -43,30 +43,30 @@ typedef struct MicroBuffer
 
     bool error;
 
-} MicroBuffer;
+} mcMicroBuffer;
 
 MCDLLAPI extern const Endianness MACHINE_ENDIANNESS;
 
 // ------------------------------------------------
 //              Main library functions
 // ------------------------------------------------
-MCDLLAPI void init_micro_buffer               (MicroBuffer* mb, uint8_t* data, const uint32_t size);
-MCDLLAPI void init_micro_buffer_offset        (MicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset);
-MCDLLAPI void init_micro_buffer_offset_endian (MicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, Endianness endianness);
-MCDLLAPI void copy_micro_buffer               (MicroBuffer* mb_dest, const MicroBuffer* mb_source);
+MCDLLAPI void init_micro_buffer               (mcMicroBuffer* mb, uint8_t* data, const uint32_t size);
+MCDLLAPI void init_micro_buffer_offset        (mcMicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset);
+MCDLLAPI void init_micro_buffer_offset_endian (mcMicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, Endianness endianness);
+MCDLLAPI void copy_micro_buffer               (mcMicroBuffer* mb_dest, const mcMicroBuffer* mb_source);
 
-MCDLLAPI void reset_micro_buffer        (MicroBuffer* mb);
-MCDLLAPI void reset_micro_buffer_offset (MicroBuffer* mb, const uint32_t offset);
+MCDLLAPI void reset_micro_buffer        (mcMicroBuffer* mb);
+MCDLLAPI void reset_micro_buffer_offset (mcMicroBuffer* mb, const uint32_t offset);
 
-MCDLLAPI void     align_to            (MicroBuffer* mb, const uint32_t alignment);
+MCDLLAPI void     align_to            (mcMicroBuffer* mb, const uint32_t alignment);
 MCDLLAPI uint32_t get_alignment       (uint32_t buffer_position, const uint32_t data_size); //change name
-MCDLLAPI uint32_t get_alignment_offset(const MicroBuffer* mb, const uint32_t data_size); //change name
+MCDLLAPI uint32_t get_alignment_offset(const mcMicroBuffer* mb, const uint32_t data_size); //change name
 
-MCDLLAPI size_t     micro_buffer_size      (const MicroBuffer* mb);
-MCDLLAPI size_t     micro_buffer_length    (const MicroBuffer* mb);
-MCDLLAPI size_t     micro_buffer_remaining (const MicroBuffer* mb);
-MCDLLAPI Endianness micro_buffer_endianness(const MicroBuffer* mb);
-MCDLLAPI bool       micro_buffer_has_error (const MicroBuffer* mb);
+MCDLLAPI size_t     micro_buffer_size      (const mcMicroBuffer* mb);
+MCDLLAPI size_t     micro_buffer_length    (const mcMicroBuffer* mb);
+MCDLLAPI size_t     micro_buffer_remaining (const mcMicroBuffer* mb);
+MCDLLAPI Endianness micro_buffer_endianness(const mcMicroBuffer* mb);
+MCDLLAPI bool       micro_buffer_has_error (const mcMicroBuffer* mb);
 
 #ifdef __cplusplus
 }

--- a/include/microcdr/common.h
+++ b/include/microcdr/common.h
@@ -50,12 +50,12 @@ MCDLLAPI extern const mrEndianness MC_MACHINE_ENDIANNESS;
 // ------------------------------------------------
 //              Main library functions
 // ------------------------------------------------
-MCDLLAPI void mc_init_micro_buffer               (mcBuffer* mb, uint8_t* data, const uint32_t size);
+MCDLLAPI void mc_init_buffer               (mcBuffer* mb, uint8_t* data, const uint32_t size);
 MCDLLAPI void mc_init_buffer_offset        (mcBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset);
 MCDLLAPI void mc_init_buffer_offset_endian (mcBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, mrEndianness endianness);
-MCDLLAPI void mc_copy_micro_buffer               (mcBuffer* mb_dest, const mcBuffer* mb_source);
+MCDLLAPI void mc_copy_buffer               (mcBuffer* mb_dest, const mcBuffer* mb_source);
 
-MCDLLAPI void mc_reset_micro_buffer        (mcBuffer* mb);
+MCDLLAPI void mc_reset_buffer        (mcBuffer* mb);
 MCDLLAPI void mc_reset_buffer_offset (mcBuffer* mb, const uint32_t offset);
 
 MCDLLAPI void     mc_align_to              (mcBuffer* mb, const uint32_t alignment);

--- a/include/microcdr/common.h
+++ b/include/microcdr/common.h
@@ -59,8 +59,8 @@ MCDLLAPI void mc_reset_micro_buffer        (mcMicroBuffer* mb);
 MCDLLAPI void mc_reset_micro_buffer_offset (mcMicroBuffer* mb, const uint32_t offset);
 
 MCDLLAPI void     mc_align_to              (mcMicroBuffer* mb, const uint32_t alignment);
-MCDLLAPI uint32_t mc_alignment             (uint32_t buffer_position, const uint32_t data_size); //change name
-MCDLLAPI uint32_t mc_micro_buffer_alignment(const mcMicroBuffer* mb, const uint32_t data_size); //change name
+MCDLLAPI uint32_t mc_alignment             (uint32_t buffer_position, const uint32_t data_size);
+MCDLLAPI uint32_t mc_micro_buffer_alignment(const mcMicroBuffer* mb, const uint32_t data_size);
 
 MCDLLAPI size_t     mc_micro_buffer_size      (const mcMicroBuffer* mb);
 MCDLLAPI size_t     mc_micro_buffer_length    (const mcMicroBuffer* mb);

--- a/include/microcdr/config.h.in
+++ b/include/microcdr/config.h.in
@@ -21,7 +21,7 @@
 #define MICROCDR_VERSION_MICRO @PROJECT_VERSION_PATCH@
 #define MICROCDR_VERSION_STR "@PROJECT_VERSION@"
 
-// mrEndianness defines
+// mcEndianness defines
 #ifndef __BIG_ENDIAN__
 #define __BIG_ENDIAN__ @__BIG_ENDIAN__@
 #endif

--- a/include/microcdr/config.h.in
+++ b/include/microcdr/config.h.in
@@ -21,7 +21,7 @@
 #define MICROCDR_VERSION_MICRO @PROJECT_VERSION_PATCH@
 #define MICROCDR_VERSION_STR "@PROJECT_VERSION@"
 
-// Endianness defines
+// mrEndianness defines
 #ifndef __BIG_ENDIAN__
 #define __BIG_ENDIAN__ @__BIG_ENDIAN__@
 #endif

--- a/include/microcdr/types/array.h
+++ b/include/microcdr/types/array.h
@@ -25,18 +25,18 @@ extern "C" {
 //                   PUBLIC SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
 
-MCDLLAPI bool serialize_array_char(mcMicroBuffer* mb, const char* array, const uint32_t size);
-MCDLLAPI bool serialize_array_bool(mcMicroBuffer* mb, const bool* array, const uint32_t size);
-MCDLLAPI bool serialize_array_uint8_t(mcMicroBuffer* mb, const uint8_t* array, const uint32_t size);
-MCDLLAPI bool serialize_array_uint16_t(mcMicroBuffer* mb, const uint16_t* array, const uint32_t size);
-MCDLLAPI bool serialize_array_uint32_t(mcMicroBuffer* mb, const uint32_t* array, const uint32_t size);
-MCDLLAPI bool serialize_array_uint64_t(mcMicroBuffer* mb, const uint64_t* array, const uint32_t size);
-MCDLLAPI bool serialize_array_int8_t(mcMicroBuffer* mb, const int8_t* array, const uint32_t size);
-MCDLLAPI bool serialize_array_int16_t(mcMicroBuffer* mb, const int16_t* array, const uint32_t size);
-MCDLLAPI bool serialize_array_int32_t(mcMicroBuffer* mb, const int32_t* array, const uint32_t size);
-MCDLLAPI bool serialize_array_int64_t(mcMicroBuffer* mb, const int64_t* array, const uint32_t size);
-MCDLLAPI bool serialize_array_float(mcMicroBuffer* mb, const float* array, const uint32_t size);
-MCDLLAPI bool serialize_array_double(mcMicroBuffer* mb, const double* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_array_char(mcMicroBuffer* mb, const char* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_array_bool(mcMicroBuffer* mb, const bool* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_array_uint8_t(mcMicroBuffer* mb, const uint8_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_array_uint16_t(mcMicroBuffer* mb, const uint16_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_array_uint32_t(mcMicroBuffer* mb, const uint32_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_array_uint64_t(mcMicroBuffer* mb, const uint64_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_array_int8_t(mcMicroBuffer* mb, const int8_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_array_int16_t(mcMicroBuffer* mb, const int16_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_array_int32_t(mcMicroBuffer* mb, const int32_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_array_int64_t(mcMicroBuffer* mb, const int64_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_array_float(mcMicroBuffer* mb, const float* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_array_double(mcMicroBuffer* mb, const double* array, const uint32_t size);
 
 MCDLLAPI bool mc_deserialize_array_char(mcMicroBuffer* mb, char* array, const uint32_t size);
 MCDLLAPI bool mc_deserialize_array_bool(mcMicroBuffer* mb, bool* array, const uint32_t size);
@@ -51,14 +51,14 @@ MCDLLAPI bool mc_deserialize_array_int64_t(mcMicroBuffer* mb, int64_t* array, co
 MCDLLAPI bool mc_deserialize_array_float(mcMicroBuffer* mb, float* array, const uint32_t size);
 MCDLLAPI bool mc_deserialize_array_double(mcMicroBuffer* mb, double* array, const uint32_t size);
 
-MCDLLAPI bool serialize_endian_array_uint16_t(mcMicroBuffer* mb, Endianness endianness, const uint16_t* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_array_uint32_t(mcMicroBuffer* mb, Endianness endianness, const uint32_t* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_array_uint64_t(mcMicroBuffer* mb, Endianness endianness, const uint64_t* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_array_int16_t(mcMicroBuffer* mb, Endianness endianness, const int16_t* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_array_int32_t(mcMicroBuffer* mb, Endianness endianness, const int32_t* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_array_int64_t(mcMicroBuffer* mb, Endianness endianness, const int64_t* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_array_float(mcMicroBuffer* mb, Endianness endianness, const float* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_array_double(mcMicroBuffer* mb, Endianness endianness, const double* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_uint16_t(mcMicroBuffer* mb, Endianness endianness, const uint16_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_uint32_t(mcMicroBuffer* mb, Endianness endianness, const uint32_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_uint64_t(mcMicroBuffer* mb, Endianness endianness, const uint64_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_int16_t(mcMicroBuffer* mb, Endianness endianness, const int16_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_int32_t(mcMicroBuffer* mb, Endianness endianness, const int32_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_int64_t(mcMicroBuffer* mb, Endianness endianness, const int64_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_float(mcMicroBuffer* mb, Endianness endianness, const float* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_double(mcMicroBuffer* mb, Endianness endianness, const double* array, const uint32_t size);
 
 MCDLLAPI bool mc_deserialize_endian_array_uint16_t(mcMicroBuffer* mb, Endianness endianness, uint16_t* array, const uint32_t size);
 MCDLLAPI bool mc_deserialize_endian_array_uint32_t(mcMicroBuffer* mb, Endianness endianness, uint32_t* array, const uint32_t size);

--- a/include/microcdr/types/array.h
+++ b/include/microcdr/types/array.h
@@ -25,49 +25,49 @@ extern "C" {
 //                   PUBLIC SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
 
-MCDLLAPI bool mc_serialize_array_char(mcMicroBuffer* mb, const char* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_array_bool(mcMicroBuffer* mb, const bool* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_array_uint8_t(mcMicroBuffer* mb, const uint8_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_array_uint16_t(mcMicroBuffer* mb, const uint16_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_array_uint32_t(mcMicroBuffer* mb, const uint32_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_array_uint64_t(mcMicroBuffer* mb, const uint64_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_array_int8_t(mcMicroBuffer* mb, const int8_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_array_int16_t(mcMicroBuffer* mb, const int16_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_array_int32_t(mcMicroBuffer* mb, const int32_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_array_int64_t(mcMicroBuffer* mb, const int64_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_array_float(mcMicroBuffer* mb, const float* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_array_double(mcMicroBuffer* mb, const double* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_array_char(mcBuffer* mb, const char* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_array_bool(mcBuffer* mb, const bool* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_array_uint8_t(mcBuffer* mb, const uint8_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_array_uint16_t(mcBuffer* mb, const uint16_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_array_uint32_t(mcBuffer* mb, const uint32_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_array_uint64_t(mcBuffer* mb, const uint64_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_array_int8_t(mcBuffer* mb, const int8_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_array_int16_t(mcBuffer* mb, const int16_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_array_int32_t(mcBuffer* mb, const int32_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_array_int64_t(mcBuffer* mb, const int64_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_array_float(mcBuffer* mb, const float* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_array_double(mcBuffer* mb, const double* array, const uint32_t size);
 
-MCDLLAPI bool mc_deserialize_array_char(mcMicroBuffer* mb, char* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_array_bool(mcMicroBuffer* mb, bool* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_array_uint8_t(mcMicroBuffer* mb, uint8_t* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_array_uint16_t(mcMicroBuffer* mb, uint16_t* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_array_uint32_t(mcMicroBuffer* mb, uint32_t* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_array_uint64_t(mcMicroBuffer* mb, uint64_t* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_array_int8_t(mcMicroBuffer* mb, int8_t* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_array_int16_t(mcMicroBuffer* mb, int16_t* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_array_int32_t(mcMicroBuffer* mb, int32_t* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_array_int64_t(mcMicroBuffer* mb, int64_t* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_array_float(mcMicroBuffer* mb, float* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_array_double(mcMicroBuffer* mb, double* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_array_char(mcBuffer* mb, char* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_array_bool(mcBuffer* mb, bool* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_array_uint8_t(mcBuffer* mb, uint8_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_array_uint16_t(mcBuffer* mb, uint16_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_array_uint32_t(mcBuffer* mb, uint32_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_array_uint64_t(mcBuffer* mb, uint64_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_array_int8_t(mcBuffer* mb, int8_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_array_int16_t(mcBuffer* mb, int16_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_array_int32_t(mcBuffer* mb, int32_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_array_int64_t(mcBuffer* mb, int64_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_array_float(mcBuffer* mb, float* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_array_double(mcBuffer* mb, double* array, const uint32_t size);
 
-MCDLLAPI bool mc_serialize_endian_array_uint16_t(mcMicroBuffer* mb, mrEndianness endianness, const uint16_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_array_uint32_t(mcMicroBuffer* mb, mrEndianness endianness, const uint32_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_array_uint64_t(mcMicroBuffer* mb, mrEndianness endianness, const uint64_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_array_int16_t(mcMicroBuffer* mb, mrEndianness endianness, const int16_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_array_int32_t(mcMicroBuffer* mb, mrEndianness endianness, const int32_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_array_int64_t(mcMicroBuffer* mb, mrEndianness endianness, const int64_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_array_float(mcMicroBuffer* mb, mrEndianness endianness, const float* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_array_double(mcMicroBuffer* mb, mrEndianness endianness, const double* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_uint16_t(mcBuffer* mb, mrEndianness endianness, const uint16_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_uint32_t(mcBuffer* mb, mrEndianness endianness, const uint32_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_uint64_t(mcBuffer* mb, mrEndianness endianness, const uint64_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_int16_t(mcBuffer* mb, mrEndianness endianness, const int16_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_int32_t(mcBuffer* mb, mrEndianness endianness, const int32_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_int64_t(mcBuffer* mb, mrEndianness endianness, const int64_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_float(mcBuffer* mb, mrEndianness endianness, const float* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_double(mcBuffer* mb, mrEndianness endianness, const double* array, const uint32_t size);
 
-MCDLLAPI bool mc_deserialize_endian_array_uint16_t(mcMicroBuffer* mb, mrEndianness endianness, uint16_t* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_endian_array_uint32_t(mcMicroBuffer* mb, mrEndianness endianness, uint32_t* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_endian_array_uint64_t(mcMicroBuffer* mb, mrEndianness endianness, uint64_t* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_endian_array_int16_t(mcMicroBuffer* mb, mrEndianness endianness, int16_t* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_endian_array_int32_t(mcMicroBuffer* mb, mrEndianness endianness, int32_t* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_endian_array_int64_t(mcMicroBuffer* mb, mrEndianness endianness, int64_t* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_endian_array_float(mcMicroBuffer* mb, mrEndianness endianness, float* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_endian_array_double(mcMicroBuffer* mb, mrEndianness endianness, double* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_uint16_t(mcBuffer* mb, mrEndianness endianness, uint16_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_uint32_t(mcBuffer* mb, mrEndianness endianness, uint32_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_uint64_t(mcBuffer* mb, mrEndianness endianness, uint64_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_int16_t(mcBuffer* mb, mrEndianness endianness, int16_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_int32_t(mcBuffer* mb, mrEndianness endianness, int32_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_int64_t(mcBuffer* mb, mrEndianness endianness, int64_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_float(mcBuffer* mb, mrEndianness endianness, float* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_double(mcBuffer* mb, mrEndianness endianness, double* array, const uint32_t size);
 
 #ifdef __cplusplus
 }

--- a/include/microcdr/types/array.h
+++ b/include/microcdr/types/array.h
@@ -51,23 +51,23 @@ MCDLLAPI bool mc_deserialize_array_int64_t(mcMicroBuffer* mb, int64_t* array, co
 MCDLLAPI bool mc_deserialize_array_float(mcMicroBuffer* mb, float* array, const uint32_t size);
 MCDLLAPI bool mc_deserialize_array_double(mcMicroBuffer* mb, double* array, const uint32_t size);
 
-MCDLLAPI bool mc_serialize_endian_array_uint16_t(mcMicroBuffer* mb, Endianness endianness, const uint16_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_array_uint32_t(mcMicroBuffer* mb, Endianness endianness, const uint32_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_array_uint64_t(mcMicroBuffer* mb, Endianness endianness, const uint64_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_array_int16_t(mcMicroBuffer* mb, Endianness endianness, const int16_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_array_int32_t(mcMicroBuffer* mb, Endianness endianness, const int32_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_array_int64_t(mcMicroBuffer* mb, Endianness endianness, const int64_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_array_float(mcMicroBuffer* mb, Endianness endianness, const float* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_array_double(mcMicroBuffer* mb, Endianness endianness, const double* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_uint16_t(mcMicroBuffer* mb, mrEndianness endianness, const uint16_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_uint32_t(mcMicroBuffer* mb, mrEndianness endianness, const uint32_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_uint64_t(mcMicroBuffer* mb, mrEndianness endianness, const uint64_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_int16_t(mcMicroBuffer* mb, mrEndianness endianness, const int16_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_int32_t(mcMicroBuffer* mb, mrEndianness endianness, const int32_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_int64_t(mcMicroBuffer* mb, mrEndianness endianness, const int64_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_float(mcMicroBuffer* mb, mrEndianness endianness, const float* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_double(mcMicroBuffer* mb, mrEndianness endianness, const double* array, const uint32_t size);
 
-MCDLLAPI bool mc_deserialize_endian_array_uint16_t(mcMicroBuffer* mb, Endianness endianness, uint16_t* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_endian_array_uint32_t(mcMicroBuffer* mb, Endianness endianness, uint32_t* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_endian_array_uint64_t(mcMicroBuffer* mb, Endianness endianness, uint64_t* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_endian_array_int16_t(mcMicroBuffer* mb, Endianness endianness, int16_t* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_endian_array_int32_t(mcMicroBuffer* mb, Endianness endianness, int32_t* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_endian_array_int64_t(mcMicroBuffer* mb, Endianness endianness, int64_t* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_endian_array_float(mcMicroBuffer* mb, Endianness endianness, float* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_endian_array_double(mcMicroBuffer* mb, Endianness endianness, double* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_uint16_t(mcMicroBuffer* mb, mrEndianness endianness, uint16_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_uint32_t(mcMicroBuffer* mb, mrEndianness endianness, uint32_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_uint64_t(mcMicroBuffer* mb, mrEndianness endianness, uint64_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_int16_t(mcMicroBuffer* mb, mrEndianness endianness, int16_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_int32_t(mcMicroBuffer* mb, mrEndianness endianness, int32_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_int64_t(mcMicroBuffer* mb, mrEndianness endianness, int64_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_float(mcMicroBuffer* mb, mrEndianness endianness, float* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_double(mcMicroBuffer* mb, mrEndianness endianness, double* array, const uint32_t size);
 
 #ifdef __cplusplus
 }

--- a/include/microcdr/types/array.h
+++ b/include/microcdr/types/array.h
@@ -51,23 +51,23 @@ MCDLLAPI bool mc_deserialize_array_int64_t(mcBuffer* mb, int64_t* array, const u
 MCDLLAPI bool mc_deserialize_array_float(mcBuffer* mb, float* array, const uint32_t size);
 MCDLLAPI bool mc_deserialize_array_double(mcBuffer* mb, double* array, const uint32_t size);
 
-MCDLLAPI bool mc_serialize_endian_array_uint16_t(mcBuffer* mb, mrEndianness endianness, const uint16_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_array_uint32_t(mcBuffer* mb, mrEndianness endianness, const uint32_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_array_uint64_t(mcBuffer* mb, mrEndianness endianness, const uint64_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_array_int16_t(mcBuffer* mb, mrEndianness endianness, const int16_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_array_int32_t(mcBuffer* mb, mrEndianness endianness, const int32_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_array_int64_t(mcBuffer* mb, mrEndianness endianness, const int64_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_array_float(mcBuffer* mb, mrEndianness endianness, const float* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_array_double(mcBuffer* mb, mrEndianness endianness, const double* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_uint16_t(mcBuffer* mb, mcEndianness endianness, const uint16_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_uint32_t(mcBuffer* mb, mcEndianness endianness, const uint32_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_uint64_t(mcBuffer* mb, mcEndianness endianness, const uint64_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_int16_t(mcBuffer* mb, mcEndianness endianness, const int16_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_int32_t(mcBuffer* mb, mcEndianness endianness, const int32_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_int64_t(mcBuffer* mb, mcEndianness endianness, const int64_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_float(mcBuffer* mb, mcEndianness endianness, const float* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_array_double(mcBuffer* mb, mcEndianness endianness, const double* array, const uint32_t size);
 
-MCDLLAPI bool mc_deserialize_endian_array_uint16_t(mcBuffer* mb, mrEndianness endianness, uint16_t* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_endian_array_uint32_t(mcBuffer* mb, mrEndianness endianness, uint32_t* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_endian_array_uint64_t(mcBuffer* mb, mrEndianness endianness, uint64_t* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_endian_array_int16_t(mcBuffer* mb, mrEndianness endianness, int16_t* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_endian_array_int32_t(mcBuffer* mb, mrEndianness endianness, int32_t* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_endian_array_int64_t(mcBuffer* mb, mrEndianness endianness, int64_t* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_endian_array_float(mcBuffer* mb, mrEndianness endianness, float* array, const uint32_t size);
-MCDLLAPI bool mc_deserialize_endian_array_double(mcBuffer* mb, mrEndianness endianness, double* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_uint16_t(mcBuffer* mb, mcEndianness endianness, uint16_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_uint32_t(mcBuffer* mb, mcEndianness endianness, uint32_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_uint64_t(mcBuffer* mb, mcEndianness endianness, uint64_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_int16_t(mcBuffer* mb, mcEndianness endianness, int16_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_int32_t(mcBuffer* mb, mcEndianness endianness, int32_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_int64_t(mcBuffer* mb, mcEndianness endianness, int64_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_float(mcBuffer* mb, mcEndianness endianness, float* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_double(mcBuffer* mb, mcEndianness endianness, double* array, const uint32_t size);
 
 #ifdef __cplusplus
 }

--- a/include/microcdr/types/array.h
+++ b/include/microcdr/types/array.h
@@ -38,18 +38,18 @@ MCDLLAPI bool serialize_array_int64_t(mcMicroBuffer* mb, const int64_t* array, c
 MCDLLAPI bool serialize_array_float(mcMicroBuffer* mb, const float* array, const uint32_t size);
 MCDLLAPI bool serialize_array_double(mcMicroBuffer* mb, const double* array, const uint32_t size);
 
-MCDLLAPI bool deserialize_array_char(mcMicroBuffer* mb, char* array, const uint32_t size);
-MCDLLAPI bool deserialize_array_bool(mcMicroBuffer* mb, bool* array, const uint32_t size);
-MCDLLAPI bool deserialize_array_uint8_t(mcMicroBuffer* mb, uint8_t* array, const uint32_t size);
-MCDLLAPI bool deserialize_array_uint16_t(mcMicroBuffer* mb, uint16_t* array, const uint32_t size);
-MCDLLAPI bool deserialize_array_uint32_t(mcMicroBuffer* mb, uint32_t* array, const uint32_t size);
-MCDLLAPI bool deserialize_array_uint64_t(mcMicroBuffer* mb, uint64_t* array, const uint32_t size);
-MCDLLAPI bool deserialize_array_int8_t(mcMicroBuffer* mb, int8_t* array, const uint32_t size);
-MCDLLAPI bool deserialize_array_int16_t(mcMicroBuffer* mb, int16_t* array, const uint32_t size);
-MCDLLAPI bool deserialize_array_int32_t(mcMicroBuffer* mb, int32_t* array, const uint32_t size);
-MCDLLAPI bool deserialize_array_int64_t(mcMicroBuffer* mb, int64_t* array, const uint32_t size);
-MCDLLAPI bool deserialize_array_float(mcMicroBuffer* mb, float* array, const uint32_t size);
-MCDLLAPI bool deserialize_array_double(mcMicroBuffer* mb, double* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_array_char(mcMicroBuffer* mb, char* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_array_bool(mcMicroBuffer* mb, bool* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_array_uint8_t(mcMicroBuffer* mb, uint8_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_array_uint16_t(mcMicroBuffer* mb, uint16_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_array_uint32_t(mcMicroBuffer* mb, uint32_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_array_uint64_t(mcMicroBuffer* mb, uint64_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_array_int8_t(mcMicroBuffer* mb, int8_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_array_int16_t(mcMicroBuffer* mb, int16_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_array_int32_t(mcMicroBuffer* mb, int32_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_array_int64_t(mcMicroBuffer* mb, int64_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_array_float(mcMicroBuffer* mb, float* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_array_double(mcMicroBuffer* mb, double* array, const uint32_t size);
 
 MCDLLAPI bool serialize_endian_array_uint16_t(mcMicroBuffer* mb, Endianness endianness, const uint16_t* array, const uint32_t size);
 MCDLLAPI bool serialize_endian_array_uint32_t(mcMicroBuffer* mb, Endianness endianness, const uint32_t* array, const uint32_t size);
@@ -60,14 +60,14 @@ MCDLLAPI bool serialize_endian_array_int64_t(mcMicroBuffer* mb, Endianness endia
 MCDLLAPI bool serialize_endian_array_float(mcMicroBuffer* mb, Endianness endianness, const float* array, const uint32_t size);
 MCDLLAPI bool serialize_endian_array_double(mcMicroBuffer* mb, Endianness endianness, const double* array, const uint32_t size);
 
-MCDLLAPI bool deserialize_endian_array_uint16_t(mcMicroBuffer* mb, Endianness endianness, uint16_t* array, const uint32_t size);
-MCDLLAPI bool deserialize_endian_array_uint32_t(mcMicroBuffer* mb, Endianness endianness, uint32_t* array, const uint32_t size);
-MCDLLAPI bool deserialize_endian_array_uint64_t(mcMicroBuffer* mb, Endianness endianness, uint64_t* array, const uint32_t size);
-MCDLLAPI bool deserialize_endian_array_int16_t(mcMicroBuffer* mb, Endianness endianness, int16_t* array, const uint32_t size);
-MCDLLAPI bool deserialize_endian_array_int32_t(mcMicroBuffer* mb, Endianness endianness, int32_t* array, const uint32_t size);
-MCDLLAPI bool deserialize_endian_array_int64_t(mcMicroBuffer* mb, Endianness endianness, int64_t* array, const uint32_t size);
-MCDLLAPI bool deserialize_endian_array_float(mcMicroBuffer* mb, Endianness endianness, float* array, const uint32_t size);
-MCDLLAPI bool deserialize_endian_array_double(mcMicroBuffer* mb, Endianness endianness, double* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_uint16_t(mcMicroBuffer* mb, Endianness endianness, uint16_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_uint32_t(mcMicroBuffer* mb, Endianness endianness, uint32_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_uint64_t(mcMicroBuffer* mb, Endianness endianness, uint64_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_int16_t(mcMicroBuffer* mb, Endianness endianness, int16_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_int32_t(mcMicroBuffer* mb, Endianness endianness, int32_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_int64_t(mcMicroBuffer* mb, Endianness endianness, int64_t* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_float(mcMicroBuffer* mb, Endianness endianness, float* array, const uint32_t size);
+MCDLLAPI bool mc_deserialize_endian_array_double(mcMicroBuffer* mb, Endianness endianness, double* array, const uint32_t size);
 
 #ifdef __cplusplus
 }

--- a/include/microcdr/types/array.h
+++ b/include/microcdr/types/array.h
@@ -25,49 +25,49 @@ extern "C" {
 //                   PUBLIC SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
 
-MCDLLAPI bool serialize_array_char(MicroBuffer* mb, const char* array, const uint32_t size);
-MCDLLAPI bool serialize_array_bool(MicroBuffer* mb, const bool* array, const uint32_t size);
-MCDLLAPI bool serialize_array_uint8_t(MicroBuffer* mb, const uint8_t* array, const uint32_t size);
-MCDLLAPI bool serialize_array_uint16_t(MicroBuffer* mb, const uint16_t* array, const uint32_t size);
-MCDLLAPI bool serialize_array_uint32_t(MicroBuffer* mb, const uint32_t* array, const uint32_t size);
-MCDLLAPI bool serialize_array_uint64_t(MicroBuffer* mb, const uint64_t* array, const uint32_t size);
-MCDLLAPI bool serialize_array_int8_t(MicroBuffer* mb, const int8_t* array, const uint32_t size);
-MCDLLAPI bool serialize_array_int16_t(MicroBuffer* mb, const int16_t* array, const uint32_t size);
-MCDLLAPI bool serialize_array_int32_t(MicroBuffer* mb, const int32_t* array, const uint32_t size);
-MCDLLAPI bool serialize_array_int64_t(MicroBuffer* mb, const int64_t* array, const uint32_t size);
-MCDLLAPI bool serialize_array_float(MicroBuffer* mb, const float* array, const uint32_t size);
-MCDLLAPI bool serialize_array_double(MicroBuffer* mb, const double* array, const uint32_t size);
+MCDLLAPI bool serialize_array_char(mcMicroBuffer* mb, const char* array, const uint32_t size);
+MCDLLAPI bool serialize_array_bool(mcMicroBuffer* mb, const bool* array, const uint32_t size);
+MCDLLAPI bool serialize_array_uint8_t(mcMicroBuffer* mb, const uint8_t* array, const uint32_t size);
+MCDLLAPI bool serialize_array_uint16_t(mcMicroBuffer* mb, const uint16_t* array, const uint32_t size);
+MCDLLAPI bool serialize_array_uint32_t(mcMicroBuffer* mb, const uint32_t* array, const uint32_t size);
+MCDLLAPI bool serialize_array_uint64_t(mcMicroBuffer* mb, const uint64_t* array, const uint32_t size);
+MCDLLAPI bool serialize_array_int8_t(mcMicroBuffer* mb, const int8_t* array, const uint32_t size);
+MCDLLAPI bool serialize_array_int16_t(mcMicroBuffer* mb, const int16_t* array, const uint32_t size);
+MCDLLAPI bool serialize_array_int32_t(mcMicroBuffer* mb, const int32_t* array, const uint32_t size);
+MCDLLAPI bool serialize_array_int64_t(mcMicroBuffer* mb, const int64_t* array, const uint32_t size);
+MCDLLAPI bool serialize_array_float(mcMicroBuffer* mb, const float* array, const uint32_t size);
+MCDLLAPI bool serialize_array_double(mcMicroBuffer* mb, const double* array, const uint32_t size);
 
-MCDLLAPI bool deserialize_array_char(MicroBuffer* mb, char* array, const uint32_t size);
-MCDLLAPI bool deserialize_array_bool(MicroBuffer* mb, bool* array, const uint32_t size);
-MCDLLAPI bool deserialize_array_uint8_t(MicroBuffer* mb, uint8_t* array, const uint32_t size);
-MCDLLAPI bool deserialize_array_uint16_t(MicroBuffer* mb, uint16_t* array, const uint32_t size);
-MCDLLAPI bool deserialize_array_uint32_t(MicroBuffer* mb, uint32_t* array, const uint32_t size);
-MCDLLAPI bool deserialize_array_uint64_t(MicroBuffer* mb, uint64_t* array, const uint32_t size);
-MCDLLAPI bool deserialize_array_int8_t(MicroBuffer* mb, int8_t* array, const uint32_t size);
-MCDLLAPI bool deserialize_array_int16_t(MicroBuffer* mb, int16_t* array, const uint32_t size);
-MCDLLAPI bool deserialize_array_int32_t(MicroBuffer* mb, int32_t* array, const uint32_t size);
-MCDLLAPI bool deserialize_array_int64_t(MicroBuffer* mb, int64_t* array, const uint32_t size);
-MCDLLAPI bool deserialize_array_float(MicroBuffer* mb, float* array, const uint32_t size);
-MCDLLAPI bool deserialize_array_double(MicroBuffer* mb, double* array, const uint32_t size);
+MCDLLAPI bool deserialize_array_char(mcMicroBuffer* mb, char* array, const uint32_t size);
+MCDLLAPI bool deserialize_array_bool(mcMicroBuffer* mb, bool* array, const uint32_t size);
+MCDLLAPI bool deserialize_array_uint8_t(mcMicroBuffer* mb, uint8_t* array, const uint32_t size);
+MCDLLAPI bool deserialize_array_uint16_t(mcMicroBuffer* mb, uint16_t* array, const uint32_t size);
+MCDLLAPI bool deserialize_array_uint32_t(mcMicroBuffer* mb, uint32_t* array, const uint32_t size);
+MCDLLAPI bool deserialize_array_uint64_t(mcMicroBuffer* mb, uint64_t* array, const uint32_t size);
+MCDLLAPI bool deserialize_array_int8_t(mcMicroBuffer* mb, int8_t* array, const uint32_t size);
+MCDLLAPI bool deserialize_array_int16_t(mcMicroBuffer* mb, int16_t* array, const uint32_t size);
+MCDLLAPI bool deserialize_array_int32_t(mcMicroBuffer* mb, int32_t* array, const uint32_t size);
+MCDLLAPI bool deserialize_array_int64_t(mcMicroBuffer* mb, int64_t* array, const uint32_t size);
+MCDLLAPI bool deserialize_array_float(mcMicroBuffer* mb, float* array, const uint32_t size);
+MCDLLAPI bool deserialize_array_double(mcMicroBuffer* mb, double* array, const uint32_t size);
 
-MCDLLAPI bool serialize_endian_array_uint16_t(MicroBuffer* mb, Endianness endianness, const uint16_t* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_array_uint32_t(MicroBuffer* mb, Endianness endianness, const uint32_t* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_array_uint64_t(MicroBuffer* mb, Endianness endianness, const uint64_t* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_array_int16_t(MicroBuffer* mb, Endianness endianness, const int16_t* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_array_int32_t(MicroBuffer* mb, Endianness endianness, const int32_t* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_array_int64_t(MicroBuffer* mb, Endianness endianness, const int64_t* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_array_float(MicroBuffer* mb, Endianness endianness, const float* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_array_double(MicroBuffer* mb, Endianness endianness, const double* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_array_uint16_t(mcMicroBuffer* mb, Endianness endianness, const uint16_t* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_array_uint32_t(mcMicroBuffer* mb, Endianness endianness, const uint32_t* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_array_uint64_t(mcMicroBuffer* mb, Endianness endianness, const uint64_t* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_array_int16_t(mcMicroBuffer* mb, Endianness endianness, const int16_t* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_array_int32_t(mcMicroBuffer* mb, Endianness endianness, const int32_t* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_array_int64_t(mcMicroBuffer* mb, Endianness endianness, const int64_t* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_array_float(mcMicroBuffer* mb, Endianness endianness, const float* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_array_double(mcMicroBuffer* mb, Endianness endianness, const double* array, const uint32_t size);
 
-MCDLLAPI bool deserialize_endian_array_uint16_t(MicroBuffer* mb, Endianness endianness, uint16_t* array, const uint32_t size);
-MCDLLAPI bool deserialize_endian_array_uint32_t(MicroBuffer* mb, Endianness endianness, uint32_t* array, const uint32_t size);
-MCDLLAPI bool deserialize_endian_array_uint64_t(MicroBuffer* mb, Endianness endianness, uint64_t* array, const uint32_t size);
-MCDLLAPI bool deserialize_endian_array_int16_t(MicroBuffer* mb, Endianness endianness, int16_t* array, const uint32_t size);
-MCDLLAPI bool deserialize_endian_array_int32_t(MicroBuffer* mb, Endianness endianness, int32_t* array, const uint32_t size);
-MCDLLAPI bool deserialize_endian_array_int64_t(MicroBuffer* mb, Endianness endianness, int64_t* array, const uint32_t size);
-MCDLLAPI bool deserialize_endian_array_float(MicroBuffer* mb, Endianness endianness, float* array, const uint32_t size);
-MCDLLAPI bool deserialize_endian_array_double(MicroBuffer* mb, Endianness endianness, double* array, const uint32_t size);
+MCDLLAPI bool deserialize_endian_array_uint16_t(mcMicroBuffer* mb, Endianness endianness, uint16_t* array, const uint32_t size);
+MCDLLAPI bool deserialize_endian_array_uint32_t(mcMicroBuffer* mb, Endianness endianness, uint32_t* array, const uint32_t size);
+MCDLLAPI bool deserialize_endian_array_uint64_t(mcMicroBuffer* mb, Endianness endianness, uint64_t* array, const uint32_t size);
+MCDLLAPI bool deserialize_endian_array_int16_t(mcMicroBuffer* mb, Endianness endianness, int16_t* array, const uint32_t size);
+MCDLLAPI bool deserialize_endian_array_int32_t(mcMicroBuffer* mb, Endianness endianness, int32_t* array, const uint32_t size);
+MCDLLAPI bool deserialize_endian_array_int64_t(mcMicroBuffer* mb, Endianness endianness, int64_t* array, const uint32_t size);
+MCDLLAPI bool deserialize_endian_array_float(mcMicroBuffer* mb, Endianness endianness, float* array, const uint32_t size);
+MCDLLAPI bool deserialize_endian_array_double(mcMicroBuffer* mb, Endianness endianness, double* array, const uint32_t size);
 
 #ifdef __cplusplus
 }

--- a/include/microcdr/types/basic.h
+++ b/include/microcdr/types/basic.h
@@ -25,49 +25,49 @@ extern "C" {
 //                   PUBLIC SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
 
-MCDLLAPI bool mc_serialize_char(mcMicroBuffer* mb, const char value);
-MCDLLAPI bool mc_serialize_bool(mcMicroBuffer* mb, const bool value);
-MCDLLAPI bool mc_serialize_uint8_t(mcMicroBuffer* mb, const uint8_t value);
-MCDLLAPI bool mc_serialize_uint16_t(mcMicroBuffer* mb, const uint16_t value);
-MCDLLAPI bool mc_serialize_uint32_t(mcMicroBuffer* mb, const uint32_t value);
-MCDLLAPI bool mc_serialize_uint64_t(mcMicroBuffer* mb, const uint64_t value);
-MCDLLAPI bool mc_serialize_int8_t(mcMicroBuffer* mb, const int8_t value);
-MCDLLAPI bool mc_serialize_int16_t(mcMicroBuffer* mb, const int16_t value);
-MCDLLAPI bool mc_serialize_int32_t(mcMicroBuffer* mb, const int32_t value);
-MCDLLAPI bool mc_serialize_int64_t(mcMicroBuffer* mb, const int64_t value);
-MCDLLAPI bool mc_serialize_float(mcMicroBuffer* mb, const float value);
-MCDLLAPI bool mc_serialize_double(mcMicroBuffer* mb, const double value);
+MCDLLAPI bool mc_serialize_char(mcBuffer* mb, const char value);
+MCDLLAPI bool mc_serialize_bool(mcBuffer* mb, const bool value);
+MCDLLAPI bool mc_serialize_uint8_t(mcBuffer* mb, const uint8_t value);
+MCDLLAPI bool mc_serialize_uint16_t(mcBuffer* mb, const uint16_t value);
+MCDLLAPI bool mc_serialize_uint32_t(mcBuffer* mb, const uint32_t value);
+MCDLLAPI bool mc_serialize_uint64_t(mcBuffer* mb, const uint64_t value);
+MCDLLAPI bool mc_serialize_int8_t(mcBuffer* mb, const int8_t value);
+MCDLLAPI bool mc_serialize_int16_t(mcBuffer* mb, const int16_t value);
+MCDLLAPI bool mc_serialize_int32_t(mcBuffer* mb, const int32_t value);
+MCDLLAPI bool mc_serialize_int64_t(mcBuffer* mb, const int64_t value);
+MCDLLAPI bool mc_serialize_float(mcBuffer* mb, const float value);
+MCDLLAPI bool mc_serialize_double(mcBuffer* mb, const double value);
 
-MCDLLAPI bool mc_deserialize_char(mcMicroBuffer* mb, char* value);
-MCDLLAPI bool mc_deserialize_bool(mcMicroBuffer* mb, bool* value);
-MCDLLAPI bool mc_deserialize_uint8_t(mcMicroBuffer* mb, uint8_t* value);
-MCDLLAPI bool mc_deserialize_uint16_t(mcMicroBuffer* mb, uint16_t* value);
-MCDLLAPI bool mc_deserialize_uint32_t(mcMicroBuffer* mb, uint32_t* value);
-MCDLLAPI bool mc_deserialize_uint64_t(mcMicroBuffer* mb, uint64_t* value);
-MCDLLAPI bool mc_deserialize_int8_t(mcMicroBuffer* mb, int8_t* value);
-MCDLLAPI bool mc_deserialize_int16_t(mcMicroBuffer* mb, int16_t* value);
-MCDLLAPI bool mc_deserialize_int32_t(mcMicroBuffer* mb, int32_t* value);
-MCDLLAPI bool mc_deserialize_int64_t(mcMicroBuffer* mb, int64_t* value);
-MCDLLAPI bool mc_deserialize_float(mcMicroBuffer* mb, float* value);
-MCDLLAPI bool mc_deserialize_double(mcMicroBuffer* mb, double* value);
+MCDLLAPI bool mc_deserialize_char(mcBuffer* mb, char* value);
+MCDLLAPI bool mc_deserialize_bool(mcBuffer* mb, bool* value);
+MCDLLAPI bool mc_deserialize_uint8_t(mcBuffer* mb, uint8_t* value);
+MCDLLAPI bool mc_deserialize_uint16_t(mcBuffer* mb, uint16_t* value);
+MCDLLAPI bool mc_deserialize_uint32_t(mcBuffer* mb, uint32_t* value);
+MCDLLAPI bool mc_deserialize_uint64_t(mcBuffer* mb, uint64_t* value);
+MCDLLAPI bool mc_deserialize_int8_t(mcBuffer* mb, int8_t* value);
+MCDLLAPI bool mc_deserialize_int16_t(mcBuffer* mb, int16_t* value);
+MCDLLAPI bool mc_deserialize_int32_t(mcBuffer* mb, int32_t* value);
+MCDLLAPI bool mc_deserialize_int64_t(mcBuffer* mb, int64_t* value);
+MCDLLAPI bool mc_deserialize_float(mcBuffer* mb, float* value);
+MCDLLAPI bool mc_deserialize_double(mcBuffer* mb, double* value);
 
-MCDLLAPI bool mc_serialize_endian_uint16_t(mcMicroBuffer* mb, mrEndianness endianness, const uint16_t value);
-MCDLLAPI bool mc_serialize_endian_uint32_t(mcMicroBuffer* mb, mrEndianness endianness, const uint32_t value);
-MCDLLAPI bool mc_serialize_endian_uint64_t(mcMicroBuffer* mb, mrEndianness endianness, const uint64_t value);
-MCDLLAPI bool mc_serialize_endian_int16_t(mcMicroBuffer* mb, mrEndianness endianness, const int16_t value);
-MCDLLAPI bool mc_serialize_endian_int32_t(mcMicroBuffer* mb, mrEndianness endianness, const int32_t value);
-MCDLLAPI bool mc_serialize_endian_int64_t(mcMicroBuffer* mb, mrEndianness endianness, const int64_t value);
-MCDLLAPI bool mc_serialize_endian_float(mcMicroBuffer* mb, mrEndianness endianness, const float value);
-MCDLLAPI bool mc_serialize_endian_double(mcMicroBuffer* mb, mrEndianness endianness, const double value);
+MCDLLAPI bool mc_serialize_endian_uint16_t(mcBuffer* mb, mrEndianness endianness, const uint16_t value);
+MCDLLAPI bool mc_serialize_endian_uint32_t(mcBuffer* mb, mrEndianness endianness, const uint32_t value);
+MCDLLAPI bool mc_serialize_endian_uint64_t(mcBuffer* mb, mrEndianness endianness, const uint64_t value);
+MCDLLAPI bool mc_serialize_endian_int16_t(mcBuffer* mb, mrEndianness endianness, const int16_t value);
+MCDLLAPI bool mc_serialize_endian_int32_t(mcBuffer* mb, mrEndianness endianness, const int32_t value);
+MCDLLAPI bool mc_serialize_endian_int64_t(mcBuffer* mb, mrEndianness endianness, const int64_t value);
+MCDLLAPI bool mc_serialize_endian_float(mcBuffer* mb, mrEndianness endianness, const float value);
+MCDLLAPI bool mc_serialize_endian_double(mcBuffer* mb, mrEndianness endianness, const double value);
 
-MCDLLAPI bool mc_deserialize_endian_uint16_t(mcMicroBuffer* mb, mrEndianness endianness, uint16_t* value);
-MCDLLAPI bool mc_deserialize_endian_uint32_t(mcMicroBuffer* mb, mrEndianness endianness, uint32_t *value);
-MCDLLAPI bool mc_deserialize_endian_uint64_t(mcMicroBuffer* mb, mrEndianness endianness, uint64_t* value);
-MCDLLAPI bool mc_deserialize_endian_int16_t(mcMicroBuffer* mb, mrEndianness endianness, int16_t* value);
-MCDLLAPI bool mc_deserialize_endian_int32_t(mcMicroBuffer* mb, mrEndianness endianness, int32_t* value);
-MCDLLAPI bool mc_deserialize_endian_int64_t(mcMicroBuffer* mb, mrEndianness endianness, int64_t* value);
-MCDLLAPI bool mc_deserialize_endian_float(mcMicroBuffer* mb, mrEndianness endianness, float* value);
-MCDLLAPI bool mc_deserialize_endian_double(mcMicroBuffer* mb, mrEndianness endianness, double* value);
+MCDLLAPI bool mc_deserialize_endian_uint16_t(mcBuffer* mb, mrEndianness endianness, uint16_t* value);
+MCDLLAPI bool mc_deserialize_endian_uint32_t(mcBuffer* mb, mrEndianness endianness, uint32_t *value);
+MCDLLAPI bool mc_deserialize_endian_uint64_t(mcBuffer* mb, mrEndianness endianness, uint64_t* value);
+MCDLLAPI bool mc_deserialize_endian_int16_t(mcBuffer* mb, mrEndianness endianness, int16_t* value);
+MCDLLAPI bool mc_deserialize_endian_int32_t(mcBuffer* mb, mrEndianness endianness, int32_t* value);
+MCDLLAPI bool mc_deserialize_endian_int64_t(mcBuffer* mb, mrEndianness endianness, int64_t* value);
+MCDLLAPI bool mc_deserialize_endian_float(mcBuffer* mb, mrEndianness endianness, float* value);
+MCDLLAPI bool mc_deserialize_endian_double(mcBuffer* mb, mrEndianness endianness, double* value);
 
 #ifdef __cplusplus
 }

--- a/include/microcdr/types/basic.h
+++ b/include/microcdr/types/basic.h
@@ -25,18 +25,18 @@ extern "C" {
 //                   PUBLIC SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
 
-MCDLLAPI bool serialize_char(mcMicroBuffer* mb, const char value);
-MCDLLAPI bool serialize_bool(mcMicroBuffer* mb, const bool value);
-MCDLLAPI bool serialize_uint8_t(mcMicroBuffer* mb, const uint8_t value);
-MCDLLAPI bool serialize_uint16_t(mcMicroBuffer* mb, const uint16_t value);
-MCDLLAPI bool serialize_uint32_t(mcMicroBuffer* mb, const uint32_t value);
-MCDLLAPI bool serialize_uint64_t(mcMicroBuffer* mb, const uint64_t value);
-MCDLLAPI bool serialize_int8_t(mcMicroBuffer* mb, const int8_t value);
-MCDLLAPI bool serialize_int16_t(mcMicroBuffer* mb, const int16_t value);
-MCDLLAPI bool serialize_int32_t(mcMicroBuffer* mb, const int32_t value);
-MCDLLAPI bool serialize_int64_t(mcMicroBuffer* mb, const int64_t value);
-MCDLLAPI bool serialize_float(mcMicroBuffer* mb, const float value);
-MCDLLAPI bool serialize_double(mcMicroBuffer* mb, const double value);
+MCDLLAPI bool mc_serialize_char(mcMicroBuffer* mb, const char value);
+MCDLLAPI bool mc_serialize_bool(mcMicroBuffer* mb, const bool value);
+MCDLLAPI bool mc_serialize_uint8_t(mcMicroBuffer* mb, const uint8_t value);
+MCDLLAPI bool mc_serialize_uint16_t(mcMicroBuffer* mb, const uint16_t value);
+MCDLLAPI bool mc_serialize_uint32_t(mcMicroBuffer* mb, const uint32_t value);
+MCDLLAPI bool mc_serialize_uint64_t(mcMicroBuffer* mb, const uint64_t value);
+MCDLLAPI bool mc_serialize_int8_t(mcMicroBuffer* mb, const int8_t value);
+MCDLLAPI bool mc_serialize_int16_t(mcMicroBuffer* mb, const int16_t value);
+MCDLLAPI bool mc_serialize_int32_t(mcMicroBuffer* mb, const int32_t value);
+MCDLLAPI bool mc_serialize_int64_t(mcMicroBuffer* mb, const int64_t value);
+MCDLLAPI bool mc_serialize_float(mcMicroBuffer* mb, const float value);
+MCDLLAPI bool mc_serialize_double(mcMicroBuffer* mb, const double value);
 
 MCDLLAPI bool mc_deserialize_char(mcMicroBuffer* mb, char* value);
 MCDLLAPI bool mc_deserialize_bool(mcMicroBuffer* mb, bool* value);
@@ -51,14 +51,14 @@ MCDLLAPI bool mc_deserialize_int64_t(mcMicroBuffer* mb, int64_t* value);
 MCDLLAPI bool mc_deserialize_float(mcMicroBuffer* mb, float* value);
 MCDLLAPI bool mc_deserialize_double(mcMicroBuffer* mb, double* value);
 
-MCDLLAPI bool serialize_endian_uint16_t(mcMicroBuffer* mb, Endianness endianness, const uint16_t value);
-MCDLLAPI bool serialize_endian_uint32_t(mcMicroBuffer* mb, Endianness endianness, const uint32_t value);
-MCDLLAPI bool serialize_endian_uint64_t(mcMicroBuffer* mb, Endianness endianness, const uint64_t value);
-MCDLLAPI bool serialize_endian_int16_t(mcMicroBuffer* mb, Endianness endianness, const int16_t value);
-MCDLLAPI bool serialize_endian_int32_t(mcMicroBuffer* mb, Endianness endianness, const int32_t value);
-MCDLLAPI bool serialize_endian_int64_t(mcMicroBuffer* mb, Endianness endianness, const int64_t value);
-MCDLLAPI bool serialize_endian_float(mcMicroBuffer* mb, Endianness endianness, const float value);
-MCDLLAPI bool serialize_endian_double(mcMicroBuffer* mb, Endianness endianness, const double value);
+MCDLLAPI bool mc_serialize_endian_uint16_t(mcMicroBuffer* mb, Endianness endianness, const uint16_t value);
+MCDLLAPI bool mc_serialize_endian_uint32_t(mcMicroBuffer* mb, Endianness endianness, const uint32_t value);
+MCDLLAPI bool mc_serialize_endian_uint64_t(mcMicroBuffer* mb, Endianness endianness, const uint64_t value);
+MCDLLAPI bool mc_serialize_endian_int16_t(mcMicroBuffer* mb, Endianness endianness, const int16_t value);
+MCDLLAPI bool mc_serialize_endian_int32_t(mcMicroBuffer* mb, Endianness endianness, const int32_t value);
+MCDLLAPI bool mc_serialize_endian_int64_t(mcMicroBuffer* mb, Endianness endianness, const int64_t value);
+MCDLLAPI bool mc_serialize_endian_float(mcMicroBuffer* mb, Endianness endianness, const float value);
+MCDLLAPI bool mc_serialize_endian_double(mcMicroBuffer* mb, Endianness endianness, const double value);
 
 MCDLLAPI bool mc_deserialize_endian_uint16_t(mcMicroBuffer* mb, Endianness endianness, uint16_t* value);
 MCDLLAPI bool mc_deserialize_endian_uint32_t(mcMicroBuffer* mb, Endianness endianness, uint32_t *value);

--- a/include/microcdr/types/basic.h
+++ b/include/microcdr/types/basic.h
@@ -25,49 +25,49 @@ extern "C" {
 //                   PUBLIC SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
 
-MCDLLAPI bool serialize_char(MicroBuffer* mb, const char value);
-MCDLLAPI bool serialize_bool(MicroBuffer* mb, const bool value);
-MCDLLAPI bool serialize_uint8_t(MicroBuffer* mb, const uint8_t value);
-MCDLLAPI bool serialize_uint16_t(MicroBuffer* mb, const uint16_t value);
-MCDLLAPI bool serialize_uint32_t(MicroBuffer* mb, const uint32_t value);
-MCDLLAPI bool serialize_uint64_t(MicroBuffer* mb, const uint64_t value);
-MCDLLAPI bool serialize_int8_t(MicroBuffer* mb, const int8_t value);
-MCDLLAPI bool serialize_int16_t(MicroBuffer* mb, const int16_t value);
-MCDLLAPI bool serialize_int32_t(MicroBuffer* mb, const int32_t value);
-MCDLLAPI bool serialize_int64_t(MicroBuffer* mb, const int64_t value);
-MCDLLAPI bool serialize_float(MicroBuffer* mb, const float value);
-MCDLLAPI bool serialize_double(MicroBuffer* mb, const double value);
+MCDLLAPI bool serialize_char(mcMicroBuffer* mb, const char value);
+MCDLLAPI bool serialize_bool(mcMicroBuffer* mb, const bool value);
+MCDLLAPI bool serialize_uint8_t(mcMicroBuffer* mb, const uint8_t value);
+MCDLLAPI bool serialize_uint16_t(mcMicroBuffer* mb, const uint16_t value);
+MCDLLAPI bool serialize_uint32_t(mcMicroBuffer* mb, const uint32_t value);
+MCDLLAPI bool serialize_uint64_t(mcMicroBuffer* mb, const uint64_t value);
+MCDLLAPI bool serialize_int8_t(mcMicroBuffer* mb, const int8_t value);
+MCDLLAPI bool serialize_int16_t(mcMicroBuffer* mb, const int16_t value);
+MCDLLAPI bool serialize_int32_t(mcMicroBuffer* mb, const int32_t value);
+MCDLLAPI bool serialize_int64_t(mcMicroBuffer* mb, const int64_t value);
+MCDLLAPI bool serialize_float(mcMicroBuffer* mb, const float value);
+MCDLLAPI bool serialize_double(mcMicroBuffer* mb, const double value);
 
-MCDLLAPI bool deserialize_char(MicroBuffer* mb, char* value);
-MCDLLAPI bool deserialize_bool(MicroBuffer* mb, bool* value);
-MCDLLAPI bool deserialize_uint8_t(MicroBuffer* mb, uint8_t* value);
-MCDLLAPI bool deserialize_uint16_t(MicroBuffer* mb, uint16_t* value);
-MCDLLAPI bool deserialize_uint32_t(MicroBuffer* mb, uint32_t* value);
-MCDLLAPI bool deserialize_uint64_t(MicroBuffer* mb, uint64_t* value);
-MCDLLAPI bool deserialize_int8_t(MicroBuffer* mb, int8_t* value);
-MCDLLAPI bool deserialize_int16_t(MicroBuffer* mb, int16_t* value);
-MCDLLAPI bool deserialize_int32_t(MicroBuffer* mb, int32_t* value);
-MCDLLAPI bool deserialize_int64_t(MicroBuffer* mb, int64_t* value);
-MCDLLAPI bool deserialize_float(MicroBuffer* mb, float* value);
-MCDLLAPI bool deserialize_double(MicroBuffer* mb, double* value);
+MCDLLAPI bool deserialize_char(mcMicroBuffer* mb, char* value);
+MCDLLAPI bool deserialize_bool(mcMicroBuffer* mb, bool* value);
+MCDLLAPI bool deserialize_uint8_t(mcMicroBuffer* mb, uint8_t* value);
+MCDLLAPI bool deserialize_uint16_t(mcMicroBuffer* mb, uint16_t* value);
+MCDLLAPI bool deserialize_uint32_t(mcMicroBuffer* mb, uint32_t* value);
+MCDLLAPI bool deserialize_uint64_t(mcMicroBuffer* mb, uint64_t* value);
+MCDLLAPI bool deserialize_int8_t(mcMicroBuffer* mb, int8_t* value);
+MCDLLAPI bool deserialize_int16_t(mcMicroBuffer* mb, int16_t* value);
+MCDLLAPI bool deserialize_int32_t(mcMicroBuffer* mb, int32_t* value);
+MCDLLAPI bool deserialize_int64_t(mcMicroBuffer* mb, int64_t* value);
+MCDLLAPI bool deserialize_float(mcMicroBuffer* mb, float* value);
+MCDLLAPI bool deserialize_double(mcMicroBuffer* mb, double* value);
 
-MCDLLAPI bool serialize_endian_uint16_t(MicroBuffer* mb, Endianness endianness, const uint16_t value);
-MCDLLAPI bool serialize_endian_uint32_t(MicroBuffer* mb, Endianness endianness, const uint32_t value);
-MCDLLAPI bool serialize_endian_uint64_t(MicroBuffer* mb, Endianness endianness, const uint64_t value);
-MCDLLAPI bool serialize_endian_int16_t(MicroBuffer* mb, Endianness endianness, const int16_t value);
-MCDLLAPI bool serialize_endian_int32_t(MicroBuffer* mb, Endianness endianness, const int32_t value);
-MCDLLAPI bool serialize_endian_int64_t(MicroBuffer* mb, Endianness endianness, const int64_t value);
-MCDLLAPI bool serialize_endian_float(MicroBuffer* mb, Endianness endianness, const float value);
-MCDLLAPI bool serialize_endian_double(MicroBuffer* mb, Endianness endianness, const double value);
+MCDLLAPI bool serialize_endian_uint16_t(mcMicroBuffer* mb, Endianness endianness, const uint16_t value);
+MCDLLAPI bool serialize_endian_uint32_t(mcMicroBuffer* mb, Endianness endianness, const uint32_t value);
+MCDLLAPI bool serialize_endian_uint64_t(mcMicroBuffer* mb, Endianness endianness, const uint64_t value);
+MCDLLAPI bool serialize_endian_int16_t(mcMicroBuffer* mb, Endianness endianness, const int16_t value);
+MCDLLAPI bool serialize_endian_int32_t(mcMicroBuffer* mb, Endianness endianness, const int32_t value);
+MCDLLAPI bool serialize_endian_int64_t(mcMicroBuffer* mb, Endianness endianness, const int64_t value);
+MCDLLAPI bool serialize_endian_float(mcMicroBuffer* mb, Endianness endianness, const float value);
+MCDLLAPI bool serialize_endian_double(mcMicroBuffer* mb, Endianness endianness, const double value);
 
-MCDLLAPI bool deserialize_endian_uint16_t(MicroBuffer* mb, Endianness endianness, uint16_t* value);
-MCDLLAPI bool deserialize_endian_uint32_t(MicroBuffer* mb, Endianness endianness, uint32_t *value);
-MCDLLAPI bool deserialize_endian_uint64_t(MicroBuffer* mb, Endianness endianness, uint64_t* value);
-MCDLLAPI bool deserialize_endian_int16_t(MicroBuffer* mb, Endianness endianness, int16_t* value);
-MCDLLAPI bool deserialize_endian_int32_t(MicroBuffer* mb, Endianness endianness, int32_t* value);
-MCDLLAPI bool deserialize_endian_int64_t(MicroBuffer* mb, Endianness endianness, int64_t* value);
-MCDLLAPI bool deserialize_endian_float(MicroBuffer* mb, Endianness endianness, float* value);
-MCDLLAPI bool deserialize_endian_double(MicroBuffer* mb, Endianness endianness, double* value);
+MCDLLAPI bool deserialize_endian_uint16_t(mcMicroBuffer* mb, Endianness endianness, uint16_t* value);
+MCDLLAPI bool deserialize_endian_uint32_t(mcMicroBuffer* mb, Endianness endianness, uint32_t *value);
+MCDLLAPI bool deserialize_endian_uint64_t(mcMicroBuffer* mb, Endianness endianness, uint64_t* value);
+MCDLLAPI bool deserialize_endian_int16_t(mcMicroBuffer* mb, Endianness endianness, int16_t* value);
+MCDLLAPI bool deserialize_endian_int32_t(mcMicroBuffer* mb, Endianness endianness, int32_t* value);
+MCDLLAPI bool deserialize_endian_int64_t(mcMicroBuffer* mb, Endianness endianness, int64_t* value);
+MCDLLAPI bool deserialize_endian_float(mcMicroBuffer* mb, Endianness endianness, float* value);
+MCDLLAPI bool deserialize_endian_double(mcMicroBuffer* mb, Endianness endianness, double* value);
 
 #ifdef __cplusplus
 }

--- a/include/microcdr/types/basic.h
+++ b/include/microcdr/types/basic.h
@@ -51,23 +51,23 @@ MCDLLAPI bool mc_deserialize_int64_t(mcBuffer* mb, int64_t* value);
 MCDLLAPI bool mc_deserialize_float(mcBuffer* mb, float* value);
 MCDLLAPI bool mc_deserialize_double(mcBuffer* mb, double* value);
 
-MCDLLAPI bool mc_serialize_endian_uint16_t(mcBuffer* mb, mrEndianness endianness, const uint16_t value);
-MCDLLAPI bool mc_serialize_endian_uint32_t(mcBuffer* mb, mrEndianness endianness, const uint32_t value);
-MCDLLAPI bool mc_serialize_endian_uint64_t(mcBuffer* mb, mrEndianness endianness, const uint64_t value);
-MCDLLAPI bool mc_serialize_endian_int16_t(mcBuffer* mb, mrEndianness endianness, const int16_t value);
-MCDLLAPI bool mc_serialize_endian_int32_t(mcBuffer* mb, mrEndianness endianness, const int32_t value);
-MCDLLAPI bool mc_serialize_endian_int64_t(mcBuffer* mb, mrEndianness endianness, const int64_t value);
-MCDLLAPI bool mc_serialize_endian_float(mcBuffer* mb, mrEndianness endianness, const float value);
-MCDLLAPI bool mc_serialize_endian_double(mcBuffer* mb, mrEndianness endianness, const double value);
+MCDLLAPI bool mc_serialize_endian_uint16_t(mcBuffer* mb, mcEndianness endianness, const uint16_t value);
+MCDLLAPI bool mc_serialize_endian_uint32_t(mcBuffer* mb, mcEndianness endianness, const uint32_t value);
+MCDLLAPI bool mc_serialize_endian_uint64_t(mcBuffer* mb, mcEndianness endianness, const uint64_t value);
+MCDLLAPI bool mc_serialize_endian_int16_t(mcBuffer* mb, mcEndianness endianness, const int16_t value);
+MCDLLAPI bool mc_serialize_endian_int32_t(mcBuffer* mb, mcEndianness endianness, const int32_t value);
+MCDLLAPI bool mc_serialize_endian_int64_t(mcBuffer* mb, mcEndianness endianness, const int64_t value);
+MCDLLAPI bool mc_serialize_endian_float(mcBuffer* mb, mcEndianness endianness, const float value);
+MCDLLAPI bool mc_serialize_endian_double(mcBuffer* mb, mcEndianness endianness, const double value);
 
-MCDLLAPI bool mc_deserialize_endian_uint16_t(mcBuffer* mb, mrEndianness endianness, uint16_t* value);
-MCDLLAPI bool mc_deserialize_endian_uint32_t(mcBuffer* mb, mrEndianness endianness, uint32_t *value);
-MCDLLAPI bool mc_deserialize_endian_uint64_t(mcBuffer* mb, mrEndianness endianness, uint64_t* value);
-MCDLLAPI bool mc_deserialize_endian_int16_t(mcBuffer* mb, mrEndianness endianness, int16_t* value);
-MCDLLAPI bool mc_deserialize_endian_int32_t(mcBuffer* mb, mrEndianness endianness, int32_t* value);
-MCDLLAPI bool mc_deserialize_endian_int64_t(mcBuffer* mb, mrEndianness endianness, int64_t* value);
-MCDLLAPI bool mc_deserialize_endian_float(mcBuffer* mb, mrEndianness endianness, float* value);
-MCDLLAPI bool mc_deserialize_endian_double(mcBuffer* mb, mrEndianness endianness, double* value);
+MCDLLAPI bool mc_deserialize_endian_uint16_t(mcBuffer* mb, mcEndianness endianness, uint16_t* value);
+MCDLLAPI bool mc_deserialize_endian_uint32_t(mcBuffer* mb, mcEndianness endianness, uint32_t *value);
+MCDLLAPI bool mc_deserialize_endian_uint64_t(mcBuffer* mb, mcEndianness endianness, uint64_t* value);
+MCDLLAPI bool mc_deserialize_endian_int16_t(mcBuffer* mb, mcEndianness endianness, int16_t* value);
+MCDLLAPI bool mc_deserialize_endian_int32_t(mcBuffer* mb, mcEndianness endianness, int32_t* value);
+MCDLLAPI bool mc_deserialize_endian_int64_t(mcBuffer* mb, mcEndianness endianness, int64_t* value);
+MCDLLAPI bool mc_deserialize_endian_float(mcBuffer* mb, mcEndianness endianness, float* value);
+MCDLLAPI bool mc_deserialize_endian_double(mcBuffer* mb, mcEndianness endianness, double* value);
 
 #ifdef __cplusplus
 }

--- a/include/microcdr/types/basic.h
+++ b/include/microcdr/types/basic.h
@@ -51,23 +51,23 @@ MCDLLAPI bool mc_deserialize_int64_t(mcMicroBuffer* mb, int64_t* value);
 MCDLLAPI bool mc_deserialize_float(mcMicroBuffer* mb, float* value);
 MCDLLAPI bool mc_deserialize_double(mcMicroBuffer* mb, double* value);
 
-MCDLLAPI bool mc_serialize_endian_uint16_t(mcMicroBuffer* mb, Endianness endianness, const uint16_t value);
-MCDLLAPI bool mc_serialize_endian_uint32_t(mcMicroBuffer* mb, Endianness endianness, const uint32_t value);
-MCDLLAPI bool mc_serialize_endian_uint64_t(mcMicroBuffer* mb, Endianness endianness, const uint64_t value);
-MCDLLAPI bool mc_serialize_endian_int16_t(mcMicroBuffer* mb, Endianness endianness, const int16_t value);
-MCDLLAPI bool mc_serialize_endian_int32_t(mcMicroBuffer* mb, Endianness endianness, const int32_t value);
-MCDLLAPI bool mc_serialize_endian_int64_t(mcMicroBuffer* mb, Endianness endianness, const int64_t value);
-MCDLLAPI bool mc_serialize_endian_float(mcMicroBuffer* mb, Endianness endianness, const float value);
-MCDLLAPI bool mc_serialize_endian_double(mcMicroBuffer* mb, Endianness endianness, const double value);
+MCDLLAPI bool mc_serialize_endian_uint16_t(mcMicroBuffer* mb, mrEndianness endianness, const uint16_t value);
+MCDLLAPI bool mc_serialize_endian_uint32_t(mcMicroBuffer* mb, mrEndianness endianness, const uint32_t value);
+MCDLLAPI bool mc_serialize_endian_uint64_t(mcMicroBuffer* mb, mrEndianness endianness, const uint64_t value);
+MCDLLAPI bool mc_serialize_endian_int16_t(mcMicroBuffer* mb, mrEndianness endianness, const int16_t value);
+MCDLLAPI bool mc_serialize_endian_int32_t(mcMicroBuffer* mb, mrEndianness endianness, const int32_t value);
+MCDLLAPI bool mc_serialize_endian_int64_t(mcMicroBuffer* mb, mrEndianness endianness, const int64_t value);
+MCDLLAPI bool mc_serialize_endian_float(mcMicroBuffer* mb, mrEndianness endianness, const float value);
+MCDLLAPI bool mc_serialize_endian_double(mcMicroBuffer* mb, mrEndianness endianness, const double value);
 
-MCDLLAPI bool mc_deserialize_endian_uint16_t(mcMicroBuffer* mb, Endianness endianness, uint16_t* value);
-MCDLLAPI bool mc_deserialize_endian_uint32_t(mcMicroBuffer* mb, Endianness endianness, uint32_t *value);
-MCDLLAPI bool mc_deserialize_endian_uint64_t(mcMicroBuffer* mb, Endianness endianness, uint64_t* value);
-MCDLLAPI bool mc_deserialize_endian_int16_t(mcMicroBuffer* mb, Endianness endianness, int16_t* value);
-MCDLLAPI bool mc_deserialize_endian_int32_t(mcMicroBuffer* mb, Endianness endianness, int32_t* value);
-MCDLLAPI bool mc_deserialize_endian_int64_t(mcMicroBuffer* mb, Endianness endianness, int64_t* value);
-MCDLLAPI bool mc_deserialize_endian_float(mcMicroBuffer* mb, Endianness endianness, float* value);
-MCDLLAPI bool mc_deserialize_endian_double(mcMicroBuffer* mb, Endianness endianness, double* value);
+MCDLLAPI bool mc_deserialize_endian_uint16_t(mcMicroBuffer* mb, mrEndianness endianness, uint16_t* value);
+MCDLLAPI bool mc_deserialize_endian_uint32_t(mcMicroBuffer* mb, mrEndianness endianness, uint32_t *value);
+MCDLLAPI bool mc_deserialize_endian_uint64_t(mcMicroBuffer* mb, mrEndianness endianness, uint64_t* value);
+MCDLLAPI bool mc_deserialize_endian_int16_t(mcMicroBuffer* mb, mrEndianness endianness, int16_t* value);
+MCDLLAPI bool mc_deserialize_endian_int32_t(mcMicroBuffer* mb, mrEndianness endianness, int32_t* value);
+MCDLLAPI bool mc_deserialize_endian_int64_t(mcMicroBuffer* mb, mrEndianness endianness, int64_t* value);
+MCDLLAPI bool mc_deserialize_endian_float(mcMicroBuffer* mb, mrEndianness endianness, float* value);
+MCDLLAPI bool mc_deserialize_endian_double(mcMicroBuffer* mb, mrEndianness endianness, double* value);
 
 #ifdef __cplusplus
 }

--- a/include/microcdr/types/basic.h
+++ b/include/microcdr/types/basic.h
@@ -38,18 +38,18 @@ MCDLLAPI bool serialize_int64_t(mcMicroBuffer* mb, const int64_t value);
 MCDLLAPI bool serialize_float(mcMicroBuffer* mb, const float value);
 MCDLLAPI bool serialize_double(mcMicroBuffer* mb, const double value);
 
-MCDLLAPI bool deserialize_char(mcMicroBuffer* mb, char* value);
-MCDLLAPI bool deserialize_bool(mcMicroBuffer* mb, bool* value);
-MCDLLAPI bool deserialize_uint8_t(mcMicroBuffer* mb, uint8_t* value);
-MCDLLAPI bool deserialize_uint16_t(mcMicroBuffer* mb, uint16_t* value);
-MCDLLAPI bool deserialize_uint32_t(mcMicroBuffer* mb, uint32_t* value);
-MCDLLAPI bool deserialize_uint64_t(mcMicroBuffer* mb, uint64_t* value);
-MCDLLAPI bool deserialize_int8_t(mcMicroBuffer* mb, int8_t* value);
-MCDLLAPI bool deserialize_int16_t(mcMicroBuffer* mb, int16_t* value);
-MCDLLAPI bool deserialize_int32_t(mcMicroBuffer* mb, int32_t* value);
-MCDLLAPI bool deserialize_int64_t(mcMicroBuffer* mb, int64_t* value);
-MCDLLAPI bool deserialize_float(mcMicroBuffer* mb, float* value);
-MCDLLAPI bool deserialize_double(mcMicroBuffer* mb, double* value);
+MCDLLAPI bool mc_deserialize_char(mcMicroBuffer* mb, char* value);
+MCDLLAPI bool mc_deserialize_bool(mcMicroBuffer* mb, bool* value);
+MCDLLAPI bool mc_deserialize_uint8_t(mcMicroBuffer* mb, uint8_t* value);
+MCDLLAPI bool mc_deserialize_uint16_t(mcMicroBuffer* mb, uint16_t* value);
+MCDLLAPI bool mc_deserialize_uint32_t(mcMicroBuffer* mb, uint32_t* value);
+MCDLLAPI bool mc_deserialize_uint64_t(mcMicroBuffer* mb, uint64_t* value);
+MCDLLAPI bool mc_deserialize_int8_t(mcMicroBuffer* mb, int8_t* value);
+MCDLLAPI bool mc_deserialize_int16_t(mcMicroBuffer* mb, int16_t* value);
+MCDLLAPI bool mc_deserialize_int32_t(mcMicroBuffer* mb, int32_t* value);
+MCDLLAPI bool mc_deserialize_int64_t(mcMicroBuffer* mb, int64_t* value);
+MCDLLAPI bool mc_deserialize_float(mcMicroBuffer* mb, float* value);
+MCDLLAPI bool mc_deserialize_double(mcMicroBuffer* mb, double* value);
 
 MCDLLAPI bool serialize_endian_uint16_t(mcMicroBuffer* mb, Endianness endianness, const uint16_t value);
 MCDLLAPI bool serialize_endian_uint32_t(mcMicroBuffer* mb, Endianness endianness, const uint32_t value);
@@ -60,14 +60,14 @@ MCDLLAPI bool serialize_endian_int64_t(mcMicroBuffer* mb, Endianness endianness,
 MCDLLAPI bool serialize_endian_float(mcMicroBuffer* mb, Endianness endianness, const float value);
 MCDLLAPI bool serialize_endian_double(mcMicroBuffer* mb, Endianness endianness, const double value);
 
-MCDLLAPI bool deserialize_endian_uint16_t(mcMicroBuffer* mb, Endianness endianness, uint16_t* value);
-MCDLLAPI bool deserialize_endian_uint32_t(mcMicroBuffer* mb, Endianness endianness, uint32_t *value);
-MCDLLAPI bool deserialize_endian_uint64_t(mcMicroBuffer* mb, Endianness endianness, uint64_t* value);
-MCDLLAPI bool deserialize_endian_int16_t(mcMicroBuffer* mb, Endianness endianness, int16_t* value);
-MCDLLAPI bool deserialize_endian_int32_t(mcMicroBuffer* mb, Endianness endianness, int32_t* value);
-MCDLLAPI bool deserialize_endian_int64_t(mcMicroBuffer* mb, Endianness endianness, int64_t* value);
-MCDLLAPI bool deserialize_endian_float(mcMicroBuffer* mb, Endianness endianness, float* value);
-MCDLLAPI bool deserialize_endian_double(mcMicroBuffer* mb, Endianness endianness, double* value);
+MCDLLAPI bool mc_deserialize_endian_uint16_t(mcMicroBuffer* mb, Endianness endianness, uint16_t* value);
+MCDLLAPI bool mc_deserialize_endian_uint32_t(mcMicroBuffer* mb, Endianness endianness, uint32_t *value);
+MCDLLAPI bool mc_deserialize_endian_uint64_t(mcMicroBuffer* mb, Endianness endianness, uint64_t* value);
+MCDLLAPI bool mc_deserialize_endian_int16_t(mcMicroBuffer* mb, Endianness endianness, int16_t* value);
+MCDLLAPI bool mc_deserialize_endian_int32_t(mcMicroBuffer* mb, Endianness endianness, int32_t* value);
+MCDLLAPI bool mc_deserialize_endian_int64_t(mcMicroBuffer* mb, Endianness endianness, int64_t* value);
+MCDLLAPI bool mc_deserialize_endian_float(mcMicroBuffer* mb, Endianness endianness, float* value);
+MCDLLAPI bool mc_deserialize_endian_double(mcMicroBuffer* mb, Endianness endianness, double* value);
 
 #ifdef __cplusplus
 }

--- a/include/microcdr/types/sequence.h
+++ b/include/microcdr/types/sequence.h
@@ -51,31 +51,31 @@ MCDLLAPI bool mc_deserialize_sequence_int64_t(mcBuffer* mb, int64_t* array, cons
 MCDLLAPI bool mc_deserialize_sequence_float(mcBuffer* mb, float* array, const uint32_t array_capacity, uint32_t* size);
 MCDLLAPI bool mc_deserialize_sequence_double(mcBuffer* mb, double* array, const uint32_t array_capacity, uint32_t* size);
 
-MCDLLAPI bool mc_serialize_endian_sequence_char(mcBuffer* mb, mrEndianness endianness, const char* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_bool(mcBuffer* mb, mrEndianness endianness, const bool* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_uint8_t(mcBuffer* mb, mrEndianness endianness, const uint8_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_uint16_t(mcBuffer* mb, mrEndianness endianness, const uint16_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_uint32_t(mcBuffer* mb, mrEndianness endianness, const uint32_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_uint64_t(mcBuffer* mb, mrEndianness endianness, const uint64_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_int8_t(mcBuffer* mb, mrEndianness endianness, const int8_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_int16_t(mcBuffer* mb, mrEndianness endianness, const int16_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_int32_t(mcBuffer* mb, mrEndianness endianness, const int32_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_int64_t(mcBuffer* mb, mrEndianness endianness, const int64_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_float(mcBuffer* mb, mrEndianness endianness, const float* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_double(mcBuffer* mb, mrEndianness endianness, const double* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_char(mcBuffer* mb, mcEndianness endianness, const char* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_bool(mcBuffer* mb, mcEndianness endianness, const bool* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_uint8_t(mcBuffer* mb, mcEndianness endianness, const uint8_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_uint16_t(mcBuffer* mb, mcEndianness endianness, const uint16_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_uint32_t(mcBuffer* mb, mcEndianness endianness, const uint32_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_uint64_t(mcBuffer* mb, mcEndianness endianness, const uint64_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_int8_t(mcBuffer* mb, mcEndianness endianness, const int8_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_int16_t(mcBuffer* mb, mcEndianness endianness, const int16_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_int32_t(mcBuffer* mb, mcEndianness endianness, const int32_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_int64_t(mcBuffer* mb, mcEndianness endianness, const int64_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_float(mcBuffer* mb, mcEndianness endianness, const float* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_double(mcBuffer* mb, mcEndianness endianness, const double* array, const uint32_t size);
 
-MCDLLAPI bool mc_deserialize_endian_sequence_char(mcBuffer* mb, mrEndianness endianness, char* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_bool(mcBuffer* mb, mrEndianness endianness, bool* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_uint8_t(mcBuffer* mb, mrEndianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_uint16_t(mcBuffer* mb, mrEndianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_uint32_t(mcBuffer* mb, mrEndianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_uint64_t(mcBuffer* mb, mrEndianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_int8_t(mcBuffer* mb, mrEndianness endianness, int8_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_int16_t(mcBuffer* mb, mrEndianness endianness, int16_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_int32_t(mcBuffer* mb, mrEndianness endianness, int32_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_int64_t(mcBuffer* mb, mrEndianness endianness, int64_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_float(mcBuffer* mb, mrEndianness endianness, float* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_double(mcBuffer* mb, mrEndianness endianness, double* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_char(mcBuffer* mb, mcEndianness endianness, char* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_bool(mcBuffer* mb, mcEndianness endianness, bool* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_uint8_t(mcBuffer* mb, mcEndianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_uint16_t(mcBuffer* mb, mcEndianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_uint32_t(mcBuffer* mb, mcEndianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_uint64_t(mcBuffer* mb, mcEndianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_int8_t(mcBuffer* mb, mcEndianness endianness, int8_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_int16_t(mcBuffer* mb, mcEndianness endianness, int16_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_int32_t(mcBuffer* mb, mcEndianness endianness, int32_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_int64_t(mcBuffer* mb, mcEndianness endianness, int64_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_float(mcBuffer* mb, mcEndianness endianness, float* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_double(mcBuffer* mb, mcEndianness endianness, double* array, const uint32_t array_capacity, uint32_t* size);
 
 #ifdef __cplusplus
 }

--- a/include/microcdr/types/sequence.h
+++ b/include/microcdr/types/sequence.h
@@ -25,57 +25,57 @@ extern "C" {
 //                   PUBLIC SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
 
-MCDLLAPI bool serialize_sequence_char(MicroBuffer* mb, const char* array, const uint32_t size);
-MCDLLAPI bool serialize_sequence_bool(MicroBuffer* mb, const bool* array, const uint32_t size);
-MCDLLAPI bool serialize_sequence_uint8_t(MicroBuffer* mb, const uint8_t* array, const uint32_t size);
-MCDLLAPI bool serialize_sequence_uint16_t(MicroBuffer* mb, const uint16_t* array, const uint32_t size);
-MCDLLAPI bool serialize_sequence_uint32_t(MicroBuffer* mb, const uint32_t* array, const uint32_t size);
-MCDLLAPI bool serialize_sequence_uint64_t(MicroBuffer* mb, const uint64_t* array, const uint32_t size);
-MCDLLAPI bool serialize_sequence_int8_t(MicroBuffer* mb, const int8_t* array, const uint32_t size);
-MCDLLAPI bool serialize_sequence_int16_t(MicroBuffer* mb, const int16_t* array, const uint32_t size);
-MCDLLAPI bool serialize_sequence_int32_t(MicroBuffer* mb, const int32_t* array, const uint32_t size);
-MCDLLAPI bool serialize_sequence_int64_t(MicroBuffer* mb, const int64_t* array, const uint32_t size);
-MCDLLAPI bool serialize_sequence_float(MicroBuffer* mb, const float* array, const uint32_t size);
-MCDLLAPI bool serialize_sequence_double(MicroBuffer* mb, const double* array, const uint32_t size);
+MCDLLAPI bool serialize_sequence_char(mcMicroBuffer* mb, const char* array, const uint32_t size);
+MCDLLAPI bool serialize_sequence_bool(mcMicroBuffer* mb, const bool* array, const uint32_t size);
+MCDLLAPI bool serialize_sequence_uint8_t(mcMicroBuffer* mb, const uint8_t* array, const uint32_t size);
+MCDLLAPI bool serialize_sequence_uint16_t(mcMicroBuffer* mb, const uint16_t* array, const uint32_t size);
+MCDLLAPI bool serialize_sequence_uint32_t(mcMicroBuffer* mb, const uint32_t* array, const uint32_t size);
+MCDLLAPI bool serialize_sequence_uint64_t(mcMicroBuffer* mb, const uint64_t* array, const uint32_t size);
+MCDLLAPI bool serialize_sequence_int8_t(mcMicroBuffer* mb, const int8_t* array, const uint32_t size);
+MCDLLAPI bool serialize_sequence_int16_t(mcMicroBuffer* mb, const int16_t* array, const uint32_t size);
+MCDLLAPI bool serialize_sequence_int32_t(mcMicroBuffer* mb, const int32_t* array, const uint32_t size);
+MCDLLAPI bool serialize_sequence_int64_t(mcMicroBuffer* mb, const int64_t* array, const uint32_t size);
+MCDLLAPI bool serialize_sequence_float(mcMicroBuffer* mb, const float* array, const uint32_t size);
+MCDLLAPI bool serialize_sequence_double(mcMicroBuffer* mb, const double* array, const uint32_t size);
 
-MCDLLAPI bool deserialize_sequence_char(MicroBuffer* mb, char* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_sequence_bool(MicroBuffer* mb, bool* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_sequence_uint8_t(MicroBuffer* mb, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_sequence_uint16_t(MicroBuffer* mb, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_sequence_uint32_t(MicroBuffer* mb, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_sequence_uint64_t(MicroBuffer* mb, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_sequence_int8_t(MicroBuffer* mb, int8_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_sequence_int16_t(MicroBuffer* mb, int16_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_sequence_int32_t(MicroBuffer* mb, int32_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_sequence_int64_t(MicroBuffer* mb, int64_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_sequence_float(MicroBuffer* mb, float* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_sequence_double(MicroBuffer* mb, double* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_sequence_char(mcMicroBuffer* mb, char* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_sequence_bool(mcMicroBuffer* mb, bool* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_sequence_uint8_t(mcMicroBuffer* mb, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_sequence_uint16_t(mcMicroBuffer* mb, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_sequence_uint32_t(mcMicroBuffer* mb, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_sequence_uint64_t(mcMicroBuffer* mb, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_sequence_int8_t(mcMicroBuffer* mb, int8_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_sequence_int16_t(mcMicroBuffer* mb, int16_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_sequence_int32_t(mcMicroBuffer* mb, int32_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_sequence_int64_t(mcMicroBuffer* mb, int64_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_sequence_float(mcMicroBuffer* mb, float* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_sequence_double(mcMicroBuffer* mb, double* array, const uint32_t array_capacity, uint32_t* size);
 
-MCDLLAPI bool serialize_endian_sequence_char(MicroBuffer* mb, Endianness endianness, const char* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_sequence_bool(MicroBuffer* mb, Endianness endianness, const bool* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_sequence_uint8_t(MicroBuffer* mb, Endianness endianness, const uint8_t* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_sequence_uint16_t(MicroBuffer* mb, Endianness endianness, const uint16_t* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_sequence_uint32_t(MicroBuffer* mb, Endianness endianness, const uint32_t* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_sequence_uint64_t(MicroBuffer* mb, Endianness endianness, const uint64_t* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_sequence_int8_t(MicroBuffer* mb, Endianness endianness, const int8_t* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_sequence_int16_t(MicroBuffer* mb, Endianness endianness, const int16_t* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_sequence_int32_t(MicroBuffer* mb, Endianness endianness, const int32_t* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_sequence_int64_t(MicroBuffer* mb, Endianness endianness, const int64_t* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_sequence_float(MicroBuffer* mb, Endianness endianness, const float* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_sequence_double(MicroBuffer* mb, Endianness endianness, const double* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_sequence_char(mcMicroBuffer* mb, Endianness endianness, const char* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_sequence_bool(mcMicroBuffer* mb, Endianness endianness, const bool* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_sequence_uint8_t(mcMicroBuffer* mb, Endianness endianness, const uint8_t* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_sequence_uint16_t(mcMicroBuffer* mb, Endianness endianness, const uint16_t* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_sequence_uint32_t(mcMicroBuffer* mb, Endianness endianness, const uint32_t* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_sequence_uint64_t(mcMicroBuffer* mb, Endianness endianness, const uint64_t* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_sequence_int8_t(mcMicroBuffer* mb, Endianness endianness, const int8_t* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_sequence_int16_t(mcMicroBuffer* mb, Endianness endianness, const int16_t* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_sequence_int32_t(mcMicroBuffer* mb, Endianness endianness, const int32_t* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_sequence_int64_t(mcMicroBuffer* mb, Endianness endianness, const int64_t* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_sequence_float(mcMicroBuffer* mb, Endianness endianness, const float* array, const uint32_t size);
+MCDLLAPI bool serialize_endian_sequence_double(mcMicroBuffer* mb, Endianness endianness, const double* array, const uint32_t size);
 
-MCDLLAPI bool deserialize_endian_sequence_char(MicroBuffer* mb, Endianness endianness, char* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_endian_sequence_bool(MicroBuffer* mb, Endianness endianness, bool* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_endian_sequence_uint8_t(MicroBuffer* mb, Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_endian_sequence_uint16_t(MicroBuffer* mb, Endianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_endian_sequence_uint32_t(MicroBuffer* mb, Endianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_endian_sequence_uint64_t(MicroBuffer* mb, Endianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_endian_sequence_int8_t(MicroBuffer* mb, Endianness endianness, int8_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_endian_sequence_int16_t(MicroBuffer* mb, Endianness endianness, int16_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_endian_sequence_int32_t(MicroBuffer* mb, Endianness endianness, int32_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_endian_sequence_int64_t(MicroBuffer* mb, Endianness endianness, int64_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_endian_sequence_float(MicroBuffer* mb, Endianness endianness, float* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_endian_sequence_double(MicroBuffer* mb, Endianness endianness, double* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_endian_sequence_char(mcMicroBuffer* mb, Endianness endianness, char* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_endian_sequence_bool(mcMicroBuffer* mb, Endianness endianness, bool* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_endian_sequence_uint8_t(mcMicroBuffer* mb, Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_endian_sequence_uint16_t(mcMicroBuffer* mb, Endianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_endian_sequence_uint32_t(mcMicroBuffer* mb, Endianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_endian_sequence_uint64_t(mcMicroBuffer* mb, Endianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_endian_sequence_int8_t(mcMicroBuffer* mb, Endianness endianness, int8_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_endian_sequence_int16_t(mcMicroBuffer* mb, Endianness endianness, int16_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_endian_sequence_int32_t(mcMicroBuffer* mb, Endianness endianness, int32_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_endian_sequence_int64_t(mcMicroBuffer* mb, Endianness endianness, int64_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_endian_sequence_float(mcMicroBuffer* mb, Endianness endianness, float* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool deserialize_endian_sequence_double(mcMicroBuffer* mb, Endianness endianness, double* array, const uint32_t array_capacity, uint32_t* size);
 
 #ifdef __cplusplus
 }

--- a/include/microcdr/types/sequence.h
+++ b/include/microcdr/types/sequence.h
@@ -51,31 +51,31 @@ MCDLLAPI bool mc_deserialize_sequence_int64_t(mcMicroBuffer* mb, int64_t* array,
 MCDLLAPI bool mc_deserialize_sequence_float(mcMicroBuffer* mb, float* array, const uint32_t array_capacity, uint32_t* size);
 MCDLLAPI bool mc_deserialize_sequence_double(mcMicroBuffer* mb, double* array, const uint32_t array_capacity, uint32_t* size);
 
-MCDLLAPI bool mc_serialize_endian_sequence_char(mcMicroBuffer* mb, Endianness endianness, const char* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_bool(mcMicroBuffer* mb, Endianness endianness, const bool* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_uint8_t(mcMicroBuffer* mb, Endianness endianness, const uint8_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_uint16_t(mcMicroBuffer* mb, Endianness endianness, const uint16_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_uint32_t(mcMicroBuffer* mb, Endianness endianness, const uint32_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_uint64_t(mcMicroBuffer* mb, Endianness endianness, const uint64_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_int8_t(mcMicroBuffer* mb, Endianness endianness, const int8_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_int16_t(mcMicroBuffer* mb, Endianness endianness, const int16_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_int32_t(mcMicroBuffer* mb, Endianness endianness, const int32_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_int64_t(mcMicroBuffer* mb, Endianness endianness, const int64_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_float(mcMicroBuffer* mb, Endianness endianness, const float* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_double(mcMicroBuffer* mb, Endianness endianness, const double* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_char(mcMicroBuffer* mb, mrEndianness endianness, const char* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_bool(mcMicroBuffer* mb, mrEndianness endianness, const bool* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_uint8_t(mcMicroBuffer* mb, mrEndianness endianness, const uint8_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_uint16_t(mcMicroBuffer* mb, mrEndianness endianness, const uint16_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_uint32_t(mcMicroBuffer* mb, mrEndianness endianness, const uint32_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_uint64_t(mcMicroBuffer* mb, mrEndianness endianness, const uint64_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_int8_t(mcMicroBuffer* mb, mrEndianness endianness, const int8_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_int16_t(mcMicroBuffer* mb, mrEndianness endianness, const int16_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_int32_t(mcMicroBuffer* mb, mrEndianness endianness, const int32_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_int64_t(mcMicroBuffer* mb, mrEndianness endianness, const int64_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_float(mcMicroBuffer* mb, mrEndianness endianness, const float* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_double(mcMicroBuffer* mb, mrEndianness endianness, const double* array, const uint32_t size);
 
-MCDLLAPI bool mc_deserialize_endian_sequence_char(mcMicroBuffer* mb, Endianness endianness, char* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_bool(mcMicroBuffer* mb, Endianness endianness, bool* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_uint8_t(mcMicroBuffer* mb, Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_uint16_t(mcMicroBuffer* mb, Endianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_uint32_t(mcMicroBuffer* mb, Endianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_uint64_t(mcMicroBuffer* mb, Endianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_int8_t(mcMicroBuffer* mb, Endianness endianness, int8_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_int16_t(mcMicroBuffer* mb, Endianness endianness, int16_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_int32_t(mcMicroBuffer* mb, Endianness endianness, int32_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_int64_t(mcMicroBuffer* mb, Endianness endianness, int64_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_float(mcMicroBuffer* mb, Endianness endianness, float* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_double(mcMicroBuffer* mb, Endianness endianness, double* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_char(mcMicroBuffer* mb, mrEndianness endianness, char* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_bool(mcMicroBuffer* mb, mrEndianness endianness, bool* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_uint8_t(mcMicroBuffer* mb, mrEndianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_uint16_t(mcMicroBuffer* mb, mrEndianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_uint32_t(mcMicroBuffer* mb, mrEndianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_uint64_t(mcMicroBuffer* mb, mrEndianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_int8_t(mcMicroBuffer* mb, mrEndianness endianness, int8_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_int16_t(mcMicroBuffer* mb, mrEndianness endianness, int16_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_int32_t(mcMicroBuffer* mb, mrEndianness endianness, int32_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_int64_t(mcMicroBuffer* mb, mrEndianness endianness, int64_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_float(mcMicroBuffer* mb, mrEndianness endianness, float* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_double(mcMicroBuffer* mb, mrEndianness endianness, double* array, const uint32_t array_capacity, uint32_t* size);
 
 #ifdef __cplusplus
 }

--- a/include/microcdr/types/sequence.h
+++ b/include/microcdr/types/sequence.h
@@ -38,18 +38,18 @@ MCDLLAPI bool serialize_sequence_int64_t(mcMicroBuffer* mb, const int64_t* array
 MCDLLAPI bool serialize_sequence_float(mcMicroBuffer* mb, const float* array, const uint32_t size);
 MCDLLAPI bool serialize_sequence_double(mcMicroBuffer* mb, const double* array, const uint32_t size);
 
-MCDLLAPI bool deserialize_sequence_char(mcMicroBuffer* mb, char* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_sequence_bool(mcMicroBuffer* mb, bool* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_sequence_uint8_t(mcMicroBuffer* mb, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_sequence_uint16_t(mcMicroBuffer* mb, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_sequence_uint32_t(mcMicroBuffer* mb, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_sequence_uint64_t(mcMicroBuffer* mb, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_sequence_int8_t(mcMicroBuffer* mb, int8_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_sequence_int16_t(mcMicroBuffer* mb, int16_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_sequence_int32_t(mcMicroBuffer* mb, int32_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_sequence_int64_t(mcMicroBuffer* mb, int64_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_sequence_float(mcMicroBuffer* mb, float* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_sequence_double(mcMicroBuffer* mb, double* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_sequence_char(mcMicroBuffer* mb, char* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_sequence_bool(mcMicroBuffer* mb, bool* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_sequence_uint8_t(mcMicroBuffer* mb, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_sequence_uint16_t(mcMicroBuffer* mb, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_sequence_uint32_t(mcMicroBuffer* mb, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_sequence_uint64_t(mcMicroBuffer* mb, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_sequence_int8_t(mcMicroBuffer* mb, int8_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_sequence_int16_t(mcMicroBuffer* mb, int16_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_sequence_int32_t(mcMicroBuffer* mb, int32_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_sequence_int64_t(mcMicroBuffer* mb, int64_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_sequence_float(mcMicroBuffer* mb, float* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_sequence_double(mcMicroBuffer* mb, double* array, const uint32_t array_capacity, uint32_t* size);
 
 MCDLLAPI bool serialize_endian_sequence_char(mcMicroBuffer* mb, Endianness endianness, const char* array, const uint32_t size);
 MCDLLAPI bool serialize_endian_sequence_bool(mcMicroBuffer* mb, Endianness endianness, const bool* array, const uint32_t size);
@@ -64,18 +64,18 @@ MCDLLAPI bool serialize_endian_sequence_int64_t(mcMicroBuffer* mb, Endianness en
 MCDLLAPI bool serialize_endian_sequence_float(mcMicroBuffer* mb, Endianness endianness, const float* array, const uint32_t size);
 MCDLLAPI bool serialize_endian_sequence_double(mcMicroBuffer* mb, Endianness endianness, const double* array, const uint32_t size);
 
-MCDLLAPI bool deserialize_endian_sequence_char(mcMicroBuffer* mb, Endianness endianness, char* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_endian_sequence_bool(mcMicroBuffer* mb, Endianness endianness, bool* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_endian_sequence_uint8_t(mcMicroBuffer* mb, Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_endian_sequence_uint16_t(mcMicroBuffer* mb, Endianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_endian_sequence_uint32_t(mcMicroBuffer* mb, Endianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_endian_sequence_uint64_t(mcMicroBuffer* mb, Endianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_endian_sequence_int8_t(mcMicroBuffer* mb, Endianness endianness, int8_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_endian_sequence_int16_t(mcMicroBuffer* mb, Endianness endianness, int16_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_endian_sequence_int32_t(mcMicroBuffer* mb, Endianness endianness, int32_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_endian_sequence_int64_t(mcMicroBuffer* mb, Endianness endianness, int64_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_endian_sequence_float(mcMicroBuffer* mb, Endianness endianness, float* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool deserialize_endian_sequence_double(mcMicroBuffer* mb, Endianness endianness, double* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_char(mcMicroBuffer* mb, Endianness endianness, char* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_bool(mcMicroBuffer* mb, Endianness endianness, bool* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_uint8_t(mcMicroBuffer* mb, Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_uint16_t(mcMicroBuffer* mb, Endianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_uint32_t(mcMicroBuffer* mb, Endianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_uint64_t(mcMicroBuffer* mb, Endianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_int8_t(mcMicroBuffer* mb, Endianness endianness, int8_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_int16_t(mcMicroBuffer* mb, Endianness endianness, int16_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_int32_t(mcMicroBuffer* mb, Endianness endianness, int32_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_int64_t(mcMicroBuffer* mb, Endianness endianness, int64_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_float(mcMicroBuffer* mb, Endianness endianness, float* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_double(mcMicroBuffer* mb, Endianness endianness, double* array, const uint32_t array_capacity, uint32_t* size);
 
 #ifdef __cplusplus
 }

--- a/include/microcdr/types/sequence.h
+++ b/include/microcdr/types/sequence.h
@@ -25,57 +25,57 @@ extern "C" {
 //                   PUBLIC SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
 
-MCDLLAPI bool mc_serialize_sequence_char(mcMicroBuffer* mb, const char* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_sequence_bool(mcMicroBuffer* mb, const bool* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_sequence_uint8_t(mcMicroBuffer* mb, const uint8_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_sequence_uint16_t(mcMicroBuffer* mb, const uint16_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_sequence_uint32_t(mcMicroBuffer* mb, const uint32_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_sequence_uint64_t(mcMicroBuffer* mb, const uint64_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_sequence_int8_t(mcMicroBuffer* mb, const int8_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_sequence_int16_t(mcMicroBuffer* mb, const int16_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_sequence_int32_t(mcMicroBuffer* mb, const int32_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_sequence_int64_t(mcMicroBuffer* mb, const int64_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_sequence_float(mcMicroBuffer* mb, const float* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_sequence_double(mcMicroBuffer* mb, const double* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_sequence_char(mcBuffer* mb, const char* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_sequence_bool(mcBuffer* mb, const bool* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_sequence_uint8_t(mcBuffer* mb, const uint8_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_sequence_uint16_t(mcBuffer* mb, const uint16_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_sequence_uint32_t(mcBuffer* mb, const uint32_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_sequence_uint64_t(mcBuffer* mb, const uint64_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_sequence_int8_t(mcBuffer* mb, const int8_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_sequence_int16_t(mcBuffer* mb, const int16_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_sequence_int32_t(mcBuffer* mb, const int32_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_sequence_int64_t(mcBuffer* mb, const int64_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_sequence_float(mcBuffer* mb, const float* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_sequence_double(mcBuffer* mb, const double* array, const uint32_t size);
 
-MCDLLAPI bool mc_deserialize_sequence_char(mcMicroBuffer* mb, char* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_sequence_bool(mcMicroBuffer* mb, bool* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_sequence_uint8_t(mcMicroBuffer* mb, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_sequence_uint16_t(mcMicroBuffer* mb, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_sequence_uint32_t(mcMicroBuffer* mb, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_sequence_uint64_t(mcMicroBuffer* mb, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_sequence_int8_t(mcMicroBuffer* mb, int8_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_sequence_int16_t(mcMicroBuffer* mb, int16_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_sequence_int32_t(mcMicroBuffer* mb, int32_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_sequence_int64_t(mcMicroBuffer* mb, int64_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_sequence_float(mcMicroBuffer* mb, float* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_sequence_double(mcMicroBuffer* mb, double* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_sequence_char(mcBuffer* mb, char* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_sequence_bool(mcBuffer* mb, bool* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_sequence_uint8_t(mcBuffer* mb, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_sequence_uint16_t(mcBuffer* mb, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_sequence_uint32_t(mcBuffer* mb, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_sequence_uint64_t(mcBuffer* mb, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_sequence_int8_t(mcBuffer* mb, int8_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_sequence_int16_t(mcBuffer* mb, int16_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_sequence_int32_t(mcBuffer* mb, int32_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_sequence_int64_t(mcBuffer* mb, int64_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_sequence_float(mcBuffer* mb, float* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_sequence_double(mcBuffer* mb, double* array, const uint32_t array_capacity, uint32_t* size);
 
-MCDLLAPI bool mc_serialize_endian_sequence_char(mcMicroBuffer* mb, mrEndianness endianness, const char* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_bool(mcMicroBuffer* mb, mrEndianness endianness, const bool* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_uint8_t(mcMicroBuffer* mb, mrEndianness endianness, const uint8_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_uint16_t(mcMicroBuffer* mb, mrEndianness endianness, const uint16_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_uint32_t(mcMicroBuffer* mb, mrEndianness endianness, const uint32_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_uint64_t(mcMicroBuffer* mb, mrEndianness endianness, const uint64_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_int8_t(mcMicroBuffer* mb, mrEndianness endianness, const int8_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_int16_t(mcMicroBuffer* mb, mrEndianness endianness, const int16_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_int32_t(mcMicroBuffer* mb, mrEndianness endianness, const int32_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_int64_t(mcMicroBuffer* mb, mrEndianness endianness, const int64_t* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_float(mcMicroBuffer* mb, mrEndianness endianness, const float* array, const uint32_t size);
-MCDLLAPI bool mc_serialize_endian_sequence_double(mcMicroBuffer* mb, mrEndianness endianness, const double* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_char(mcBuffer* mb, mrEndianness endianness, const char* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_bool(mcBuffer* mb, mrEndianness endianness, const bool* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_uint8_t(mcBuffer* mb, mrEndianness endianness, const uint8_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_uint16_t(mcBuffer* mb, mrEndianness endianness, const uint16_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_uint32_t(mcBuffer* mb, mrEndianness endianness, const uint32_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_uint64_t(mcBuffer* mb, mrEndianness endianness, const uint64_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_int8_t(mcBuffer* mb, mrEndianness endianness, const int8_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_int16_t(mcBuffer* mb, mrEndianness endianness, const int16_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_int32_t(mcBuffer* mb, mrEndianness endianness, const int32_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_int64_t(mcBuffer* mb, mrEndianness endianness, const int64_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_float(mcBuffer* mb, mrEndianness endianness, const float* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_double(mcBuffer* mb, mrEndianness endianness, const double* array, const uint32_t size);
 
-MCDLLAPI bool mc_deserialize_endian_sequence_char(mcMicroBuffer* mb, mrEndianness endianness, char* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_bool(mcMicroBuffer* mb, mrEndianness endianness, bool* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_uint8_t(mcMicroBuffer* mb, mrEndianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_uint16_t(mcMicroBuffer* mb, mrEndianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_uint32_t(mcMicroBuffer* mb, mrEndianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_uint64_t(mcMicroBuffer* mb, mrEndianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_int8_t(mcMicroBuffer* mb, mrEndianness endianness, int8_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_int16_t(mcMicroBuffer* mb, mrEndianness endianness, int16_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_int32_t(mcMicroBuffer* mb, mrEndianness endianness, int32_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_int64_t(mcMicroBuffer* mb, mrEndianness endianness, int64_t* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_float(mcMicroBuffer* mb, mrEndianness endianness, float* array, const uint32_t array_capacity, uint32_t* size);
-MCDLLAPI bool mc_deserialize_endian_sequence_double(mcMicroBuffer* mb, mrEndianness endianness, double* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_char(mcBuffer* mb, mrEndianness endianness, char* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_bool(mcBuffer* mb, mrEndianness endianness, bool* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_uint8_t(mcBuffer* mb, mrEndianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_uint16_t(mcBuffer* mb, mrEndianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_uint32_t(mcBuffer* mb, mrEndianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_uint64_t(mcBuffer* mb, mrEndianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_int8_t(mcBuffer* mb, mrEndianness endianness, int8_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_int16_t(mcBuffer* mb, mrEndianness endianness, int16_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_int32_t(mcBuffer* mb, mrEndianness endianness, int32_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_int64_t(mcBuffer* mb, mrEndianness endianness, int64_t* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_float(mcBuffer* mb, mrEndianness endianness, float* array, const uint32_t array_capacity, uint32_t* size);
+MCDLLAPI bool mc_deserialize_endian_sequence_double(mcBuffer* mb, mrEndianness endianness, double* array, const uint32_t array_capacity, uint32_t* size);
 
 #ifdef __cplusplus
 }

--- a/include/microcdr/types/sequence.h
+++ b/include/microcdr/types/sequence.h
@@ -25,18 +25,18 @@ extern "C" {
 //                   PUBLIC SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
 
-MCDLLAPI bool serialize_sequence_char(mcMicroBuffer* mb, const char* array, const uint32_t size);
-MCDLLAPI bool serialize_sequence_bool(mcMicroBuffer* mb, const bool* array, const uint32_t size);
-MCDLLAPI bool serialize_sequence_uint8_t(mcMicroBuffer* mb, const uint8_t* array, const uint32_t size);
-MCDLLAPI bool serialize_sequence_uint16_t(mcMicroBuffer* mb, const uint16_t* array, const uint32_t size);
-MCDLLAPI bool serialize_sequence_uint32_t(mcMicroBuffer* mb, const uint32_t* array, const uint32_t size);
-MCDLLAPI bool serialize_sequence_uint64_t(mcMicroBuffer* mb, const uint64_t* array, const uint32_t size);
-MCDLLAPI bool serialize_sequence_int8_t(mcMicroBuffer* mb, const int8_t* array, const uint32_t size);
-MCDLLAPI bool serialize_sequence_int16_t(mcMicroBuffer* mb, const int16_t* array, const uint32_t size);
-MCDLLAPI bool serialize_sequence_int32_t(mcMicroBuffer* mb, const int32_t* array, const uint32_t size);
-MCDLLAPI bool serialize_sequence_int64_t(mcMicroBuffer* mb, const int64_t* array, const uint32_t size);
-MCDLLAPI bool serialize_sequence_float(mcMicroBuffer* mb, const float* array, const uint32_t size);
-MCDLLAPI bool serialize_sequence_double(mcMicroBuffer* mb, const double* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_sequence_char(mcMicroBuffer* mb, const char* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_sequence_bool(mcMicroBuffer* mb, const bool* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_sequence_uint8_t(mcMicroBuffer* mb, const uint8_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_sequence_uint16_t(mcMicroBuffer* mb, const uint16_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_sequence_uint32_t(mcMicroBuffer* mb, const uint32_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_sequence_uint64_t(mcMicroBuffer* mb, const uint64_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_sequence_int8_t(mcMicroBuffer* mb, const int8_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_sequence_int16_t(mcMicroBuffer* mb, const int16_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_sequence_int32_t(mcMicroBuffer* mb, const int32_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_sequence_int64_t(mcMicroBuffer* mb, const int64_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_sequence_float(mcMicroBuffer* mb, const float* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_sequence_double(mcMicroBuffer* mb, const double* array, const uint32_t size);
 
 MCDLLAPI bool mc_deserialize_sequence_char(mcMicroBuffer* mb, char* array, const uint32_t array_capacity, uint32_t* size);
 MCDLLAPI bool mc_deserialize_sequence_bool(mcMicroBuffer* mb, bool* array, const uint32_t array_capacity, uint32_t* size);
@@ -51,18 +51,18 @@ MCDLLAPI bool mc_deserialize_sequence_int64_t(mcMicroBuffer* mb, int64_t* array,
 MCDLLAPI bool mc_deserialize_sequence_float(mcMicroBuffer* mb, float* array, const uint32_t array_capacity, uint32_t* size);
 MCDLLAPI bool mc_deserialize_sequence_double(mcMicroBuffer* mb, double* array, const uint32_t array_capacity, uint32_t* size);
 
-MCDLLAPI bool serialize_endian_sequence_char(mcMicroBuffer* mb, Endianness endianness, const char* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_sequence_bool(mcMicroBuffer* mb, Endianness endianness, const bool* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_sequence_uint8_t(mcMicroBuffer* mb, Endianness endianness, const uint8_t* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_sequence_uint16_t(mcMicroBuffer* mb, Endianness endianness, const uint16_t* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_sequence_uint32_t(mcMicroBuffer* mb, Endianness endianness, const uint32_t* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_sequence_uint64_t(mcMicroBuffer* mb, Endianness endianness, const uint64_t* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_sequence_int8_t(mcMicroBuffer* mb, Endianness endianness, const int8_t* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_sequence_int16_t(mcMicroBuffer* mb, Endianness endianness, const int16_t* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_sequence_int32_t(mcMicroBuffer* mb, Endianness endianness, const int32_t* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_sequence_int64_t(mcMicroBuffer* mb, Endianness endianness, const int64_t* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_sequence_float(mcMicroBuffer* mb, Endianness endianness, const float* array, const uint32_t size);
-MCDLLAPI bool serialize_endian_sequence_double(mcMicroBuffer* mb, Endianness endianness, const double* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_char(mcMicroBuffer* mb, Endianness endianness, const char* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_bool(mcMicroBuffer* mb, Endianness endianness, const bool* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_uint8_t(mcMicroBuffer* mb, Endianness endianness, const uint8_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_uint16_t(mcMicroBuffer* mb, Endianness endianness, const uint16_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_uint32_t(mcMicroBuffer* mb, Endianness endianness, const uint32_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_uint64_t(mcMicroBuffer* mb, Endianness endianness, const uint64_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_int8_t(mcMicroBuffer* mb, Endianness endianness, const int8_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_int16_t(mcMicroBuffer* mb, Endianness endianness, const int16_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_int32_t(mcMicroBuffer* mb, Endianness endianness, const int32_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_int64_t(mcMicroBuffer* mb, Endianness endianness, const int64_t* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_float(mcMicroBuffer* mb, Endianness endianness, const float* array, const uint32_t size);
+MCDLLAPI bool mc_serialize_endian_sequence_double(mcMicroBuffer* mb, Endianness endianness, const double* array, const uint32_t size);
 
 MCDLLAPI bool mc_deserialize_endian_sequence_char(mcMicroBuffer* mb, Endianness endianness, char* array, const uint32_t array_capacity, uint32_t* size);
 MCDLLAPI bool mc_deserialize_endian_sequence_bool(mcMicroBuffer* mb, Endianness endianness, bool* array, const uint32_t array_capacity, uint32_t* size);

--- a/include/microcdr/types/string.h
+++ b/include/microcdr/types/string.h
@@ -31,8 +31,8 @@ extern "C" {
 MCDLLAPI bool mc_serialize_string(mcMicroBuffer* mb, const char* string);
 MCDLLAPI bool mc_deserialize_string(mcMicroBuffer* mb, char* string, const uint32_t string_capacity);
 
-MCDLLAPI bool mc_serialize_endian_string(mcMicroBuffer* mb, Endianness endianness, const char* string);
-MCDLLAPI bool mc_deserialize_endian_string(mcMicroBuffer* mb, Endianness endianness, char* string, const uint32_t string_capacity);
+MCDLLAPI bool mc_serialize_endian_string(mcMicroBuffer* mb, mrEndianness endianness, const char* string);
+MCDLLAPI bool mc_deserialize_endian_string(mcMicroBuffer* mb, mrEndianness endianness, char* string, const uint32_t string_capacity);
 
 #ifdef __cplusplus
 }

--- a/include/microcdr/types/string.h
+++ b/include/microcdr/types/string.h
@@ -28,10 +28,10 @@ extern "C" {
 //                   PUBLIC SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
 
-MCDLLAPI bool serialize_string(mcMicroBuffer* mb, const char* string);
+MCDLLAPI bool mc_serialize_string(mcMicroBuffer* mb, const char* string);
 MCDLLAPI bool mc_deserialize_string(mcMicroBuffer* mb, char* string, const uint32_t string_capacity);
 
-MCDLLAPI bool serialize_endian_string(mcMicroBuffer* mb, Endianness endianness, const char* string);
+MCDLLAPI bool mc_serialize_endian_string(mcMicroBuffer* mb, Endianness endianness, const char* string);
 MCDLLAPI bool mc_deserialize_endian_string(mcMicroBuffer* mb, Endianness endianness, char* string, const uint32_t string_capacity);
 
 #ifdef __cplusplus

--- a/include/microcdr/types/string.h
+++ b/include/microcdr/types/string.h
@@ -28,11 +28,11 @@ extern "C" {
 //                   PUBLIC SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
 
-MCDLLAPI bool mc_serialize_string(mcMicroBuffer* mb, const char* string);
-MCDLLAPI bool mc_deserialize_string(mcMicroBuffer* mb, char* string, const uint32_t string_capacity);
+MCDLLAPI bool mc_serialize_string(mcBuffer* mb, const char* string);
+MCDLLAPI bool mc_deserialize_string(mcBuffer* mb, char* string, const uint32_t string_capacity);
 
-MCDLLAPI bool mc_serialize_endian_string(mcMicroBuffer* mb, mrEndianness endianness, const char* string);
-MCDLLAPI bool mc_deserialize_endian_string(mcMicroBuffer* mb, mrEndianness endianness, char* string, const uint32_t string_capacity);
+MCDLLAPI bool mc_serialize_endian_string(mcBuffer* mb, mrEndianness endianness, const char* string);
+MCDLLAPI bool mc_deserialize_endian_string(mcBuffer* mb, mrEndianness endianness, char* string, const uint32_t string_capacity);
 
 #ifdef __cplusplus
 }

--- a/include/microcdr/types/string.h
+++ b/include/microcdr/types/string.h
@@ -29,10 +29,10 @@ extern "C" {
 // -------------------------------------------------------------------
 
 MCDLLAPI bool serialize_string(mcMicroBuffer* mb, const char* string);
-MCDLLAPI bool deserialize_string(mcMicroBuffer* mb, char* string, const uint32_t string_capacity);
+MCDLLAPI bool mc_deserialize_string(mcMicroBuffer* mb, char* string, const uint32_t string_capacity);
 
 MCDLLAPI bool serialize_endian_string(mcMicroBuffer* mb, Endianness endianness, const char* string);
-MCDLLAPI bool deserialize_endian_string(mcMicroBuffer* mb, Endianness endianness, char* string, const uint32_t string_capacity);
+MCDLLAPI bool mc_deserialize_endian_string(mcMicroBuffer* mb, Endianness endianness, char* string, const uint32_t string_capacity);
 
 #ifdef __cplusplus
 }

--- a/include/microcdr/types/string.h
+++ b/include/microcdr/types/string.h
@@ -31,8 +31,8 @@ extern "C" {
 MCDLLAPI bool mc_serialize_string(mcBuffer* mb, const char* string);
 MCDLLAPI bool mc_deserialize_string(mcBuffer* mb, char* string, const uint32_t string_capacity);
 
-MCDLLAPI bool mc_serialize_endian_string(mcBuffer* mb, mrEndianness endianness, const char* string);
-MCDLLAPI bool mc_deserialize_endian_string(mcBuffer* mb, mrEndianness endianness, char* string, const uint32_t string_capacity);
+MCDLLAPI bool mc_serialize_endian_string(mcBuffer* mb, mcEndianness endianness, const char* string);
+MCDLLAPI bool mc_deserialize_endian_string(mcBuffer* mb, mcEndianness endianness, char* string, const uint32_t string_capacity);
 
 #ifdef __cplusplus
 }

--- a/include/microcdr/types/string.h
+++ b/include/microcdr/types/string.h
@@ -28,11 +28,11 @@ extern "C" {
 //                   PUBLIC SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
 
-MCDLLAPI bool serialize_string(MicroBuffer* mb, const char* string);
-MCDLLAPI bool deserialize_string(MicroBuffer* mb, char* string, const uint32_t string_capacity);
+MCDLLAPI bool serialize_string(mcMicroBuffer* mb, const char* string);
+MCDLLAPI bool deserialize_string(mcMicroBuffer* mb, char* string, const uint32_t string_capacity);
 
-MCDLLAPI bool serialize_endian_string(MicroBuffer* mb, Endianness endianness, const char* string);
-MCDLLAPI bool deserialize_endian_string(MicroBuffer* mb, Endianness endianness, char* string, const uint32_t string_capacity);
+MCDLLAPI bool serialize_endian_string(mcMicroBuffer* mb, Endianness endianness, const char* string);
+MCDLLAPI bool deserialize_endian_string(mcMicroBuffer* mb, Endianness endianness, char* string, const uint32_t string_capacity);
 
 #ifdef __cplusplus
 }

--- a/src/c/common.c
+++ b/src/c/common.c
@@ -44,15 +44,15 @@ bool check_buffer(mcBuffer* mb, const uint32_t bytes)
 // -------------------------------------------------------------------
 void mc_init_micro_buffer(mcBuffer* mb, uint8_t* data, const uint32_t size)
 {
-    mc_init_micro_buffer_offset(mb, data, size, 0U);
+    mc_init_buffer_offset(mb, data, size, 0U);
 }
 
-void mc_init_micro_buffer_offset(mcBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset)
+void mc_init_buffer_offset(mcBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset)
 {
-    mc_init_micro_buffer_offset_endian(mb, data, size, offset, MC_MACHINE_ENDIANNESS);
+    mc_init_buffer_offset_endian(mb, data, size, offset, MC_MACHINE_ENDIANNESS);
 }
 
-void mc_init_micro_buffer_offset_endian(mcBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, mrEndianness endianness)
+void mc_init_buffer_offset_endian(mcBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, mrEndianness endianness)
 {
     mb->init = data;
     mb->final = mb->init + size;
@@ -70,10 +70,10 @@ void mc_copy_micro_buffer(mcBuffer* mb_dest, const mcBuffer* mb_source)
 
 void mc_reset_micro_buffer(mcBuffer* mb)
 {
-    mc_reset_micro_buffer_offset(mb, 0U);
+    mc_reset_buffer_offset(mb, 0U);
 }
 
-void mc_reset_micro_buffer_offset(mcBuffer* mb, const uint32_t offset)
+void mc_reset_buffer_offset(mcBuffer* mb, const uint32_t offset)
 {
     mb->iterator = mb->init + offset;
     mb->last_data_size = 0U;
@@ -82,7 +82,7 @@ void mc_reset_micro_buffer_offset(mcBuffer* mb, const uint32_t offset)
 
 void mc_align_to(mcBuffer* mb, const uint32_t size)
 {
-    uint32_t offset = mc_micro_buffer_alignment(mb, size);
+    uint32_t offset = mc_buffer_alignment(mb, size);
     mb->iterator += offset;
     if(mb->iterator > mb->final)
     {
@@ -97,7 +97,7 @@ uint32_t mc_alignment(uint32_t current_alignment, const uint32_t data_size)
     return ((data_size - (current_alignment % data_size)) & (data_size - 1));
 }
 
-uint32_t mc_micro_buffer_alignment(const mcBuffer* mb, const uint32_t data_size)
+uint32_t mc_buffer_alignment(const mcBuffer* mb, const uint32_t data_size)
 {
     if(data_size > mb->last_data_size)
     {
@@ -107,27 +107,27 @@ uint32_t mc_micro_buffer_alignment(const mcBuffer* mb, const uint32_t data_size)
     return 0;
 }
 
-size_t mc_micro_buffer_size(const mcBuffer* mb)
+size_t mc_buffer_size(const mcBuffer* mb)
 {
     return (size_t)(mb->final - mb->init);
 }
 
-size_t mc_micro_buffer_length(const mcBuffer* mb)
+size_t mc_buffer_length(const mcBuffer* mb)
 {
     return (size_t)(mb->iterator - mb->init);
 }
 
-size_t mc_micro_buffer_remaining(const mcBuffer* mb)
+size_t mc_buffer_remaining(const mcBuffer* mb)
 {
     return (size_t)(mb->final - mb->iterator);
 }
 
-mrEndianness mc_micro_buffer_endianness(const mcBuffer* mb)
+mrEndianness mc_buffer_endianness(const mcBuffer* mb)
 {
     return mb->endianness;
 }
 
-bool mc_micro_buffer_has_error(const mcBuffer* mb)
+bool mc_buffer_has_error(const mcBuffer* mb)
 {
     return mb->error;
 }

--- a/src/c/common.c
+++ b/src/c/common.c
@@ -17,9 +17,9 @@
 #include <string.h>
 
 #if __BIG_ENDIAN__
-    const mrEndianness MC_MACHINE_ENDIANNESS = MC_BIG_ENDIANNESS;
+    const mcEndianness MC_MACHINE_ENDIANNESS = MC_BIG_ENDIANNESS;
 #else
-    const mrEndianness MC_MACHINE_ENDIANNESS = MC_LITTLE_ENDIANNESS;
+    const mcEndianness MC_MACHINE_ENDIANNESS = MC_LITTLE_ENDIANNESS;
 #endif
 
 // -------------------------------------------------------------------
@@ -52,7 +52,7 @@ void mc_init_buffer_offset(mcBuffer* mb, uint8_t* data, const uint32_t size, uin
     mc_init_buffer_offset_endian(mb, data, size, offset, MC_MACHINE_ENDIANNESS);
 }
 
-void mc_init_buffer_offset_endian(mcBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, mrEndianness endianness)
+void mc_init_buffer_offset_endian(mcBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, mcEndianness endianness)
 {
     mb->init = data;
     mb->final = mb->init + size;
@@ -122,7 +122,7 @@ size_t mc_buffer_remaining(const mcBuffer* mb)
     return (size_t)(mb->final - mb->iterator);
 }
 
-mrEndianness mc_buffer_endianness(const mcBuffer* mb)
+mcEndianness mc_buffer_endianness(const mcBuffer* mb)
 {
     return mb->endianness;
 }

--- a/src/c/common.c
+++ b/src/c/common.c
@@ -17,9 +17,9 @@
 #include <string.h>
 
 #if __BIG_ENDIAN__
-    const Endianness MACHINE_ENDIANNESS = BIG_ENDIANNESS;
+    const mrEndianness MC_MACHINE_ENDIANNESS = MC_BIG_ENDIANNESS;
 #else
-    const Endianness MACHINE_ENDIANNESS = LITTLE_ENDIANNESS;
+    const mrEndianness MC_MACHINE_ENDIANNESS = MC_LITTLE_ENDIANNESS;
 #endif
 
 // -------------------------------------------------------------------
@@ -49,10 +49,10 @@ void mc_init_micro_buffer(mcMicroBuffer* mb, uint8_t* data, const uint32_t size)
 
 void mc_init_micro_buffer_offset(mcMicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset)
 {
-    mc_init_micro_buffer_offset_endian(mb, data, size, offset, MACHINE_ENDIANNESS);
+    mc_init_micro_buffer_offset_endian(mb, data, size, offset, MC_MACHINE_ENDIANNESS);
 }
 
-void mc_init_micro_buffer_offset_endian(mcMicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, Endianness endianness)
+void mc_init_micro_buffer_offset_endian(mcMicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, mrEndianness endianness)
 {
     mb->init = data;
     mb->final = mb->init + size;
@@ -122,7 +122,7 @@ size_t mc_micro_buffer_remaining(const mcMicroBuffer* mb)
     return (size_t)(mb->final - mb->iterator);
 }
 
-Endianness mc_micro_buffer_endianness(const mcMicroBuffer* mb)
+mrEndianness mc_micro_buffer_endianness(const mcMicroBuffer* mb)
 {
     return mb->endianness;
 }

--- a/src/c/common.c
+++ b/src/c/common.c
@@ -25,7 +25,7 @@
 // -------------------------------------------------------------------
 //                   INTERNAL UTIL IMPLEMENTATIONS
 // -------------------------------------------------------------------
-bool check_buffer(MicroBuffer* mb, const uint32_t bytes)
+bool check_buffer(mcMicroBuffer* mb, const uint32_t bytes)
 {
     if(!mb->error)
     {
@@ -42,17 +42,17 @@ bool check_buffer(MicroBuffer* mb, const uint32_t bytes)
 // -------------------------------------------------------------------
 //                       PUBLIC IMPLEMENTATION
 // -------------------------------------------------------------------
-void init_micro_buffer(MicroBuffer* mb, uint8_t* data, const uint32_t size)
+void init_micro_buffer(mcMicroBuffer* mb, uint8_t* data, const uint32_t size)
 {
     init_micro_buffer_offset(mb, data, size, 0U);
 }
 
-void init_micro_buffer_offset(MicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset)
+void init_micro_buffer_offset(mcMicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset)
 {
     init_micro_buffer_offset_endian(mb, data, size, offset, MACHINE_ENDIANNESS);
 }
 
-void init_micro_buffer_offset_endian(MicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, Endianness endianness)
+void init_micro_buffer_offset_endian(mcMicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, Endianness endianness)
 {
     mb->init = data;
     mb->final = mb->init + size;
@@ -63,24 +63,24 @@ void init_micro_buffer_offset_endian(MicroBuffer* mb, uint8_t* data, const uint3
 }
 
 
-void copy_micro_buffer(MicroBuffer* mb_dest, const MicroBuffer* mb_source)
+void copy_micro_buffer(mcMicroBuffer* mb_dest, const mcMicroBuffer* mb_source)
 {
-    memcpy(mb_dest, mb_source, sizeof(MicroBuffer));
+    memcpy(mb_dest, mb_source, sizeof(mcMicroBuffer));
 }
 
-void reset_micro_buffer(MicroBuffer* mb)
+void reset_micro_buffer(mcMicroBuffer* mb)
 {
     reset_micro_buffer_offset(mb, 0U);
 }
 
-void reset_micro_buffer_offset(MicroBuffer* mb, const uint32_t offset)
+void reset_micro_buffer_offset(mcMicroBuffer* mb, const uint32_t offset)
 {
     mb->iterator = mb->init + offset;
     mb->last_data_size = 0U;
     mb->error = false;
 }
 
-void align_to(MicroBuffer* mb, const uint32_t size)
+void align_to(mcMicroBuffer* mb, const uint32_t size)
 {
     uint32_t offset = get_alignment_offset(mb, size);
     mb->iterator += offset;
@@ -97,7 +97,7 @@ uint32_t get_alignment(uint32_t current_alignment, const uint32_t data_size)
     return ((data_size - (current_alignment % data_size)) & (data_size - 1));
 }
 
-uint32_t get_alignment_offset(const MicroBuffer* mb, const uint32_t data_size)
+uint32_t get_alignment_offset(const mcMicroBuffer* mb, const uint32_t data_size)
 {
     if(data_size > mb->last_data_size)
     {
@@ -107,27 +107,27 @@ uint32_t get_alignment_offset(const MicroBuffer* mb, const uint32_t data_size)
     return 0;
 }
 
-size_t micro_buffer_size(const MicroBuffer* mb)
+size_t micro_buffer_size(const mcMicroBuffer* mb)
 {
     return (size_t)(mb->final - mb->init);
 }
 
-size_t micro_buffer_length(const MicroBuffer* mb)
+size_t micro_buffer_length(const mcMicroBuffer* mb)
 {
     return (size_t)(mb->iterator - mb->init);
 }
 
-size_t micro_buffer_remaining(const MicroBuffer* mb)
+size_t micro_buffer_remaining(const mcMicroBuffer* mb)
 {
     return (size_t)(mb->final - mb->iterator);
 }
 
-Endianness micro_buffer_endianness(const MicroBuffer* mb)
+Endianness micro_buffer_endianness(const mcMicroBuffer* mb)
 {
     return mb->endianness;
 }
 
-bool micro_buffer_has_error(const MicroBuffer* mb)
+bool micro_buffer_has_error(const mcMicroBuffer* mb)
 {
     return mb->error;
 }

--- a/src/c/common.c
+++ b/src/c/common.c
@@ -42,7 +42,7 @@ bool check_buffer(mcBuffer* mb, const uint32_t bytes)
 // -------------------------------------------------------------------
 //                       PUBLIC IMPLEMENTATION
 // -------------------------------------------------------------------
-void mc_init_micro_buffer(mcBuffer* mb, uint8_t* data, const uint32_t size)
+void mc_init_buffer(mcBuffer* mb, uint8_t* data, const uint32_t size)
 {
     mc_init_buffer_offset(mb, data, size, 0U);
 }
@@ -63,12 +63,12 @@ void mc_init_buffer_offset_endian(mcBuffer* mb, uint8_t* data, const uint32_t si
 }
 
 
-void mc_copy_micro_buffer(mcBuffer* mb_dest, const mcBuffer* mb_source)
+void mc_copy_buffer(mcBuffer* mb_dest, const mcBuffer* mb_source)
 {
     memcpy(mb_dest, mb_source, sizeof(mcBuffer));
 }
 
-void mc_reset_micro_buffer(mcBuffer* mb)
+void mc_reset_buffer(mcBuffer* mb)
 {
     mc_reset_buffer_offset(mb, 0U);
 }

--- a/src/c/common.c
+++ b/src/c/common.c
@@ -42,17 +42,17 @@ bool check_buffer(mcMicroBuffer* mb, const uint32_t bytes)
 // -------------------------------------------------------------------
 //                       PUBLIC IMPLEMENTATION
 // -------------------------------------------------------------------
-void init_micro_buffer(mcMicroBuffer* mb, uint8_t* data, const uint32_t size)
+void mc_init_micro_buffer(mcMicroBuffer* mb, uint8_t* data, const uint32_t size)
 {
-    init_micro_buffer_offset(mb, data, size, 0U);
+    mc_init_micro_buffer_offset(mb, data, size, 0U);
 }
 
-void init_micro_buffer_offset(mcMicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset)
+void mc_init_micro_buffer_offset(mcMicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset)
 {
-    init_micro_buffer_offset_endian(mb, data, size, offset, MACHINE_ENDIANNESS);
+    mc_init_micro_buffer_offset_endian(mb, data, size, offset, MACHINE_ENDIANNESS);
 }
 
-void init_micro_buffer_offset_endian(mcMicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, Endianness endianness)
+void mc_init_micro_buffer_offset_endian(mcMicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, Endianness endianness)
 {
     mb->init = data;
     mb->final = mb->init + size;
@@ -63,26 +63,26 @@ void init_micro_buffer_offset_endian(mcMicroBuffer* mb, uint8_t* data, const uin
 }
 
 
-void copy_micro_buffer(mcMicroBuffer* mb_dest, const mcMicroBuffer* mb_source)
+void mc_copy_micro_buffer(mcMicroBuffer* mb_dest, const mcMicroBuffer* mb_source)
 {
     memcpy(mb_dest, mb_source, sizeof(mcMicroBuffer));
 }
 
-void reset_micro_buffer(mcMicroBuffer* mb)
+void mc_reset_micro_buffer(mcMicroBuffer* mb)
 {
-    reset_micro_buffer_offset(mb, 0U);
+    mc_reset_micro_buffer_offset(mb, 0U);
 }
 
-void reset_micro_buffer_offset(mcMicroBuffer* mb, const uint32_t offset)
+void mc_reset_micro_buffer_offset(mcMicroBuffer* mb, const uint32_t offset)
 {
     mb->iterator = mb->init + offset;
     mb->last_data_size = 0U;
     mb->error = false;
 }
 
-void align_to(mcMicroBuffer* mb, const uint32_t size)
+void mc_align_to(mcMicroBuffer* mb, const uint32_t size)
 {
-    uint32_t offset = get_alignment_offset(mb, size);
+    uint32_t offset = mc_micro_buffer_alignment(mb, size);
     mb->iterator += offset;
     if(mb->iterator > mb->final)
     {
@@ -92,12 +92,12 @@ void align_to(mcMicroBuffer* mb, const uint32_t size)
     mb->last_data_size = size;
 }
 
-uint32_t get_alignment(uint32_t current_alignment, const uint32_t data_size)
+uint32_t mc_alignment(uint32_t current_alignment, const uint32_t data_size)
 {
     return ((data_size - (current_alignment % data_size)) & (data_size - 1));
 }
 
-uint32_t get_alignment_offset(const mcMicroBuffer* mb, const uint32_t data_size)
+uint32_t mc_micro_buffer_alignment(const mcMicroBuffer* mb, const uint32_t data_size)
 {
     if(data_size > mb->last_data_size)
     {
@@ -107,27 +107,27 @@ uint32_t get_alignment_offset(const mcMicroBuffer* mb, const uint32_t data_size)
     return 0;
 }
 
-size_t micro_buffer_size(const mcMicroBuffer* mb)
+size_t mc_micro_buffer_size(const mcMicroBuffer* mb)
 {
     return (size_t)(mb->final - mb->init);
 }
 
-size_t micro_buffer_length(const mcMicroBuffer* mb)
+size_t mc_micro_buffer_length(const mcMicroBuffer* mb)
 {
     return (size_t)(mb->iterator - mb->init);
 }
 
-size_t micro_buffer_remaining(const mcMicroBuffer* mb)
+size_t mc_micro_buffer_remaining(const mcMicroBuffer* mb)
 {
     return (size_t)(mb->final - mb->iterator);
 }
 
-Endianness micro_buffer_endianness(const mcMicroBuffer* mb)
+Endianness mc_micro_buffer_endianness(const mcMicroBuffer* mb)
 {
     return mb->endianness;
 }
 
-bool micro_buffer_has_error(const mcMicroBuffer* mb)
+bool mc_micro_buffer_has_error(const mcMicroBuffer* mb)
 {
     return mb->error;
 }

--- a/src/c/common.c
+++ b/src/c/common.c
@@ -25,7 +25,7 @@
 // -------------------------------------------------------------------
 //                   INTERNAL UTIL IMPLEMENTATIONS
 // -------------------------------------------------------------------
-bool check_buffer(mcMicroBuffer* mb, const uint32_t bytes)
+bool check_buffer(mcBuffer* mb, const uint32_t bytes)
 {
     if(!mb->error)
     {
@@ -42,17 +42,17 @@ bool check_buffer(mcMicroBuffer* mb, const uint32_t bytes)
 // -------------------------------------------------------------------
 //                       PUBLIC IMPLEMENTATION
 // -------------------------------------------------------------------
-void mc_init_micro_buffer(mcMicroBuffer* mb, uint8_t* data, const uint32_t size)
+void mc_init_micro_buffer(mcBuffer* mb, uint8_t* data, const uint32_t size)
 {
     mc_init_micro_buffer_offset(mb, data, size, 0U);
 }
 
-void mc_init_micro_buffer_offset(mcMicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset)
+void mc_init_micro_buffer_offset(mcBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset)
 {
     mc_init_micro_buffer_offset_endian(mb, data, size, offset, MC_MACHINE_ENDIANNESS);
 }
 
-void mc_init_micro_buffer_offset_endian(mcMicroBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, mrEndianness endianness)
+void mc_init_micro_buffer_offset_endian(mcBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, mrEndianness endianness)
 {
     mb->init = data;
     mb->final = mb->init + size;
@@ -63,24 +63,24 @@ void mc_init_micro_buffer_offset_endian(mcMicroBuffer* mb, uint8_t* data, const 
 }
 
 
-void mc_copy_micro_buffer(mcMicroBuffer* mb_dest, const mcMicroBuffer* mb_source)
+void mc_copy_micro_buffer(mcBuffer* mb_dest, const mcBuffer* mb_source)
 {
-    memcpy(mb_dest, mb_source, sizeof(mcMicroBuffer));
+    memcpy(mb_dest, mb_source, sizeof(mcBuffer));
 }
 
-void mc_reset_micro_buffer(mcMicroBuffer* mb)
+void mc_reset_micro_buffer(mcBuffer* mb)
 {
     mc_reset_micro_buffer_offset(mb, 0U);
 }
 
-void mc_reset_micro_buffer_offset(mcMicroBuffer* mb, const uint32_t offset)
+void mc_reset_micro_buffer_offset(mcBuffer* mb, const uint32_t offset)
 {
     mb->iterator = mb->init + offset;
     mb->last_data_size = 0U;
     mb->error = false;
 }
 
-void mc_align_to(mcMicroBuffer* mb, const uint32_t size)
+void mc_align_to(mcBuffer* mb, const uint32_t size)
 {
     uint32_t offset = mc_micro_buffer_alignment(mb, size);
     mb->iterator += offset;
@@ -97,7 +97,7 @@ uint32_t mc_alignment(uint32_t current_alignment, const uint32_t data_size)
     return ((data_size - (current_alignment % data_size)) & (data_size - 1));
 }
 
-uint32_t mc_micro_buffer_alignment(const mcMicroBuffer* mb, const uint32_t data_size)
+uint32_t mc_micro_buffer_alignment(const mcBuffer* mb, const uint32_t data_size)
 {
     if(data_size > mb->last_data_size)
     {
@@ -107,27 +107,27 @@ uint32_t mc_micro_buffer_alignment(const mcMicroBuffer* mb, const uint32_t data_
     return 0;
 }
 
-size_t mc_micro_buffer_size(const mcMicroBuffer* mb)
+size_t mc_micro_buffer_size(const mcBuffer* mb)
 {
     return (size_t)(mb->final - mb->init);
 }
 
-size_t mc_micro_buffer_length(const mcMicroBuffer* mb)
+size_t mc_micro_buffer_length(const mcBuffer* mb)
 {
     return (size_t)(mb->iterator - mb->init);
 }
 
-size_t mc_micro_buffer_remaining(const mcMicroBuffer* mb)
+size_t mc_micro_buffer_remaining(const mcBuffer* mb)
 {
     return (size_t)(mb->final - mb->iterator);
 }
 
-mrEndianness mc_micro_buffer_endianness(const mcMicroBuffer* mb)
+mrEndianness mc_micro_buffer_endianness(const mcBuffer* mb)
 {
     return mb->endianness;
 }
 
-bool mc_micro_buffer_has_error(const mcMicroBuffer* mb)
+bool mc_micro_buffer_has_error(const mcBuffer* mb)
 {
     return mb->error;
 }

--- a/src/c/common_internals.h
+++ b/src/c/common_internals.h
@@ -24,7 +24,7 @@ extern "C" {
 // -------------------------------------------------------------------
 //                     INTERNAL UTIL FUNCTIONS
 // -------------------------------------------------------------------
-bool check_buffer(MicroBuffer* mb, const uint32_t bytes);
+bool check_buffer(mcMicroBuffer* mb, const uint32_t bytes);
 
 #ifdef __cplusplus
 }

--- a/src/c/common_internals.h
+++ b/src/c/common_internals.h
@@ -24,7 +24,7 @@ extern "C" {
 // -------------------------------------------------------------------
 //                     INTERNAL UTIL FUNCTIONS
 // -------------------------------------------------------------------
-bool check_buffer(mcMicroBuffer* mb, const uint32_t bytes);
+bool check_buffer(mcBuffer* mb, const uint32_t bytes);
 
 #ifdef __cplusplus
 }

--- a/src/c/types/array.c
+++ b/src/c/types/array.c
@@ -37,7 +37,7 @@ bool serialize_array_byte_1(mcBuffer* mb, const uint8_t* array, const uint32_t s
     return !mb->error;
 }
 
-bool serialize_array_byte_2(mcBuffer* mb, const mrEndianness endianness, const uint16_t* array, const uint32_t size)
+bool serialize_array_byte_2(mcBuffer* mb, const mcEndianness endianness, const uint16_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t array_size = size * data_size;
@@ -64,7 +64,7 @@ bool serialize_array_byte_2(mcBuffer* mb, const mrEndianness endianness, const u
     return !mb->error;
 }
 
-bool serialize_array_byte_4(mcBuffer* mb, const mrEndianness endianness, const uint32_t* array, const uint32_t size)
+bool serialize_array_byte_4(mcBuffer* mb, const mcEndianness endianness, const uint32_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t array_size = size * data_size;
@@ -91,7 +91,7 @@ bool serialize_array_byte_4(mcBuffer* mb, const mrEndianness endianness, const u
     return !mb->error;
 }
 
-bool serialize_array_byte_8(mcBuffer* mb, const mrEndianness endianness, const uint64_t* array, const uint32_t size)
+bool serialize_array_byte_8(mcBuffer* mb, const mcEndianness endianness, const uint64_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t array_size = size * data_size;
@@ -131,7 +131,7 @@ bool deserialize_array_byte_1(mcBuffer* mb, uint8_t* array, const uint32_t size)
     return !mb->error;
 }
 
-bool deserialize_array_byte_2(mcBuffer* mb, const mrEndianness endianness, uint16_t* array, const uint32_t size)
+bool deserialize_array_byte_2(mcBuffer* mb, const mcEndianness endianness, uint16_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t array_size = size * data_size;
@@ -158,7 +158,7 @@ bool deserialize_array_byte_2(mcBuffer* mb, const mrEndianness endianness, uint1
     return !mb->error;
 }
 
-bool deserialize_array_byte_4(mcBuffer* mb, const mrEndianness endianness, uint32_t* array, const uint32_t size)
+bool deserialize_array_byte_4(mcBuffer* mb, const mcEndianness endianness, uint32_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t array_size = size * data_size;
@@ -185,7 +185,7 @@ bool deserialize_array_byte_4(mcBuffer* mb, const mrEndianness endianness, uint3
     return !mb->error;
 }
 
-bool deserialize_array_byte_8(mcBuffer* mb, const mrEndianness endianness, uint64_t* array, const uint32_t size)
+bool deserialize_array_byte_8(mcBuffer* mb, const mcEndianness endianness, uint64_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t array_size = size * data_size;
@@ -336,82 +336,82 @@ bool mc_deserialize_array_double(mcBuffer* mb, double* array, const uint32_t siz
     return deserialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
-bool mc_serialize_endian_array_uint16_t(mcBuffer* mb, const mrEndianness endianness, const uint16_t* array, const uint32_t size)
+bool mc_serialize_endian_array_uint16_t(mcBuffer* mb, const mcEndianness endianness, const uint16_t* array, const uint32_t size)
 {
     return serialize_array_byte_2(mb, endianness, array, size);
 }
 
-bool mc_serialize_endian_array_uint32_t(mcBuffer* mb, const mrEndianness endianness, const uint32_t* array, const uint32_t size)
+bool mc_serialize_endian_array_uint32_t(mcBuffer* mb, const mcEndianness endianness, const uint32_t* array, const uint32_t size)
 {
     return serialize_array_byte_4(mb, endianness, array, size);
 }
 
-bool mc_serialize_endian_array_uint64_t(mcBuffer* mb, const mrEndianness endianness, const uint64_t* array, const uint32_t size)
+bool mc_serialize_endian_array_uint64_t(mcBuffer* mb, const mcEndianness endianness, const uint64_t* array, const uint32_t size)
 {
     return serialize_array_byte_8(mb, endianness, array, size);
 }
 
-bool mc_serialize_endian_array_int16_t(mcBuffer* mb, const mrEndianness endianness, const int16_t* array, const uint32_t size)
+bool mc_serialize_endian_array_int16_t(mcBuffer* mb, const mcEndianness endianness, const int16_t* array, const uint32_t size)
 {
     return serialize_array_byte_2(mb, endianness, (uint16_t*)array, size);
 }
 
-bool mc_serialize_endian_array_int32_t(mcBuffer* mb, const mrEndianness endianness, const int32_t* array, const uint32_t size)
+bool mc_serialize_endian_array_int32_t(mcBuffer* mb, const mcEndianness endianness, const int32_t* array, const uint32_t size)
 {
     return serialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool mc_serialize_endian_array_int64_t(mcBuffer* mb, const mrEndianness endianness, const int64_t* array, const uint32_t size)
+bool mc_serialize_endian_array_int64_t(mcBuffer* mb, const mcEndianness endianness, const int64_t* array, const uint32_t size)
 {
     return serialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool mc_serialize_endian_array_float(mcBuffer* mb, const mrEndianness endianness, const float* array, const uint32_t size)
+bool mc_serialize_endian_array_float(mcBuffer* mb, const mcEndianness endianness, const float* array, const uint32_t size)
 {
     return serialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool mc_serialize_endian_array_double(mcBuffer* mb, const mrEndianness endianness, const double* array, const uint32_t size)
+bool mc_serialize_endian_array_double(mcBuffer* mb, const mcEndianness endianness, const double* array, const uint32_t size)
 {
     return serialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool mc_deserialize_endian_array_uint16_t(mcBuffer* mb, const mrEndianness endianness, uint16_t* array, const uint32_t size)
+bool mc_deserialize_endian_array_uint16_t(mcBuffer* mb, const mcEndianness endianness, uint16_t* array, const uint32_t size)
 {
     return deserialize_array_byte_2(mb, endianness, array, size);
 }
 
-bool mc_deserialize_endian_array_uint32_t(mcBuffer* mb, const mrEndianness endianness, uint32_t* array, const uint32_t size)
+bool mc_deserialize_endian_array_uint32_t(mcBuffer* mb, const mcEndianness endianness, uint32_t* array, const uint32_t size)
 {
     return deserialize_array_byte_4(mb, endianness, array, size);
 }
 
-bool mc_deserialize_endian_array_uint64_t(mcBuffer* mb, const mrEndianness endianness, uint64_t* array, const uint32_t size)
+bool mc_deserialize_endian_array_uint64_t(mcBuffer* mb, const mcEndianness endianness, uint64_t* array, const uint32_t size)
 {
     return deserialize_array_byte_8(mb, endianness, array, size);
 }
 
-bool mc_deserialize_endian_array_int16_t(mcBuffer* mb, const mrEndianness endianness, int16_t* array, const uint32_t size)
+bool mc_deserialize_endian_array_int16_t(mcBuffer* mb, const mcEndianness endianness, int16_t* array, const uint32_t size)
 {
     return deserialize_array_byte_2(mb, endianness, (uint16_t*)array, size);
 }
 
-bool mc_deserialize_endian_array_int32_t(mcBuffer* mb, const mrEndianness endianness, int32_t* array, const uint32_t size)
+bool mc_deserialize_endian_array_int32_t(mcBuffer* mb, const mcEndianness endianness, int32_t* array, const uint32_t size)
 {
     return deserialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool mc_deserialize_endian_array_int64_t(mcBuffer* mb, const mrEndianness endianness, int64_t* array, const uint32_t size)
+bool mc_deserialize_endian_array_int64_t(mcBuffer* mb, const mcEndianness endianness, int64_t* array, const uint32_t size)
 {
     return deserialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool mc_deserialize_endian_array_float(mcBuffer* mb, const mrEndianness endianness, float* array, const uint32_t size)
+bool mc_deserialize_endian_array_float(mcBuffer* mb, const mcEndianness endianness, float* array, const uint32_t size)
 {
     return deserialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool mc_deserialize_endian_array_double(mcBuffer* mb, const mrEndianness endianness, double* array, const uint32_t size)
+bool mc_deserialize_endian_array_double(mcBuffer* mb, const mcEndianness endianness, double* array, const uint32_t size)
 {
     return deserialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
 }

--- a/src/c/types/array.c
+++ b/src/c/types/array.c
@@ -41,7 +41,7 @@ bool serialize_array_byte_2(mcBuffer* mb, const mrEndianness endianness, const u
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t array_size = size * data_size;
-    uint32_t alignment = mc_micro_buffer_alignment(mb, sizeof(uint16_t));
+    uint32_t alignment = mc_buffer_alignment(mb, sizeof(uint16_t));
 
     if(check_buffer(mb, alignment + array_size))
     {
@@ -68,7 +68,7 @@ bool serialize_array_byte_4(mcBuffer* mb, const mrEndianness endianness, const u
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t array_size = size * data_size;
-    uint32_t alignment = mc_micro_buffer_alignment(mb, sizeof(uint32_t));
+    uint32_t alignment = mc_buffer_alignment(mb, sizeof(uint32_t));
 
     if(check_buffer(mb, alignment + array_size))
     {
@@ -95,7 +95,7 @@ bool serialize_array_byte_8(mcBuffer* mb, const mrEndianness endianness, const u
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t array_size = size * data_size;
-    uint32_t alignment = mc_micro_buffer_alignment(mb, sizeof(uint64_t));
+    uint32_t alignment = mc_buffer_alignment(mb, sizeof(uint64_t));
 
     if(check_buffer(mb, alignment + array_size))
     {
@@ -135,7 +135,7 @@ bool deserialize_array_byte_2(mcBuffer* mb, const mrEndianness endianness, uint1
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t array_size = size * data_size;
-    uint32_t alignment = mc_micro_buffer_alignment(mb, sizeof(uint16_t));
+    uint32_t alignment = mc_buffer_alignment(mb, sizeof(uint16_t));
 
     if(check_buffer(mb, alignment + array_size))
     {
@@ -162,7 +162,7 @@ bool deserialize_array_byte_4(mcBuffer* mb, const mrEndianness endianness, uint3
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t array_size = size * data_size;
-    uint32_t alignment = mc_micro_buffer_alignment(mb, sizeof(uint32_t));
+    uint32_t alignment = mc_buffer_alignment(mb, sizeof(uint32_t));
 
     if(check_buffer(mb, alignment + array_size))
     {
@@ -189,7 +189,7 @@ bool deserialize_array_byte_8(mcBuffer* mb, const mrEndianness endianness, uint6
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t array_size = size * data_size;
-    uint32_t alignment = mc_micro_buffer_alignment(mb, sizeof(uint64_t));
+    uint32_t alignment = mc_buffer_alignment(mb, sizeof(uint64_t));
 
     if(check_buffer(mb, alignment + array_size))
     {

--- a/src/c/types/array.c
+++ b/src/c/types/array.c
@@ -24,7 +24,7 @@
 //                INTERNAL SERIALIZATION IMPLEMENTATION
 // -------------------------------------------------------------------
 
-bool serialize_array_byte_1(mcMicroBuffer* mb, const uint8_t* array, const uint32_t size)
+bool serialize_array_byte_1(mcBuffer* mb, const uint8_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint8_t);
     if(check_buffer(mb, size))
@@ -37,7 +37,7 @@ bool serialize_array_byte_1(mcMicroBuffer* mb, const uint8_t* array, const uint3
     return !mb->error;
 }
 
-bool serialize_array_byte_2(mcMicroBuffer* mb, const mrEndianness endianness, const uint16_t* array, const uint32_t size)
+bool serialize_array_byte_2(mcBuffer* mb, const mrEndianness endianness, const uint16_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t array_size = size * data_size;
@@ -64,7 +64,7 @@ bool serialize_array_byte_2(mcMicroBuffer* mb, const mrEndianness endianness, co
     return !mb->error;
 }
 
-bool serialize_array_byte_4(mcMicroBuffer* mb, const mrEndianness endianness, const uint32_t* array, const uint32_t size)
+bool serialize_array_byte_4(mcBuffer* mb, const mrEndianness endianness, const uint32_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t array_size = size * data_size;
@@ -91,7 +91,7 @@ bool serialize_array_byte_4(mcMicroBuffer* mb, const mrEndianness endianness, co
     return !mb->error;
 }
 
-bool serialize_array_byte_8(mcMicroBuffer* mb, const mrEndianness endianness, const uint64_t* array, const uint32_t size)
+bool serialize_array_byte_8(mcBuffer* mb, const mrEndianness endianness, const uint64_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t array_size = size * data_size;
@@ -118,7 +118,7 @@ bool serialize_array_byte_8(mcMicroBuffer* mb, const mrEndianness endianness, co
     return !mb->error;
 }
 
-bool deserialize_array_byte_1(mcMicroBuffer* mb, uint8_t* array, const uint32_t size)
+bool deserialize_array_byte_1(mcBuffer* mb, uint8_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint8_t);
     if(check_buffer(mb, size))
@@ -131,7 +131,7 @@ bool deserialize_array_byte_1(mcMicroBuffer* mb, uint8_t* array, const uint32_t 
     return !mb->error;
 }
 
-bool deserialize_array_byte_2(mcMicroBuffer* mb, const mrEndianness endianness, uint16_t* array, const uint32_t size)
+bool deserialize_array_byte_2(mcBuffer* mb, const mrEndianness endianness, uint16_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t array_size = size * data_size;
@@ -158,7 +158,7 @@ bool deserialize_array_byte_2(mcMicroBuffer* mb, const mrEndianness endianness, 
     return !mb->error;
 }
 
-bool deserialize_array_byte_4(mcMicroBuffer* mb, const mrEndianness endianness, uint32_t* array, const uint32_t size)
+bool deserialize_array_byte_4(mcBuffer* mb, const mrEndianness endianness, uint32_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t array_size = size * data_size;
@@ -185,7 +185,7 @@ bool deserialize_array_byte_4(mcMicroBuffer* mb, const mrEndianness endianness, 
     return !mb->error;
 }
 
-bool deserialize_array_byte_8(mcMicroBuffer* mb, const mrEndianness endianness, uint64_t* array, const uint32_t size)
+bool deserialize_array_byte_8(mcBuffer* mb, const mrEndianness endianness, uint64_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t array_size = size * data_size;
@@ -216,202 +216,202 @@ bool deserialize_array_byte_8(mcMicroBuffer* mb, const mrEndianness endianness, 
 //              PUBLIC SERIALIZATION IMPLEMENTATIONS
 // -------------------------------------------------------------------
 
-bool mc_serialize_array_char(mcMicroBuffer* mb, const char* array, const uint32_t size)
+bool mc_serialize_array_char(mcBuffer* mb, const char* array, const uint32_t size)
 {
     return serialize_array_byte_1(mb, (uint8_t*)array, size);
 }
 
-bool mc_serialize_array_bool(mcMicroBuffer* mb, const bool* array, const uint32_t size)
+bool mc_serialize_array_bool(mcBuffer* mb, const bool* array, const uint32_t size)
 {
     return serialize_array_byte_1(mb, (uint8_t*)array, size);
 }
 
-bool mc_serialize_array_uint8_t(mcMicroBuffer* mb, const uint8_t* array, const uint32_t size)
+bool mc_serialize_array_uint8_t(mcBuffer* mb, const uint8_t* array, const uint32_t size)
 {
     return serialize_array_byte_1(mb, array, size);
 }
 
-bool mc_serialize_array_uint16_t(mcMicroBuffer* mb, const uint16_t* array, const uint32_t size)
+bool mc_serialize_array_uint16_t(mcBuffer* mb, const uint16_t* array, const uint32_t size)
 {
     return serialize_array_byte_2(mb, mb->endianness, array, size);
 }
 
-bool mc_serialize_array_uint32_t(mcMicroBuffer* mb, const uint32_t* array, const uint32_t size)
+bool mc_serialize_array_uint32_t(mcBuffer* mb, const uint32_t* array, const uint32_t size)
 {
     return serialize_array_byte_4(mb, mb->endianness, array, size);
 }
 
-bool mc_serialize_array_uint64_t(mcMicroBuffer* mb, const uint64_t* array, const uint32_t size)
+bool mc_serialize_array_uint64_t(mcBuffer* mb, const uint64_t* array, const uint32_t size)
 {
     return serialize_array_byte_8(mb, mb->endianness, array, size);
 }
 
-bool mc_serialize_array_int8_t(mcMicroBuffer* mb, const int8_t* array, const uint32_t size)
+bool mc_serialize_array_int8_t(mcBuffer* mb, const int8_t* array, const uint32_t size)
 {
     return serialize_array_byte_1(mb, (uint8_t*)array, size);
 }
 
-bool mc_serialize_array_int16_t(mcMicroBuffer* mb, const int16_t* array, const uint32_t size)
+bool mc_serialize_array_int16_t(mcBuffer* mb, const int16_t* array, const uint32_t size)
 {
     return serialize_array_byte_2(mb, mb->endianness, (uint16_t*)array, size);
 }
 
-bool mc_serialize_array_int32_t(mcMicroBuffer* mb, const int32_t* array, const uint32_t size)
+bool mc_serialize_array_int32_t(mcBuffer* mb, const int32_t* array, const uint32_t size)
 {
     return serialize_array_byte_4(mb, mb->endianness, (uint32_t*)array, size);
 }
 
-bool mc_serialize_array_int64_t(mcMicroBuffer* mb, const int64_t* array, const uint32_t size)
+bool mc_serialize_array_int64_t(mcBuffer* mb, const int64_t* array, const uint32_t size)
 {
     return serialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
-bool mc_serialize_array_float(mcMicroBuffer* mb, const float* array, const uint32_t size)
+bool mc_serialize_array_float(mcBuffer* mb, const float* array, const uint32_t size)
 {
     return serialize_array_byte_4(mb, mb->endianness, (uint32_t*)array, size);
 }
 
-bool mc_serialize_array_double(mcMicroBuffer* mb, const double* array, const uint32_t size)
+bool mc_serialize_array_double(mcBuffer* mb, const double* array, const uint32_t size)
 {
     return serialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
-bool mc_deserialize_array_char(mcMicroBuffer* mb, char* array, const uint32_t size)
+bool mc_deserialize_array_char(mcBuffer* mb, char* array, const uint32_t size)
 {
     return deserialize_array_byte_1(mb, (uint8_t*)array, size);
 }
 
-bool mc_deserialize_array_bool(mcMicroBuffer* mb, bool* array, const uint32_t size)
+bool mc_deserialize_array_bool(mcBuffer* mb, bool* array, const uint32_t size)
 {
     return deserialize_array_byte_1(mb, (uint8_t*)array, size);
 }
 
-bool mc_deserialize_array_uint8_t(mcMicroBuffer* mb, uint8_t* array, const uint32_t size)
+bool mc_deserialize_array_uint8_t(mcBuffer* mb, uint8_t* array, const uint32_t size)
 {
     return deserialize_array_byte_1(mb, array, size);
 }
 
-bool mc_deserialize_array_uint16_t(mcMicroBuffer* mb, uint16_t* array, const uint32_t size)
+bool mc_deserialize_array_uint16_t(mcBuffer* mb, uint16_t* array, const uint32_t size)
 {
     return deserialize_array_byte_2(mb, mb->endianness, array, size);
 }
 
-bool mc_deserialize_array_uint32_t(mcMicroBuffer* mb, uint32_t* array, const uint32_t size)
+bool mc_deserialize_array_uint32_t(mcBuffer* mb, uint32_t* array, const uint32_t size)
 {
     return deserialize_array_byte_4(mb, mb->endianness, array, size);
 }
 
-bool mc_deserialize_array_uint64_t(mcMicroBuffer* mb, uint64_t* array, const uint32_t size)
+bool mc_deserialize_array_uint64_t(mcBuffer* mb, uint64_t* array, const uint32_t size)
 {
     return deserialize_array_byte_8(mb, mb->endianness, array, size);
 }
 
-bool mc_deserialize_array_int8_t(mcMicroBuffer* mb, int8_t* array, const uint32_t size)
+bool mc_deserialize_array_int8_t(mcBuffer* mb, int8_t* array, const uint32_t size)
 {
     return deserialize_array_byte_1(mb, (uint8_t*)array, size);
 }
 
-bool mc_deserialize_array_int16_t(mcMicroBuffer* mb, int16_t* array, const uint32_t size)
+bool mc_deserialize_array_int16_t(mcBuffer* mb, int16_t* array, const uint32_t size)
 {
     return deserialize_array_byte_2(mb, mb->endianness, (uint16_t*)array, size);
 }
 
-bool mc_deserialize_array_int32_t(mcMicroBuffer* mb, int32_t* array, const uint32_t size)
+bool mc_deserialize_array_int32_t(mcBuffer* mb, int32_t* array, const uint32_t size)
 {
     return deserialize_array_byte_4(mb, mb->endianness, (uint32_t*)array, size);
 }
 
-bool mc_deserialize_array_int64_t(mcMicroBuffer* mb, int64_t* array, const uint32_t size)
+bool mc_deserialize_array_int64_t(mcBuffer* mb, int64_t* array, const uint32_t size)
 {
     return deserialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
-bool mc_deserialize_array_float(mcMicroBuffer* mb, float* array, const uint32_t size)
+bool mc_deserialize_array_float(mcBuffer* mb, float* array, const uint32_t size)
 {
     return deserialize_array_byte_4(mb, mb->endianness, (uint32_t*)array, size);
 }
 
-bool mc_deserialize_array_double(mcMicroBuffer* mb, double* array, const uint32_t size)
+bool mc_deserialize_array_double(mcBuffer* mb, double* array, const uint32_t size)
 {
     return deserialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
-bool mc_serialize_endian_array_uint16_t(mcMicroBuffer* mb, const mrEndianness endianness, const uint16_t* array, const uint32_t size)
+bool mc_serialize_endian_array_uint16_t(mcBuffer* mb, const mrEndianness endianness, const uint16_t* array, const uint32_t size)
 {
     return serialize_array_byte_2(mb, endianness, array, size);
 }
 
-bool mc_serialize_endian_array_uint32_t(mcMicroBuffer* mb, const mrEndianness endianness, const uint32_t* array, const uint32_t size)
+bool mc_serialize_endian_array_uint32_t(mcBuffer* mb, const mrEndianness endianness, const uint32_t* array, const uint32_t size)
 {
     return serialize_array_byte_4(mb, endianness, array, size);
 }
 
-bool mc_serialize_endian_array_uint64_t(mcMicroBuffer* mb, const mrEndianness endianness, const uint64_t* array, const uint32_t size)
+bool mc_serialize_endian_array_uint64_t(mcBuffer* mb, const mrEndianness endianness, const uint64_t* array, const uint32_t size)
 {
     return serialize_array_byte_8(mb, endianness, array, size);
 }
 
-bool mc_serialize_endian_array_int16_t(mcMicroBuffer* mb, const mrEndianness endianness, const int16_t* array, const uint32_t size)
+bool mc_serialize_endian_array_int16_t(mcBuffer* mb, const mrEndianness endianness, const int16_t* array, const uint32_t size)
 {
     return serialize_array_byte_2(mb, endianness, (uint16_t*)array, size);
 }
 
-bool mc_serialize_endian_array_int32_t(mcMicroBuffer* mb, const mrEndianness endianness, const int32_t* array, const uint32_t size)
+bool mc_serialize_endian_array_int32_t(mcBuffer* mb, const mrEndianness endianness, const int32_t* array, const uint32_t size)
 {
     return serialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool mc_serialize_endian_array_int64_t(mcMicroBuffer* mb, const mrEndianness endianness, const int64_t* array, const uint32_t size)
+bool mc_serialize_endian_array_int64_t(mcBuffer* mb, const mrEndianness endianness, const int64_t* array, const uint32_t size)
 {
     return serialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool mc_serialize_endian_array_float(mcMicroBuffer* mb, const mrEndianness endianness, const float* array, const uint32_t size)
+bool mc_serialize_endian_array_float(mcBuffer* mb, const mrEndianness endianness, const float* array, const uint32_t size)
 {
     return serialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool mc_serialize_endian_array_double(mcMicroBuffer* mb, const mrEndianness endianness, const double* array, const uint32_t size)
+bool mc_serialize_endian_array_double(mcBuffer* mb, const mrEndianness endianness, const double* array, const uint32_t size)
 {
     return serialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool mc_deserialize_endian_array_uint16_t(mcMicroBuffer* mb, const mrEndianness endianness, uint16_t* array, const uint32_t size)
+bool mc_deserialize_endian_array_uint16_t(mcBuffer* mb, const mrEndianness endianness, uint16_t* array, const uint32_t size)
 {
     return deserialize_array_byte_2(mb, endianness, array, size);
 }
 
-bool mc_deserialize_endian_array_uint32_t(mcMicroBuffer* mb, const mrEndianness endianness, uint32_t* array, const uint32_t size)
+bool mc_deserialize_endian_array_uint32_t(mcBuffer* mb, const mrEndianness endianness, uint32_t* array, const uint32_t size)
 {
     return deserialize_array_byte_4(mb, endianness, array, size);
 }
 
-bool mc_deserialize_endian_array_uint64_t(mcMicroBuffer* mb, const mrEndianness endianness, uint64_t* array, const uint32_t size)
+bool mc_deserialize_endian_array_uint64_t(mcBuffer* mb, const mrEndianness endianness, uint64_t* array, const uint32_t size)
 {
     return deserialize_array_byte_8(mb, endianness, array, size);
 }
 
-bool mc_deserialize_endian_array_int16_t(mcMicroBuffer* mb, const mrEndianness endianness, int16_t* array, const uint32_t size)
+bool mc_deserialize_endian_array_int16_t(mcBuffer* mb, const mrEndianness endianness, int16_t* array, const uint32_t size)
 {
     return deserialize_array_byte_2(mb, endianness, (uint16_t*)array, size);
 }
 
-bool mc_deserialize_endian_array_int32_t(mcMicroBuffer* mb, const mrEndianness endianness, int32_t* array, const uint32_t size)
+bool mc_deserialize_endian_array_int32_t(mcBuffer* mb, const mrEndianness endianness, int32_t* array, const uint32_t size)
 {
     return deserialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool mc_deserialize_endian_array_int64_t(mcMicroBuffer* mb, const mrEndianness endianness, int64_t* array, const uint32_t size)
+bool mc_deserialize_endian_array_int64_t(mcBuffer* mb, const mrEndianness endianness, int64_t* array, const uint32_t size)
 {
     return deserialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool mc_deserialize_endian_array_float(mcMicroBuffer* mb, const mrEndianness endianness, float* array, const uint32_t size)
+bool mc_deserialize_endian_array_float(mcBuffer* mb, const mrEndianness endianness, float* array, const uint32_t size)
 {
     return deserialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool mc_deserialize_endian_array_double(mcMicroBuffer* mb, const mrEndianness endianness, double* array, const uint32_t size)
+bool mc_deserialize_endian_array_double(mcBuffer* mb, const mrEndianness endianness, double* array, const uint32_t size)
 {
     return deserialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
 }

--- a/src/c/types/array.c
+++ b/src/c/types/array.c
@@ -37,7 +37,7 @@ bool serialize_array_byte_1(mcMicroBuffer* mb, const uint8_t* array, const uint3
     return !mb->error;
 }
 
-bool serialize_array_byte_2(mcMicroBuffer* mb, const Endianness endianness, const uint16_t* array, const uint32_t size)
+bool serialize_array_byte_2(mcMicroBuffer* mb, const mrEndianness endianness, const uint16_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t array_size = size * data_size;
@@ -46,7 +46,7 @@ bool serialize_array_byte_2(mcMicroBuffer* mb, const Endianness endianness, cons
     if(check_buffer(mb, alignment + array_size))
     {
         mb->iterator += alignment;
-        if(MACHINE_ENDIANNESS == endianness)
+        if(MC_MACHINE_ENDIANNESS == endianness)
         {
             memcpy(mb->iterator, array, array_size);
 
@@ -64,7 +64,7 @@ bool serialize_array_byte_2(mcMicroBuffer* mb, const Endianness endianness, cons
     return !mb->error;
 }
 
-bool serialize_array_byte_4(mcMicroBuffer* mb, const Endianness endianness, const uint32_t* array, const uint32_t size)
+bool serialize_array_byte_4(mcMicroBuffer* mb, const mrEndianness endianness, const uint32_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t array_size = size * data_size;
@@ -74,7 +74,7 @@ bool serialize_array_byte_4(mcMicroBuffer* mb, const Endianness endianness, cons
     {
         mb->iterator += alignment;
 
-        if(MACHINE_ENDIANNESS == endianness)
+        if(MC_MACHINE_ENDIANNESS == endianness)
         {
             memcpy(mb->iterator, array, array_size);
             mb->iterator += array_size;
@@ -91,7 +91,7 @@ bool serialize_array_byte_4(mcMicroBuffer* mb, const Endianness endianness, cons
     return !mb->error;
 }
 
-bool serialize_array_byte_8(mcMicroBuffer* mb, const Endianness endianness, const uint64_t* array, const uint32_t size)
+bool serialize_array_byte_8(mcMicroBuffer* mb, const mrEndianness endianness, const uint64_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t array_size = size * data_size;
@@ -101,7 +101,7 @@ bool serialize_array_byte_8(mcMicroBuffer* mb, const Endianness endianness, cons
     {
         mb->iterator += alignment;
 
-        if(MACHINE_ENDIANNESS == endianness)
+        if(MC_MACHINE_ENDIANNESS == endianness)
         {
             memcpy(mb->iterator, array, array_size);
             mb->iterator += array_size;
@@ -131,7 +131,7 @@ bool deserialize_array_byte_1(mcMicroBuffer* mb, uint8_t* array, const uint32_t 
     return !mb->error;
 }
 
-bool deserialize_array_byte_2(mcMicroBuffer* mb, const Endianness endianness, uint16_t* array, const uint32_t size)
+bool deserialize_array_byte_2(mcMicroBuffer* mb, const mrEndianness endianness, uint16_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t array_size = size * data_size;
@@ -141,7 +141,7 @@ bool deserialize_array_byte_2(mcMicroBuffer* mb, const Endianness endianness, ui
     {
         mb->iterator += alignment;
 
-        if(MACHINE_ENDIANNESS == endianness)
+        if(MC_MACHINE_ENDIANNESS == endianness)
         {
             memcpy(array, mb->iterator, array_size);
             mb->iterator += array_size;
@@ -158,7 +158,7 @@ bool deserialize_array_byte_2(mcMicroBuffer* mb, const Endianness endianness, ui
     return !mb->error;
 }
 
-bool deserialize_array_byte_4(mcMicroBuffer* mb, const Endianness endianness, uint32_t* array, const uint32_t size)
+bool deserialize_array_byte_4(mcMicroBuffer* mb, const mrEndianness endianness, uint32_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t array_size = size * data_size;
@@ -168,7 +168,7 @@ bool deserialize_array_byte_4(mcMicroBuffer* mb, const Endianness endianness, ui
     {
         mb->iterator += alignment;
 
-        if(MACHINE_ENDIANNESS == endianness)
+        if(MC_MACHINE_ENDIANNESS == endianness)
         {
             memcpy(array, mb->iterator, array_size);
             mb->iterator += array_size;
@@ -185,7 +185,7 @@ bool deserialize_array_byte_4(mcMicroBuffer* mb, const Endianness endianness, ui
     return !mb->error;
 }
 
-bool deserialize_array_byte_8(mcMicroBuffer* mb, const Endianness endianness, uint64_t* array, const uint32_t size)
+bool deserialize_array_byte_8(mcMicroBuffer* mb, const mrEndianness endianness, uint64_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t array_size = size * data_size;
@@ -195,7 +195,7 @@ bool deserialize_array_byte_8(mcMicroBuffer* mb, const Endianness endianness, ui
     {
         mb->iterator += alignment;
 
-        if(MACHINE_ENDIANNESS == endianness)
+        if(MC_MACHINE_ENDIANNESS == endianness)
         {
             memcpy(array, mb->iterator, array_size);
             mb->iterator += array_size;
@@ -336,82 +336,82 @@ bool mc_deserialize_array_double(mcMicroBuffer* mb, double* array, const uint32_
     return deserialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
-bool mc_serialize_endian_array_uint16_t(mcMicroBuffer* mb, const Endianness endianness, const uint16_t* array, const uint32_t size)
+bool mc_serialize_endian_array_uint16_t(mcMicroBuffer* mb, const mrEndianness endianness, const uint16_t* array, const uint32_t size)
 {
     return serialize_array_byte_2(mb, endianness, array, size);
 }
 
-bool mc_serialize_endian_array_uint32_t(mcMicroBuffer* mb, const Endianness endianness, const uint32_t* array, const uint32_t size)
+bool mc_serialize_endian_array_uint32_t(mcMicroBuffer* mb, const mrEndianness endianness, const uint32_t* array, const uint32_t size)
 {
     return serialize_array_byte_4(mb, endianness, array, size);
 }
 
-bool mc_serialize_endian_array_uint64_t(mcMicroBuffer* mb, const Endianness endianness, const uint64_t* array, const uint32_t size)
+bool mc_serialize_endian_array_uint64_t(mcMicroBuffer* mb, const mrEndianness endianness, const uint64_t* array, const uint32_t size)
 {
     return serialize_array_byte_8(mb, endianness, array, size);
 }
 
-bool mc_serialize_endian_array_int16_t(mcMicroBuffer* mb, const Endianness endianness, const int16_t* array, const uint32_t size)
+bool mc_serialize_endian_array_int16_t(mcMicroBuffer* mb, const mrEndianness endianness, const int16_t* array, const uint32_t size)
 {
     return serialize_array_byte_2(mb, endianness, (uint16_t*)array, size);
 }
 
-bool mc_serialize_endian_array_int32_t(mcMicroBuffer* mb, const Endianness endianness, const int32_t* array, const uint32_t size)
+bool mc_serialize_endian_array_int32_t(mcMicroBuffer* mb, const mrEndianness endianness, const int32_t* array, const uint32_t size)
 {
     return serialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool mc_serialize_endian_array_int64_t(mcMicroBuffer* mb, const Endianness endianness, const int64_t* array, const uint32_t size)
+bool mc_serialize_endian_array_int64_t(mcMicroBuffer* mb, const mrEndianness endianness, const int64_t* array, const uint32_t size)
 {
     return serialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool mc_serialize_endian_array_float(mcMicroBuffer* mb, const Endianness endianness, const float* array, const uint32_t size)
+bool mc_serialize_endian_array_float(mcMicroBuffer* mb, const mrEndianness endianness, const float* array, const uint32_t size)
 {
     return serialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool mc_serialize_endian_array_double(mcMicroBuffer* mb, const Endianness endianness, const double* array, const uint32_t size)
+bool mc_serialize_endian_array_double(mcMicroBuffer* mb, const mrEndianness endianness, const double* array, const uint32_t size)
 {
     return serialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool mc_deserialize_endian_array_uint16_t(mcMicroBuffer* mb, const Endianness endianness, uint16_t* array, const uint32_t size)
+bool mc_deserialize_endian_array_uint16_t(mcMicroBuffer* mb, const mrEndianness endianness, uint16_t* array, const uint32_t size)
 {
     return deserialize_array_byte_2(mb, endianness, array, size);
 }
 
-bool mc_deserialize_endian_array_uint32_t(mcMicroBuffer* mb, const Endianness endianness, uint32_t* array, const uint32_t size)
+bool mc_deserialize_endian_array_uint32_t(mcMicroBuffer* mb, const mrEndianness endianness, uint32_t* array, const uint32_t size)
 {
     return deserialize_array_byte_4(mb, endianness, array, size);
 }
 
-bool mc_deserialize_endian_array_uint64_t(mcMicroBuffer* mb, const Endianness endianness, uint64_t* array, const uint32_t size)
+bool mc_deserialize_endian_array_uint64_t(mcMicroBuffer* mb, const mrEndianness endianness, uint64_t* array, const uint32_t size)
 {
     return deserialize_array_byte_8(mb, endianness, array, size);
 }
 
-bool mc_deserialize_endian_array_int16_t(mcMicroBuffer* mb, const Endianness endianness, int16_t* array, const uint32_t size)
+bool mc_deserialize_endian_array_int16_t(mcMicroBuffer* mb, const mrEndianness endianness, int16_t* array, const uint32_t size)
 {
     return deserialize_array_byte_2(mb, endianness, (uint16_t*)array, size);
 }
 
-bool mc_deserialize_endian_array_int32_t(mcMicroBuffer* mb, const Endianness endianness, int32_t* array, const uint32_t size)
+bool mc_deserialize_endian_array_int32_t(mcMicroBuffer* mb, const mrEndianness endianness, int32_t* array, const uint32_t size)
 {
     return deserialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool mc_deserialize_endian_array_int64_t(mcMicroBuffer* mb, const Endianness endianness, int64_t* array, const uint32_t size)
+bool mc_deserialize_endian_array_int64_t(mcMicroBuffer* mb, const mrEndianness endianness, int64_t* array, const uint32_t size)
 {
     return deserialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool mc_deserialize_endian_array_float(mcMicroBuffer* mb, const Endianness endianness, float* array, const uint32_t size)
+bool mc_deserialize_endian_array_float(mcMicroBuffer* mb, const mrEndianness endianness, float* array, const uint32_t size)
 {
     return deserialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool mc_deserialize_endian_array_double(mcMicroBuffer* mb, const Endianness endianness, double* array, const uint32_t size)
+bool mc_deserialize_endian_array_double(mcMicroBuffer* mb, const mrEndianness endianness, double* array, const uint32_t size)
 {
     return deserialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
 }

--- a/src/c/types/array.c
+++ b/src/c/types/array.c
@@ -24,7 +24,7 @@
 //                INTERNAL SERIALIZATION IMPLEMENTATION
 // -------------------------------------------------------------------
 
-bool serialize_array_byte_1(MicroBuffer* mb, const uint8_t* array, const uint32_t size)
+bool serialize_array_byte_1(mcMicroBuffer* mb, const uint8_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint8_t);
     if(check_buffer(mb, size))
@@ -37,7 +37,7 @@ bool serialize_array_byte_1(MicroBuffer* mb, const uint8_t* array, const uint32_
     return !mb->error;
 }
 
-bool serialize_array_byte_2(MicroBuffer* mb, const Endianness endianness, const uint16_t* array, const uint32_t size)
+bool serialize_array_byte_2(mcMicroBuffer* mb, const Endianness endianness, const uint16_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t array_size = size * data_size;
@@ -64,7 +64,7 @@ bool serialize_array_byte_2(MicroBuffer* mb, const Endianness endianness, const 
     return !mb->error;
 }
 
-bool serialize_array_byte_4(MicroBuffer* mb, const Endianness endianness, const uint32_t* array, const uint32_t size)
+bool serialize_array_byte_4(mcMicroBuffer* mb, const Endianness endianness, const uint32_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t array_size = size * data_size;
@@ -91,7 +91,7 @@ bool serialize_array_byte_4(MicroBuffer* mb, const Endianness endianness, const 
     return !mb->error;
 }
 
-bool serialize_array_byte_8(MicroBuffer* mb, const Endianness endianness, const uint64_t* array, const uint32_t size)
+bool serialize_array_byte_8(mcMicroBuffer* mb, const Endianness endianness, const uint64_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t array_size = size * data_size;
@@ -118,7 +118,7 @@ bool serialize_array_byte_8(MicroBuffer* mb, const Endianness endianness, const 
     return !mb->error;
 }
 
-bool deserialize_array_byte_1(MicroBuffer* mb, uint8_t* array, const uint32_t size)
+bool deserialize_array_byte_1(mcMicroBuffer* mb, uint8_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint8_t);
     if(check_buffer(mb, size))
@@ -131,7 +131,7 @@ bool deserialize_array_byte_1(MicroBuffer* mb, uint8_t* array, const uint32_t si
     return !mb->error;
 }
 
-bool deserialize_array_byte_2(MicroBuffer* mb, const Endianness endianness, uint16_t* array, const uint32_t size)
+bool deserialize_array_byte_2(mcMicroBuffer* mb, const Endianness endianness, uint16_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t array_size = size * data_size;
@@ -158,7 +158,7 @@ bool deserialize_array_byte_2(MicroBuffer* mb, const Endianness endianness, uint
     return !mb->error;
 }
 
-bool deserialize_array_byte_4(MicroBuffer* mb, const Endianness endianness, uint32_t* array, const uint32_t size)
+bool deserialize_array_byte_4(mcMicroBuffer* mb, const Endianness endianness, uint32_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t array_size = size * data_size;
@@ -185,7 +185,7 @@ bool deserialize_array_byte_4(MicroBuffer* mb, const Endianness endianness, uint
     return !mb->error;
 }
 
-bool deserialize_array_byte_8(MicroBuffer* mb, const Endianness endianness, uint64_t* array, const uint32_t size)
+bool deserialize_array_byte_8(mcMicroBuffer* mb, const Endianness endianness, uint64_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t array_size = size * data_size;
@@ -216,202 +216,202 @@ bool deserialize_array_byte_8(MicroBuffer* mb, const Endianness endianness, uint
 //              PUBLIC SERIALIZATION IMPLEMENTATIONS
 // -------------------------------------------------------------------
 
-bool serialize_array_char(MicroBuffer* mb, const char* array, const uint32_t size)
+bool serialize_array_char(mcMicroBuffer* mb, const char* array, const uint32_t size)
 {
     return serialize_array_byte_1(mb, (uint8_t*)array, size);
 }
 
-bool serialize_array_bool(MicroBuffer* mb, const bool* array, const uint32_t size)
+bool serialize_array_bool(mcMicroBuffer* mb, const bool* array, const uint32_t size)
 {
     return serialize_array_byte_1(mb, (uint8_t*)array, size);
 }
 
-bool serialize_array_uint8_t(MicroBuffer* mb, const uint8_t* array, const uint32_t size)
+bool serialize_array_uint8_t(mcMicroBuffer* mb, const uint8_t* array, const uint32_t size)
 {
     return serialize_array_byte_1(mb, array, size);
 }
 
-bool serialize_array_uint16_t(MicroBuffer* mb, const uint16_t* array, const uint32_t size)
+bool serialize_array_uint16_t(mcMicroBuffer* mb, const uint16_t* array, const uint32_t size)
 {
     return serialize_array_byte_2(mb, mb->endianness, array, size);
 }
 
-bool serialize_array_uint32_t(MicroBuffer* mb, const uint32_t* array, const uint32_t size)
+bool serialize_array_uint32_t(mcMicroBuffer* mb, const uint32_t* array, const uint32_t size)
 {
     return serialize_array_byte_4(mb, mb->endianness, array, size);
 }
 
-bool serialize_array_uint64_t(MicroBuffer* mb, const uint64_t* array, const uint32_t size)
+bool serialize_array_uint64_t(mcMicroBuffer* mb, const uint64_t* array, const uint32_t size)
 {
     return serialize_array_byte_8(mb, mb->endianness, array, size);
 }
 
-bool serialize_array_int8_t(MicroBuffer* mb, const int8_t* array, const uint32_t size)
+bool serialize_array_int8_t(mcMicroBuffer* mb, const int8_t* array, const uint32_t size)
 {
     return serialize_array_byte_1(mb, (uint8_t*)array, size);
 }
 
-bool serialize_array_int16_t(MicroBuffer* mb, const int16_t* array, const uint32_t size)
+bool serialize_array_int16_t(mcMicroBuffer* mb, const int16_t* array, const uint32_t size)
 {
     return serialize_array_byte_2(mb, mb->endianness, (uint16_t*)array, size);
 }
 
-bool serialize_array_int32_t(MicroBuffer* mb, const int32_t* array, const uint32_t size)
+bool serialize_array_int32_t(mcMicroBuffer* mb, const int32_t* array, const uint32_t size)
 {
     return serialize_array_byte_4(mb, mb->endianness, (uint32_t*)array, size);
 }
 
-bool serialize_array_int64_t(MicroBuffer* mb, const int64_t* array, const uint32_t size)
+bool serialize_array_int64_t(mcMicroBuffer* mb, const int64_t* array, const uint32_t size)
 {
     return serialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
-bool serialize_array_float(MicroBuffer* mb, const float* array, const uint32_t size)
+bool serialize_array_float(mcMicroBuffer* mb, const float* array, const uint32_t size)
 {
     return serialize_array_byte_4(mb, mb->endianness, (uint32_t*)array, size);
 }
 
-bool serialize_array_double(MicroBuffer* mb, const double* array, const uint32_t size)
+bool serialize_array_double(mcMicroBuffer* mb, const double* array, const uint32_t size)
 {
     return serialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
-bool deserialize_array_char(MicroBuffer* mb, char* array, const uint32_t size)
+bool deserialize_array_char(mcMicroBuffer* mb, char* array, const uint32_t size)
 {
     return deserialize_array_byte_1(mb, (uint8_t*)array, size);
 }
 
-bool deserialize_array_bool(MicroBuffer* mb, bool* array, const uint32_t size)
+bool deserialize_array_bool(mcMicroBuffer* mb, bool* array, const uint32_t size)
 {
     return deserialize_array_byte_1(mb, (uint8_t*)array, size);
 }
 
-bool deserialize_array_uint8_t(MicroBuffer* mb, uint8_t* array, const uint32_t size)
+bool deserialize_array_uint8_t(mcMicroBuffer* mb, uint8_t* array, const uint32_t size)
 {
     return deserialize_array_byte_1(mb, array, size);
 }
 
-bool deserialize_array_uint16_t(MicroBuffer* mb, uint16_t* array, const uint32_t size)
+bool deserialize_array_uint16_t(mcMicroBuffer* mb, uint16_t* array, const uint32_t size)
 {
     return deserialize_array_byte_2(mb, mb->endianness, array, size);
 }
 
-bool deserialize_array_uint32_t(MicroBuffer* mb, uint32_t* array, const uint32_t size)
+bool deserialize_array_uint32_t(mcMicroBuffer* mb, uint32_t* array, const uint32_t size)
 {
     return deserialize_array_byte_4(mb, mb->endianness, array, size);
 }
 
-bool deserialize_array_uint64_t(MicroBuffer* mb, uint64_t* array, const uint32_t size)
+bool deserialize_array_uint64_t(mcMicroBuffer* mb, uint64_t* array, const uint32_t size)
 {
     return deserialize_array_byte_8(mb, mb->endianness, array, size);
 }
 
-bool deserialize_array_int8_t(MicroBuffer* mb, int8_t* array, const uint32_t size)
+bool deserialize_array_int8_t(mcMicroBuffer* mb, int8_t* array, const uint32_t size)
 {
     return deserialize_array_byte_1(mb, (uint8_t*)array, size);
 }
 
-bool deserialize_array_int16_t(MicroBuffer* mb, int16_t* array, const uint32_t size)
+bool deserialize_array_int16_t(mcMicroBuffer* mb, int16_t* array, const uint32_t size)
 {
     return deserialize_array_byte_2(mb, mb->endianness, (uint16_t*)array, size);
 }
 
-bool deserialize_array_int32_t(MicroBuffer* mb, int32_t* array, const uint32_t size)
+bool deserialize_array_int32_t(mcMicroBuffer* mb, int32_t* array, const uint32_t size)
 {
     return deserialize_array_byte_4(mb, mb->endianness, (uint32_t*)array, size);
 }
 
-bool deserialize_array_int64_t(MicroBuffer* mb, int64_t* array, const uint32_t size)
+bool deserialize_array_int64_t(mcMicroBuffer* mb, int64_t* array, const uint32_t size)
 {
     return deserialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
-bool deserialize_array_float(MicroBuffer* mb, float* array, const uint32_t size)
+bool deserialize_array_float(mcMicroBuffer* mb, float* array, const uint32_t size)
 {
     return deserialize_array_byte_4(mb, mb->endianness, (uint32_t*)array, size);
 }
 
-bool deserialize_array_double(MicroBuffer* mb, double* array, const uint32_t size)
+bool deserialize_array_double(mcMicroBuffer* mb, double* array, const uint32_t size)
 {
     return deserialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
-bool serialize_endian_array_uint16_t(MicroBuffer* mb, const Endianness endianness, const uint16_t* array, const uint32_t size)
+bool serialize_endian_array_uint16_t(mcMicroBuffer* mb, const Endianness endianness, const uint16_t* array, const uint32_t size)
 {
     return serialize_array_byte_2(mb, endianness, array, size);
 }
 
-bool serialize_endian_array_uint32_t(MicroBuffer* mb, const Endianness endianness, const uint32_t* array, const uint32_t size)
+bool serialize_endian_array_uint32_t(mcMicroBuffer* mb, const Endianness endianness, const uint32_t* array, const uint32_t size)
 {
     return serialize_array_byte_4(mb, endianness, array, size);
 }
 
-bool serialize_endian_array_uint64_t(MicroBuffer* mb, const Endianness endianness, const uint64_t* array, const uint32_t size)
+bool serialize_endian_array_uint64_t(mcMicroBuffer* mb, const Endianness endianness, const uint64_t* array, const uint32_t size)
 {
     return serialize_array_byte_8(mb, endianness, array, size);
 }
 
-bool serialize_endian_array_int16_t(MicroBuffer* mb, const Endianness endianness, const int16_t* array, const uint32_t size)
+bool serialize_endian_array_int16_t(mcMicroBuffer* mb, const Endianness endianness, const int16_t* array, const uint32_t size)
 {
     return serialize_array_byte_2(mb, endianness, (uint16_t*)array, size);
 }
 
-bool serialize_endian_array_int32_t(MicroBuffer* mb, const Endianness endianness, const int32_t* array, const uint32_t size)
+bool serialize_endian_array_int32_t(mcMicroBuffer* mb, const Endianness endianness, const int32_t* array, const uint32_t size)
 {
     return serialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool serialize_endian_array_int64_t(MicroBuffer* mb, const Endianness endianness, const int64_t* array, const uint32_t size)
+bool serialize_endian_array_int64_t(mcMicroBuffer* mb, const Endianness endianness, const int64_t* array, const uint32_t size)
 {
     return serialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool serialize_endian_array_float(MicroBuffer* mb, const Endianness endianness, const float* array, const uint32_t size)
+bool serialize_endian_array_float(mcMicroBuffer* mb, const Endianness endianness, const float* array, const uint32_t size)
 {
     return serialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool serialize_endian_array_double(MicroBuffer* mb, const Endianness endianness, const double* array, const uint32_t size)
+bool serialize_endian_array_double(mcMicroBuffer* mb, const Endianness endianness, const double* array, const uint32_t size)
 {
     return serialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool deserialize_endian_array_uint16_t(MicroBuffer* mb, const Endianness endianness, uint16_t* array, const uint32_t size)
+bool deserialize_endian_array_uint16_t(mcMicroBuffer* mb, const Endianness endianness, uint16_t* array, const uint32_t size)
 {
     return deserialize_array_byte_2(mb, endianness, array, size);
 }
 
-bool deserialize_endian_array_uint32_t(MicroBuffer* mb, const Endianness endianness, uint32_t* array, const uint32_t size)
+bool deserialize_endian_array_uint32_t(mcMicroBuffer* mb, const Endianness endianness, uint32_t* array, const uint32_t size)
 {
     return deserialize_array_byte_4(mb, endianness, array, size);
 }
 
-bool deserialize_endian_array_uint64_t(MicroBuffer* mb, const Endianness endianness, uint64_t* array, const uint32_t size)
+bool deserialize_endian_array_uint64_t(mcMicroBuffer* mb, const Endianness endianness, uint64_t* array, const uint32_t size)
 {
     return deserialize_array_byte_8(mb, endianness, array, size);
 }
 
-bool deserialize_endian_array_int16_t(MicroBuffer* mb, const Endianness endianness, int16_t* array, const uint32_t size)
+bool deserialize_endian_array_int16_t(mcMicroBuffer* mb, const Endianness endianness, int16_t* array, const uint32_t size)
 {
     return deserialize_array_byte_2(mb, endianness, (uint16_t*)array, size);
 }
 
-bool deserialize_endian_array_int32_t(MicroBuffer* mb, const Endianness endianness, int32_t* array, const uint32_t size)
+bool deserialize_endian_array_int32_t(mcMicroBuffer* mb, const Endianness endianness, int32_t* array, const uint32_t size)
 {
     return deserialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool deserialize_endian_array_int64_t(MicroBuffer* mb, const Endianness endianness, int64_t* array, const uint32_t size)
+bool deserialize_endian_array_int64_t(mcMicroBuffer* mb, const Endianness endianness, int64_t* array, const uint32_t size)
 {
     return deserialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool deserialize_endian_array_float(MicroBuffer* mb, const Endianness endianness, float* array, const uint32_t size)
+bool deserialize_endian_array_float(mcMicroBuffer* mb, const Endianness endianness, float* array, const uint32_t size)
 {
     return deserialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool deserialize_endian_array_double(MicroBuffer* mb, const Endianness endianness, double* array, const uint32_t size)
+bool deserialize_endian_array_double(mcMicroBuffer* mb, const Endianness endianness, double* array, const uint32_t size)
 {
     return deserialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
 }

--- a/src/c/types/array.c
+++ b/src/c/types/array.c
@@ -41,7 +41,7 @@ bool serialize_array_byte_2(mcMicroBuffer* mb, const Endianness endianness, cons
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t array_size = size * data_size;
-    uint32_t alignment = get_alignment_offset(mb, sizeof(uint16_t));
+    uint32_t alignment = mc_micro_buffer_alignment(mb, sizeof(uint16_t));
 
     if(check_buffer(mb, alignment + array_size))
     {
@@ -68,7 +68,7 @@ bool serialize_array_byte_4(mcMicroBuffer* mb, const Endianness endianness, cons
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t array_size = size * data_size;
-    uint32_t alignment = get_alignment_offset(mb, sizeof(uint32_t));
+    uint32_t alignment = mc_micro_buffer_alignment(mb, sizeof(uint32_t));
 
     if(check_buffer(mb, alignment + array_size))
     {
@@ -95,7 +95,7 @@ bool serialize_array_byte_8(mcMicroBuffer* mb, const Endianness endianness, cons
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t array_size = size * data_size;
-    uint32_t alignment = get_alignment_offset(mb, sizeof(uint64_t));
+    uint32_t alignment = mc_micro_buffer_alignment(mb, sizeof(uint64_t));
 
     if(check_buffer(mb, alignment + array_size))
     {
@@ -135,7 +135,7 @@ bool deserialize_array_byte_2(mcMicroBuffer* mb, const Endianness endianness, ui
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t array_size = size * data_size;
-    uint32_t alignment = get_alignment_offset(mb, sizeof(uint16_t));
+    uint32_t alignment = mc_micro_buffer_alignment(mb, sizeof(uint16_t));
 
     if(check_buffer(mb, alignment + array_size))
     {
@@ -162,7 +162,7 @@ bool deserialize_array_byte_4(mcMicroBuffer* mb, const Endianness endianness, ui
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t array_size = size * data_size;
-    uint32_t alignment = get_alignment_offset(mb, sizeof(uint32_t));
+    uint32_t alignment = mc_micro_buffer_alignment(mb, sizeof(uint32_t));
 
     if(check_buffer(mb, alignment + array_size))
     {
@@ -189,7 +189,7 @@ bool deserialize_array_byte_8(mcMicroBuffer* mb, const Endianness endianness, ui
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t array_size = size * data_size;
-    uint32_t alignment = get_alignment_offset(mb, sizeof(uint64_t));
+    uint32_t alignment = mc_micro_buffer_alignment(mb, sizeof(uint64_t));
 
     if(check_buffer(mb, alignment + array_size))
     {

--- a/src/c/types/array.c
+++ b/src/c/types/array.c
@@ -118,7 +118,7 @@ bool serialize_array_byte_8(mcMicroBuffer* mb, const Endianness endianness, cons
     return !mb->error;
 }
 
-bool deserialize_array_byte_1(mcMicroBuffer* mb, uint8_t* array, const uint32_t size)
+bool mc_deserialize_array_byte_1(mcMicroBuffer* mb, uint8_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint8_t);
     if(check_buffer(mb, size))
@@ -131,7 +131,7 @@ bool deserialize_array_byte_1(mcMicroBuffer* mb, uint8_t* array, const uint32_t 
     return !mb->error;
 }
 
-bool deserialize_array_byte_2(mcMicroBuffer* mb, const Endianness endianness, uint16_t* array, const uint32_t size)
+bool mc_deserialize_array_byte_2(mcMicroBuffer* mb, const Endianness endianness, uint16_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t array_size = size * data_size;
@@ -151,14 +151,14 @@ bool deserialize_array_byte_2(mcMicroBuffer* mb, const Endianness endianness, ui
         {
             for(uint32_t i = 0; i < size; i++)
             {
-                deserialize_byte_2(mb, endianness, array + i);
+                mc_deserialize_byte_2(mb, endianness, array + i);
             }
         }
     }
     return !mb->error;
 }
 
-bool deserialize_array_byte_4(mcMicroBuffer* mb, const Endianness endianness, uint32_t* array, const uint32_t size)
+bool mc_deserialize_array_byte_4(mcMicroBuffer* mb, const Endianness endianness, uint32_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t array_size = size * data_size;
@@ -178,14 +178,14 @@ bool deserialize_array_byte_4(mcMicroBuffer* mb, const Endianness endianness, ui
         {
             for(uint32_t i = 0; i < size; i++)
             {
-                deserialize_byte_4(mb, endianness, array + i);
+                mc_deserialize_byte_4(mb, endianness, array + i);
             }
         }
     }
     return !mb->error;
 }
 
-bool deserialize_array_byte_8(mcMicroBuffer* mb, const Endianness endianness, uint64_t* array, const uint32_t size)
+bool mc_deserialize_array_byte_8(mcMicroBuffer* mb, const Endianness endianness, uint64_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t array_size = size * data_size;
@@ -205,7 +205,7 @@ bool deserialize_array_byte_8(mcMicroBuffer* mb, const Endianness endianness, ui
         {
             for(uint32_t i = 0; i < size; i++)
             {
-                deserialize_byte_8(mb, endianness, array + i);
+                mc_deserialize_byte_8(mb, endianness, array + i);
             }
         }
     }
@@ -276,64 +276,64 @@ bool serialize_array_double(mcMicroBuffer* mb, const double* array, const uint32
     return serialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
-bool deserialize_array_char(mcMicroBuffer* mb, char* array, const uint32_t size)
+bool mc_deserialize_array_char(mcMicroBuffer* mb, char* array, const uint32_t size)
 {
-    return deserialize_array_byte_1(mb, (uint8_t*)array, size);
+    return mc_deserialize_array_byte_1(mb, (uint8_t*)array, size);
 }
 
-bool deserialize_array_bool(mcMicroBuffer* mb, bool* array, const uint32_t size)
+bool mc_deserialize_array_bool(mcMicroBuffer* mb, bool* array, const uint32_t size)
 {
-    return deserialize_array_byte_1(mb, (uint8_t*)array, size);
+    return mc_deserialize_array_byte_1(mb, (uint8_t*)array, size);
 }
 
-bool deserialize_array_uint8_t(mcMicroBuffer* mb, uint8_t* array, const uint32_t size)
+bool mc_deserialize_array_uint8_t(mcMicroBuffer* mb, uint8_t* array, const uint32_t size)
 {
-    return deserialize_array_byte_1(mb, array, size);
+    return mc_deserialize_array_byte_1(mb, array, size);
 }
 
-bool deserialize_array_uint16_t(mcMicroBuffer* mb, uint16_t* array, const uint32_t size)
+bool mc_deserialize_array_uint16_t(mcMicroBuffer* mb, uint16_t* array, const uint32_t size)
 {
-    return deserialize_array_byte_2(mb, mb->endianness, array, size);
+    return mc_deserialize_array_byte_2(mb, mb->endianness, array, size);
 }
 
-bool deserialize_array_uint32_t(mcMicroBuffer* mb, uint32_t* array, const uint32_t size)
+bool mc_deserialize_array_uint32_t(mcMicroBuffer* mb, uint32_t* array, const uint32_t size)
 {
-    return deserialize_array_byte_4(mb, mb->endianness, array, size);
+    return mc_deserialize_array_byte_4(mb, mb->endianness, array, size);
 }
 
-bool deserialize_array_uint64_t(mcMicroBuffer* mb, uint64_t* array, const uint32_t size)
+bool mc_deserialize_array_uint64_t(mcMicroBuffer* mb, uint64_t* array, const uint32_t size)
 {
-    return deserialize_array_byte_8(mb, mb->endianness, array, size);
+    return mc_deserialize_array_byte_8(mb, mb->endianness, array, size);
 }
 
-bool deserialize_array_int8_t(mcMicroBuffer* mb, int8_t* array, const uint32_t size)
+bool mc_deserialize_array_int8_t(mcMicroBuffer* mb, int8_t* array, const uint32_t size)
 {
-    return deserialize_array_byte_1(mb, (uint8_t*)array, size);
+    return mc_deserialize_array_byte_1(mb, (uint8_t*)array, size);
 }
 
-bool deserialize_array_int16_t(mcMicroBuffer* mb, int16_t* array, const uint32_t size)
+bool mc_deserialize_array_int16_t(mcMicroBuffer* mb, int16_t* array, const uint32_t size)
 {
-    return deserialize_array_byte_2(mb, mb->endianness, (uint16_t*)array, size);
+    return mc_deserialize_array_byte_2(mb, mb->endianness, (uint16_t*)array, size);
 }
 
-bool deserialize_array_int32_t(mcMicroBuffer* mb, int32_t* array, const uint32_t size)
+bool mc_deserialize_array_int32_t(mcMicroBuffer* mb, int32_t* array, const uint32_t size)
 {
-    return deserialize_array_byte_4(mb, mb->endianness, (uint32_t*)array, size);
+    return mc_deserialize_array_byte_4(mb, mb->endianness, (uint32_t*)array, size);
 }
 
-bool deserialize_array_int64_t(mcMicroBuffer* mb, int64_t* array, const uint32_t size)
+bool mc_deserialize_array_int64_t(mcMicroBuffer* mb, int64_t* array, const uint32_t size)
 {
-    return deserialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
+    return mc_deserialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
-bool deserialize_array_float(mcMicroBuffer* mb, float* array, const uint32_t size)
+bool mc_deserialize_array_float(mcMicroBuffer* mb, float* array, const uint32_t size)
 {
-    return deserialize_array_byte_4(mb, mb->endianness, (uint32_t*)array, size);
+    return mc_deserialize_array_byte_4(mb, mb->endianness, (uint32_t*)array, size);
 }
 
-bool deserialize_array_double(mcMicroBuffer* mb, double* array, const uint32_t size)
+bool mc_deserialize_array_double(mcMicroBuffer* mb, double* array, const uint32_t size)
 {
-    return deserialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
+    return mc_deserialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
 bool serialize_endian_array_uint16_t(mcMicroBuffer* mb, const Endianness endianness, const uint16_t* array, const uint32_t size)
@@ -376,43 +376,43 @@ bool serialize_endian_array_double(mcMicroBuffer* mb, const Endianness endiannes
     return serialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool deserialize_endian_array_uint16_t(mcMicroBuffer* mb, const Endianness endianness, uint16_t* array, const uint32_t size)
+bool mc_deserialize_endian_array_uint16_t(mcMicroBuffer* mb, const Endianness endianness, uint16_t* array, const uint32_t size)
 {
-    return deserialize_array_byte_2(mb, endianness, array, size);
+    return mc_deserialize_array_byte_2(mb, endianness, array, size);
 }
 
-bool deserialize_endian_array_uint32_t(mcMicroBuffer* mb, const Endianness endianness, uint32_t* array, const uint32_t size)
+bool mc_deserialize_endian_array_uint32_t(mcMicroBuffer* mb, const Endianness endianness, uint32_t* array, const uint32_t size)
 {
-    return deserialize_array_byte_4(mb, endianness, array, size);
+    return mc_deserialize_array_byte_4(mb, endianness, array, size);
 }
 
-bool deserialize_endian_array_uint64_t(mcMicroBuffer* mb, const Endianness endianness, uint64_t* array, const uint32_t size)
+bool mc_deserialize_endian_array_uint64_t(mcMicroBuffer* mb, const Endianness endianness, uint64_t* array, const uint32_t size)
 {
-    return deserialize_array_byte_8(mb, endianness, array, size);
+    return mc_deserialize_array_byte_8(mb, endianness, array, size);
 }
 
-bool deserialize_endian_array_int16_t(mcMicroBuffer* mb, const Endianness endianness, int16_t* array, const uint32_t size)
+bool mc_deserialize_endian_array_int16_t(mcMicroBuffer* mb, const Endianness endianness, int16_t* array, const uint32_t size)
 {
-    return deserialize_array_byte_2(mb, endianness, (uint16_t*)array, size);
+    return mc_deserialize_array_byte_2(mb, endianness, (uint16_t*)array, size);
 }
 
-bool deserialize_endian_array_int32_t(mcMicroBuffer* mb, const Endianness endianness, int32_t* array, const uint32_t size)
+bool mc_deserialize_endian_array_int32_t(mcMicroBuffer* mb, const Endianness endianness, int32_t* array, const uint32_t size)
 {
-    return deserialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
+    return mc_deserialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool deserialize_endian_array_int64_t(mcMicroBuffer* mb, const Endianness endianness, int64_t* array, const uint32_t size)
+bool mc_deserialize_endian_array_int64_t(mcMicroBuffer* mb, const Endianness endianness, int64_t* array, const uint32_t size)
 {
-    return deserialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
+    return mc_deserialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool deserialize_endian_array_float(mcMicroBuffer* mb, const Endianness endianness, float* array, const uint32_t size)
+bool mc_deserialize_endian_array_float(mcMicroBuffer* mb, const Endianness endianness, float* array, const uint32_t size)
 {
-    return deserialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
+    return mc_deserialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool deserialize_endian_array_double(mcMicroBuffer* mb, const Endianness endianness, double* array, const uint32_t size)
+bool mc_deserialize_endian_array_double(mcMicroBuffer* mb, const Endianness endianness, double* array, const uint32_t size)
 {
-    return deserialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
+    return mc_deserialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 

--- a/src/c/types/array.c
+++ b/src/c/types/array.c
@@ -24,7 +24,7 @@
 //                INTERNAL SERIALIZATION IMPLEMENTATION
 // -------------------------------------------------------------------
 
-bool mc_serialize_array_byte_1(mcMicroBuffer* mb, const uint8_t* array, const uint32_t size)
+bool serialize_array_byte_1(mcMicroBuffer* mb, const uint8_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint8_t);
     if(check_buffer(mb, size))
@@ -37,7 +37,7 @@ bool mc_serialize_array_byte_1(mcMicroBuffer* mb, const uint8_t* array, const ui
     return !mb->error;
 }
 
-bool mc_serialize_array_byte_2(mcMicroBuffer* mb, const Endianness endianness, const uint16_t* array, const uint32_t size)
+bool serialize_array_byte_2(mcMicroBuffer* mb, const Endianness endianness, const uint16_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t array_size = size * data_size;
@@ -57,14 +57,14 @@ bool mc_serialize_array_byte_2(mcMicroBuffer* mb, const Endianness endianness, c
         {
             for(uint32_t i = 0; i < size; i++)
             {
-                mc_serialize_byte_2(mb, endianness, array + i);
+                serialize_byte_2(mb, endianness, array + i);
             }
         }
     }
     return !mb->error;
 }
 
-bool mc_serialize_array_byte_4(mcMicroBuffer* mb, const Endianness endianness, const uint32_t* array, const uint32_t size)
+bool serialize_array_byte_4(mcMicroBuffer* mb, const Endianness endianness, const uint32_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t array_size = size * data_size;
@@ -84,14 +84,14 @@ bool mc_serialize_array_byte_4(mcMicroBuffer* mb, const Endianness endianness, c
         {
             for(uint32_t i = 0; i < size; i++)
             {
-                mc_serialize_byte_4(mb, endianness, array + i);
+                serialize_byte_4(mb, endianness, array + i);
             }
         }
     }
     return !mb->error;
 }
 
-bool mc_serialize_array_byte_8(mcMicroBuffer* mb, const Endianness endianness, const uint64_t* array, const uint32_t size)
+bool serialize_array_byte_8(mcMicroBuffer* mb, const Endianness endianness, const uint64_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t array_size = size * data_size;
@@ -111,14 +111,14 @@ bool mc_serialize_array_byte_8(mcMicroBuffer* mb, const Endianness endianness, c
         {
             for(uint32_t i = 0; i < size; i++)
             {
-                mc_serialize_byte_8(mb, endianness, array + i);
+                serialize_byte_8(mb, endianness, array + i);
             }
         }
     }
     return !mb->error;
 }
 
-bool mc_deserialize_array_byte_1(mcMicroBuffer* mb, uint8_t* array, const uint32_t size)
+bool deserialize_array_byte_1(mcMicroBuffer* mb, uint8_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint8_t);
     if(check_buffer(mb, size))
@@ -131,7 +131,7 @@ bool mc_deserialize_array_byte_1(mcMicroBuffer* mb, uint8_t* array, const uint32
     return !mb->error;
 }
 
-bool mc_deserialize_array_byte_2(mcMicroBuffer* mb, const Endianness endianness, uint16_t* array, const uint32_t size)
+bool deserialize_array_byte_2(mcMicroBuffer* mb, const Endianness endianness, uint16_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t array_size = size * data_size;
@@ -151,14 +151,14 @@ bool mc_deserialize_array_byte_2(mcMicroBuffer* mb, const Endianness endianness,
         {
             for(uint32_t i = 0; i < size; i++)
             {
-                mc_deserialize_byte_2(mb, endianness, array + i);
+                deserialize_byte_2(mb, endianness, array + i);
             }
         }
     }
     return !mb->error;
 }
 
-bool mc_deserialize_array_byte_4(mcMicroBuffer* mb, const Endianness endianness, uint32_t* array, const uint32_t size)
+bool deserialize_array_byte_4(mcMicroBuffer* mb, const Endianness endianness, uint32_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t array_size = size * data_size;
@@ -178,14 +178,14 @@ bool mc_deserialize_array_byte_4(mcMicroBuffer* mb, const Endianness endianness,
         {
             for(uint32_t i = 0; i < size; i++)
             {
-                mc_deserialize_byte_4(mb, endianness, array + i);
+                deserialize_byte_4(mb, endianness, array + i);
             }
         }
     }
     return !mb->error;
 }
 
-bool mc_deserialize_array_byte_8(mcMicroBuffer* mb, const Endianness endianness, uint64_t* array, const uint32_t size)
+bool deserialize_array_byte_8(mcMicroBuffer* mb, const Endianness endianness, uint64_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t array_size = size * data_size;
@@ -205,7 +205,7 @@ bool mc_deserialize_array_byte_8(mcMicroBuffer* mb, const Endianness endianness,
         {
             for(uint32_t i = 0; i < size; i++)
             {
-                mc_deserialize_byte_8(mb, endianness, array + i);
+                deserialize_byte_8(mb, endianness, array + i);
             }
         }
     }
@@ -218,201 +218,201 @@ bool mc_deserialize_array_byte_8(mcMicroBuffer* mb, const Endianness endianness,
 
 bool mc_serialize_array_char(mcMicroBuffer* mb, const char* array, const uint32_t size)
 {
-    return mc_serialize_array_byte_1(mb, (uint8_t*)array, size);
+    return serialize_array_byte_1(mb, (uint8_t*)array, size);
 }
 
 bool mc_serialize_array_bool(mcMicroBuffer* mb, const bool* array, const uint32_t size)
 {
-    return mc_serialize_array_byte_1(mb, (uint8_t*)array, size);
+    return serialize_array_byte_1(mb, (uint8_t*)array, size);
 }
 
 bool mc_serialize_array_uint8_t(mcMicroBuffer* mb, const uint8_t* array, const uint32_t size)
 {
-    return mc_serialize_array_byte_1(mb, array, size);
+    return serialize_array_byte_1(mb, array, size);
 }
 
 bool mc_serialize_array_uint16_t(mcMicroBuffer* mb, const uint16_t* array, const uint32_t size)
 {
-    return mc_serialize_array_byte_2(mb, mb->endianness, array, size);
+    return serialize_array_byte_2(mb, mb->endianness, array, size);
 }
 
 bool mc_serialize_array_uint32_t(mcMicroBuffer* mb, const uint32_t* array, const uint32_t size)
 {
-    return mc_serialize_array_byte_4(mb, mb->endianness, array, size);
+    return serialize_array_byte_4(mb, mb->endianness, array, size);
 }
 
 bool mc_serialize_array_uint64_t(mcMicroBuffer* mb, const uint64_t* array, const uint32_t size)
 {
-    return mc_serialize_array_byte_8(mb, mb->endianness, array, size);
+    return serialize_array_byte_8(mb, mb->endianness, array, size);
 }
 
 bool mc_serialize_array_int8_t(mcMicroBuffer* mb, const int8_t* array, const uint32_t size)
 {
-    return mc_serialize_array_byte_1(mb, (uint8_t*)array, size);
+    return serialize_array_byte_1(mb, (uint8_t*)array, size);
 }
 
 bool mc_serialize_array_int16_t(mcMicroBuffer* mb, const int16_t* array, const uint32_t size)
 {
-    return mc_serialize_array_byte_2(mb, mb->endianness, (uint16_t*)array, size);
+    return serialize_array_byte_2(mb, mb->endianness, (uint16_t*)array, size);
 }
 
 bool mc_serialize_array_int32_t(mcMicroBuffer* mb, const int32_t* array, const uint32_t size)
 {
-    return mc_serialize_array_byte_4(mb, mb->endianness, (uint32_t*)array, size);
+    return serialize_array_byte_4(mb, mb->endianness, (uint32_t*)array, size);
 }
 
 bool mc_serialize_array_int64_t(mcMicroBuffer* mb, const int64_t* array, const uint32_t size)
 {
-    return mc_serialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
+    return serialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
 bool mc_serialize_array_float(mcMicroBuffer* mb, const float* array, const uint32_t size)
 {
-    return mc_serialize_array_byte_4(mb, mb->endianness, (uint32_t*)array, size);
+    return serialize_array_byte_4(mb, mb->endianness, (uint32_t*)array, size);
 }
 
 bool mc_serialize_array_double(mcMicroBuffer* mb, const double* array, const uint32_t size)
 {
-    return mc_serialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
+    return serialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
 bool mc_deserialize_array_char(mcMicroBuffer* mb, char* array, const uint32_t size)
 {
-    return mc_deserialize_array_byte_1(mb, (uint8_t*)array, size);
+    return deserialize_array_byte_1(mb, (uint8_t*)array, size);
 }
 
 bool mc_deserialize_array_bool(mcMicroBuffer* mb, bool* array, const uint32_t size)
 {
-    return mc_deserialize_array_byte_1(mb, (uint8_t*)array, size);
+    return deserialize_array_byte_1(mb, (uint8_t*)array, size);
 }
 
 bool mc_deserialize_array_uint8_t(mcMicroBuffer* mb, uint8_t* array, const uint32_t size)
 {
-    return mc_deserialize_array_byte_1(mb, array, size);
+    return deserialize_array_byte_1(mb, array, size);
 }
 
 bool mc_deserialize_array_uint16_t(mcMicroBuffer* mb, uint16_t* array, const uint32_t size)
 {
-    return mc_deserialize_array_byte_2(mb, mb->endianness, array, size);
+    return deserialize_array_byte_2(mb, mb->endianness, array, size);
 }
 
 bool mc_deserialize_array_uint32_t(mcMicroBuffer* mb, uint32_t* array, const uint32_t size)
 {
-    return mc_deserialize_array_byte_4(mb, mb->endianness, array, size);
+    return deserialize_array_byte_4(mb, mb->endianness, array, size);
 }
 
 bool mc_deserialize_array_uint64_t(mcMicroBuffer* mb, uint64_t* array, const uint32_t size)
 {
-    return mc_deserialize_array_byte_8(mb, mb->endianness, array, size);
+    return deserialize_array_byte_8(mb, mb->endianness, array, size);
 }
 
 bool mc_deserialize_array_int8_t(mcMicroBuffer* mb, int8_t* array, const uint32_t size)
 {
-    return mc_deserialize_array_byte_1(mb, (uint8_t*)array, size);
+    return deserialize_array_byte_1(mb, (uint8_t*)array, size);
 }
 
 bool mc_deserialize_array_int16_t(mcMicroBuffer* mb, int16_t* array, const uint32_t size)
 {
-    return mc_deserialize_array_byte_2(mb, mb->endianness, (uint16_t*)array, size);
+    return deserialize_array_byte_2(mb, mb->endianness, (uint16_t*)array, size);
 }
 
 bool mc_deserialize_array_int32_t(mcMicroBuffer* mb, int32_t* array, const uint32_t size)
 {
-    return mc_deserialize_array_byte_4(mb, mb->endianness, (uint32_t*)array, size);
+    return deserialize_array_byte_4(mb, mb->endianness, (uint32_t*)array, size);
 }
 
 bool mc_deserialize_array_int64_t(mcMicroBuffer* mb, int64_t* array, const uint32_t size)
 {
-    return mc_deserialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
+    return deserialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
 bool mc_deserialize_array_float(mcMicroBuffer* mb, float* array, const uint32_t size)
 {
-    return mc_deserialize_array_byte_4(mb, mb->endianness, (uint32_t*)array, size);
+    return deserialize_array_byte_4(mb, mb->endianness, (uint32_t*)array, size);
 }
 
 bool mc_deserialize_array_double(mcMicroBuffer* mb, double* array, const uint32_t size)
 {
-    return mc_deserialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
+    return deserialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
 bool mc_serialize_endian_array_uint16_t(mcMicroBuffer* mb, const Endianness endianness, const uint16_t* array, const uint32_t size)
 {
-    return mc_serialize_array_byte_2(mb, endianness, array, size);
+    return serialize_array_byte_2(mb, endianness, array, size);
 }
 
 bool mc_serialize_endian_array_uint32_t(mcMicroBuffer* mb, const Endianness endianness, const uint32_t* array, const uint32_t size)
 {
-    return mc_serialize_array_byte_4(mb, endianness, array, size);
+    return serialize_array_byte_4(mb, endianness, array, size);
 }
 
 bool mc_serialize_endian_array_uint64_t(mcMicroBuffer* mb, const Endianness endianness, const uint64_t* array, const uint32_t size)
 {
-    return mc_serialize_array_byte_8(mb, endianness, array, size);
+    return serialize_array_byte_8(mb, endianness, array, size);
 }
 
 bool mc_serialize_endian_array_int16_t(mcMicroBuffer* mb, const Endianness endianness, const int16_t* array, const uint32_t size)
 {
-    return mc_serialize_array_byte_2(mb, endianness, (uint16_t*)array, size);
+    return serialize_array_byte_2(mb, endianness, (uint16_t*)array, size);
 }
 
 bool mc_serialize_endian_array_int32_t(mcMicroBuffer* mb, const Endianness endianness, const int32_t* array, const uint32_t size)
 {
-    return mc_serialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
+    return serialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
 bool mc_serialize_endian_array_int64_t(mcMicroBuffer* mb, const Endianness endianness, const int64_t* array, const uint32_t size)
 {
-    return mc_serialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
+    return serialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
 bool mc_serialize_endian_array_float(mcMicroBuffer* mb, const Endianness endianness, const float* array, const uint32_t size)
 {
-    return mc_serialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
+    return serialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
 bool mc_serialize_endian_array_double(mcMicroBuffer* mb, const Endianness endianness, const double* array, const uint32_t size)
 {
-    return mc_serialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
+    return serialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
 bool mc_deserialize_endian_array_uint16_t(mcMicroBuffer* mb, const Endianness endianness, uint16_t* array, const uint32_t size)
 {
-    return mc_deserialize_array_byte_2(mb, endianness, array, size);
+    return deserialize_array_byte_2(mb, endianness, array, size);
 }
 
 bool mc_deserialize_endian_array_uint32_t(mcMicroBuffer* mb, const Endianness endianness, uint32_t* array, const uint32_t size)
 {
-    return mc_deserialize_array_byte_4(mb, endianness, array, size);
+    return deserialize_array_byte_4(mb, endianness, array, size);
 }
 
 bool mc_deserialize_endian_array_uint64_t(mcMicroBuffer* mb, const Endianness endianness, uint64_t* array, const uint32_t size)
 {
-    return mc_deserialize_array_byte_8(mb, endianness, array, size);
+    return deserialize_array_byte_8(mb, endianness, array, size);
 }
 
 bool mc_deserialize_endian_array_int16_t(mcMicroBuffer* mb, const Endianness endianness, int16_t* array, const uint32_t size)
 {
-    return mc_deserialize_array_byte_2(mb, endianness, (uint16_t*)array, size);
+    return deserialize_array_byte_2(mb, endianness, (uint16_t*)array, size);
 }
 
 bool mc_deserialize_endian_array_int32_t(mcMicroBuffer* mb, const Endianness endianness, int32_t* array, const uint32_t size)
 {
-    return mc_deserialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
+    return deserialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
 bool mc_deserialize_endian_array_int64_t(mcMicroBuffer* mb, const Endianness endianness, int64_t* array, const uint32_t size)
 {
-    return mc_deserialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
+    return deserialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
 bool mc_deserialize_endian_array_float(mcMicroBuffer* mb, const Endianness endianness, float* array, const uint32_t size)
 {
-    return mc_deserialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
+    return deserialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
 bool mc_deserialize_endian_array_double(mcMicroBuffer* mb, const Endianness endianness, double* array, const uint32_t size)
 {
-    return mc_deserialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
+    return deserialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 

--- a/src/c/types/array.c
+++ b/src/c/types/array.c
@@ -24,7 +24,7 @@
 //                INTERNAL SERIALIZATION IMPLEMENTATION
 // -------------------------------------------------------------------
 
-bool serialize_array_byte_1(mcMicroBuffer* mb, const uint8_t* array, const uint32_t size)
+bool mc_serialize_array_byte_1(mcMicroBuffer* mb, const uint8_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint8_t);
     if(check_buffer(mb, size))
@@ -37,7 +37,7 @@ bool serialize_array_byte_1(mcMicroBuffer* mb, const uint8_t* array, const uint3
     return !mb->error;
 }
 
-bool serialize_array_byte_2(mcMicroBuffer* mb, const Endianness endianness, const uint16_t* array, const uint32_t size)
+bool mc_serialize_array_byte_2(mcMicroBuffer* mb, const Endianness endianness, const uint16_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t array_size = size * data_size;
@@ -57,14 +57,14 @@ bool serialize_array_byte_2(mcMicroBuffer* mb, const Endianness endianness, cons
         {
             for(uint32_t i = 0; i < size; i++)
             {
-                serialize_byte_2(mb, endianness, array + i);
+                mc_serialize_byte_2(mb, endianness, array + i);
             }
         }
     }
     return !mb->error;
 }
 
-bool serialize_array_byte_4(mcMicroBuffer* mb, const Endianness endianness, const uint32_t* array, const uint32_t size)
+bool mc_serialize_array_byte_4(mcMicroBuffer* mb, const Endianness endianness, const uint32_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t array_size = size * data_size;
@@ -84,14 +84,14 @@ bool serialize_array_byte_4(mcMicroBuffer* mb, const Endianness endianness, cons
         {
             for(uint32_t i = 0; i < size; i++)
             {
-                serialize_byte_4(mb, endianness, array + i);
+                mc_serialize_byte_4(mb, endianness, array + i);
             }
         }
     }
     return !mb->error;
 }
 
-bool serialize_array_byte_8(mcMicroBuffer* mb, const Endianness endianness, const uint64_t* array, const uint32_t size)
+bool mc_serialize_array_byte_8(mcMicroBuffer* mb, const Endianness endianness, const uint64_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t array_size = size * data_size;
@@ -111,7 +111,7 @@ bool serialize_array_byte_8(mcMicroBuffer* mb, const Endianness endianness, cons
         {
             for(uint32_t i = 0; i < size; i++)
             {
-                serialize_byte_8(mb, endianness, array + i);
+                mc_serialize_byte_8(mb, endianness, array + i);
             }
         }
     }
@@ -216,64 +216,64 @@ bool mc_deserialize_array_byte_8(mcMicroBuffer* mb, const Endianness endianness,
 //              PUBLIC SERIALIZATION IMPLEMENTATIONS
 // -------------------------------------------------------------------
 
-bool serialize_array_char(mcMicroBuffer* mb, const char* array, const uint32_t size)
+bool mc_serialize_array_char(mcMicroBuffer* mb, const char* array, const uint32_t size)
 {
-    return serialize_array_byte_1(mb, (uint8_t*)array, size);
+    return mc_serialize_array_byte_1(mb, (uint8_t*)array, size);
 }
 
-bool serialize_array_bool(mcMicroBuffer* mb, const bool* array, const uint32_t size)
+bool mc_serialize_array_bool(mcMicroBuffer* mb, const bool* array, const uint32_t size)
 {
-    return serialize_array_byte_1(mb, (uint8_t*)array, size);
+    return mc_serialize_array_byte_1(mb, (uint8_t*)array, size);
 }
 
-bool serialize_array_uint8_t(mcMicroBuffer* mb, const uint8_t* array, const uint32_t size)
+bool mc_serialize_array_uint8_t(mcMicroBuffer* mb, const uint8_t* array, const uint32_t size)
 {
-    return serialize_array_byte_1(mb, array, size);
+    return mc_serialize_array_byte_1(mb, array, size);
 }
 
-bool serialize_array_uint16_t(mcMicroBuffer* mb, const uint16_t* array, const uint32_t size)
+bool mc_serialize_array_uint16_t(mcMicroBuffer* mb, const uint16_t* array, const uint32_t size)
 {
-    return serialize_array_byte_2(mb, mb->endianness, array, size);
+    return mc_serialize_array_byte_2(mb, mb->endianness, array, size);
 }
 
-bool serialize_array_uint32_t(mcMicroBuffer* mb, const uint32_t* array, const uint32_t size)
+bool mc_serialize_array_uint32_t(mcMicroBuffer* mb, const uint32_t* array, const uint32_t size)
 {
-    return serialize_array_byte_4(mb, mb->endianness, array, size);
+    return mc_serialize_array_byte_4(mb, mb->endianness, array, size);
 }
 
-bool serialize_array_uint64_t(mcMicroBuffer* mb, const uint64_t* array, const uint32_t size)
+bool mc_serialize_array_uint64_t(mcMicroBuffer* mb, const uint64_t* array, const uint32_t size)
 {
-    return serialize_array_byte_8(mb, mb->endianness, array, size);
+    return mc_serialize_array_byte_8(mb, mb->endianness, array, size);
 }
 
-bool serialize_array_int8_t(mcMicroBuffer* mb, const int8_t* array, const uint32_t size)
+bool mc_serialize_array_int8_t(mcMicroBuffer* mb, const int8_t* array, const uint32_t size)
 {
-    return serialize_array_byte_1(mb, (uint8_t*)array, size);
+    return mc_serialize_array_byte_1(mb, (uint8_t*)array, size);
 }
 
-bool serialize_array_int16_t(mcMicroBuffer* mb, const int16_t* array, const uint32_t size)
+bool mc_serialize_array_int16_t(mcMicroBuffer* mb, const int16_t* array, const uint32_t size)
 {
-    return serialize_array_byte_2(mb, mb->endianness, (uint16_t*)array, size);
+    return mc_serialize_array_byte_2(mb, mb->endianness, (uint16_t*)array, size);
 }
 
-bool serialize_array_int32_t(mcMicroBuffer* mb, const int32_t* array, const uint32_t size)
+bool mc_serialize_array_int32_t(mcMicroBuffer* mb, const int32_t* array, const uint32_t size)
 {
-    return serialize_array_byte_4(mb, mb->endianness, (uint32_t*)array, size);
+    return mc_serialize_array_byte_4(mb, mb->endianness, (uint32_t*)array, size);
 }
 
-bool serialize_array_int64_t(mcMicroBuffer* mb, const int64_t* array, const uint32_t size)
+bool mc_serialize_array_int64_t(mcMicroBuffer* mb, const int64_t* array, const uint32_t size)
 {
-    return serialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
+    return mc_serialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
-bool serialize_array_float(mcMicroBuffer* mb, const float* array, const uint32_t size)
+bool mc_serialize_array_float(mcMicroBuffer* mb, const float* array, const uint32_t size)
 {
-    return serialize_array_byte_4(mb, mb->endianness, (uint32_t*)array, size);
+    return mc_serialize_array_byte_4(mb, mb->endianness, (uint32_t*)array, size);
 }
 
-bool serialize_array_double(mcMicroBuffer* mb, const double* array, const uint32_t size)
+bool mc_serialize_array_double(mcMicroBuffer* mb, const double* array, const uint32_t size)
 {
-    return serialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
+    return mc_serialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
 bool mc_deserialize_array_char(mcMicroBuffer* mb, char* array, const uint32_t size)
@@ -336,44 +336,44 @@ bool mc_deserialize_array_double(mcMicroBuffer* mb, double* array, const uint32_
     return mc_deserialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
-bool serialize_endian_array_uint16_t(mcMicroBuffer* mb, const Endianness endianness, const uint16_t* array, const uint32_t size)
+bool mc_serialize_endian_array_uint16_t(mcMicroBuffer* mb, const Endianness endianness, const uint16_t* array, const uint32_t size)
 {
-    return serialize_array_byte_2(mb, endianness, array, size);
+    return mc_serialize_array_byte_2(mb, endianness, array, size);
 }
 
-bool serialize_endian_array_uint32_t(mcMicroBuffer* mb, const Endianness endianness, const uint32_t* array, const uint32_t size)
+bool mc_serialize_endian_array_uint32_t(mcMicroBuffer* mb, const Endianness endianness, const uint32_t* array, const uint32_t size)
 {
-    return serialize_array_byte_4(mb, endianness, array, size);
+    return mc_serialize_array_byte_4(mb, endianness, array, size);
 }
 
-bool serialize_endian_array_uint64_t(mcMicroBuffer* mb, const Endianness endianness, const uint64_t* array, const uint32_t size)
+bool mc_serialize_endian_array_uint64_t(mcMicroBuffer* mb, const Endianness endianness, const uint64_t* array, const uint32_t size)
 {
-    return serialize_array_byte_8(mb, endianness, array, size);
+    return mc_serialize_array_byte_8(mb, endianness, array, size);
 }
 
-bool serialize_endian_array_int16_t(mcMicroBuffer* mb, const Endianness endianness, const int16_t* array, const uint32_t size)
+bool mc_serialize_endian_array_int16_t(mcMicroBuffer* mb, const Endianness endianness, const int16_t* array, const uint32_t size)
 {
-    return serialize_array_byte_2(mb, endianness, (uint16_t*)array, size);
+    return mc_serialize_array_byte_2(mb, endianness, (uint16_t*)array, size);
 }
 
-bool serialize_endian_array_int32_t(mcMicroBuffer* mb, const Endianness endianness, const int32_t* array, const uint32_t size)
+bool mc_serialize_endian_array_int32_t(mcMicroBuffer* mb, const Endianness endianness, const int32_t* array, const uint32_t size)
 {
-    return serialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
+    return mc_serialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool serialize_endian_array_int64_t(mcMicroBuffer* mb, const Endianness endianness, const int64_t* array, const uint32_t size)
+bool mc_serialize_endian_array_int64_t(mcMicroBuffer* mb, const Endianness endianness, const int64_t* array, const uint32_t size)
 {
-    return serialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
+    return mc_serialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool serialize_endian_array_float(mcMicroBuffer* mb, const Endianness endianness, const float* array, const uint32_t size)
+bool mc_serialize_endian_array_float(mcMicroBuffer* mb, const Endianness endianness, const float* array, const uint32_t size)
 {
-    return serialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
+    return mc_serialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool serialize_endian_array_double(mcMicroBuffer* mb, const Endianness endianness, const double* array, const uint32_t size)
+bool mc_serialize_endian_array_double(mcMicroBuffer* mb, const Endianness endianness, const double* array, const uint32_t size)
 {
-    return serialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
+    return mc_serialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
 bool mc_deserialize_endian_array_uint16_t(mcMicroBuffer* mb, const Endianness endianness, uint16_t* array, const uint32_t size)

--- a/src/c/types/array_internals.h
+++ b/src/c/types/array_internals.h
@@ -25,15 +25,15 @@ extern "C" {
 // -------------------------------------------------------------------
 //                  INTERNAL SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
-bool serialize_array_byte_1(mcMicroBuffer* buffer, const uint8_t* array, const uint32_t size);
-bool serialize_array_byte_2(mcMicroBuffer* buffer, mrEndianness endianness, const uint16_t* array, const uint32_t size);
-bool serialize_array_byte_4(mcMicroBuffer* buffer, mrEndianness endianness, const uint32_t* array, const uint32_t size);
-bool serialize_array_byte_8(mcMicroBuffer* buffer, mrEndianness endianness, const uint64_t* array, const uint32_t size);
+bool serialize_array_byte_1(mcBuffer* buffer, const uint8_t* array, const uint32_t size);
+bool serialize_array_byte_2(mcBuffer* buffer, mrEndianness endianness, const uint16_t* array, const uint32_t size);
+bool serialize_array_byte_4(mcBuffer* buffer, mrEndianness endianness, const uint32_t* array, const uint32_t size);
+bool serialize_array_byte_8(mcBuffer* buffer, mrEndianness endianness, const uint64_t* array, const uint32_t size);
 
-bool deserialize_array_byte_1(mcMicroBuffer* buffer, uint8_t* array, const uint32_t size);
-bool deserialize_array_byte_2(mcMicroBuffer* buffer, mrEndianness endianness, uint16_t* array, const uint32_t size);
-bool deserialize_array_byte_4(mcMicroBuffer* buffer, mrEndianness endianness, uint32_t* array, const uint32_t size);
-bool deserialize_array_byte_8(mcMicroBuffer* buffer, mrEndianness endianness, uint64_t* array, const uint32_t size);
+bool deserialize_array_byte_1(mcBuffer* buffer, uint8_t* array, const uint32_t size);
+bool deserialize_array_byte_2(mcBuffer* buffer, mrEndianness endianness, uint16_t* array, const uint32_t size);
+bool deserialize_array_byte_4(mcBuffer* buffer, mrEndianness endianness, uint32_t* array, const uint32_t size);
+bool deserialize_array_byte_8(mcBuffer* buffer, mrEndianness endianness, uint64_t* array, const uint32_t size);
 
 #ifdef __cplusplus
 }

--- a/src/c/types/array_internals.h
+++ b/src/c/types/array_internals.h
@@ -26,14 +26,14 @@ extern "C" {
 //                  INTERNAL SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
 bool serialize_array_byte_1(mcMicroBuffer* buffer, const uint8_t* array, const uint32_t size);
-bool serialize_array_byte_2(mcMicroBuffer* buffer, Endianness endianness, const uint16_t* array, const uint32_t size);
-bool serialize_array_byte_4(mcMicroBuffer* buffer, Endianness endianness, const uint32_t* array, const uint32_t size);
-bool serialize_array_byte_8(mcMicroBuffer* buffer, Endianness endianness, const uint64_t* array, const uint32_t size);
+bool serialize_array_byte_2(mcMicroBuffer* buffer, mrEndianness endianness, const uint16_t* array, const uint32_t size);
+bool serialize_array_byte_4(mcMicroBuffer* buffer, mrEndianness endianness, const uint32_t* array, const uint32_t size);
+bool serialize_array_byte_8(mcMicroBuffer* buffer, mrEndianness endianness, const uint64_t* array, const uint32_t size);
 
 bool deserialize_array_byte_1(mcMicroBuffer* buffer, uint8_t* array, const uint32_t size);
-bool deserialize_array_byte_2(mcMicroBuffer* buffer, Endianness endianness, uint16_t* array, const uint32_t size);
-bool deserialize_array_byte_4(mcMicroBuffer* buffer, Endianness endianness, uint32_t* array, const uint32_t size);
-bool deserialize_array_byte_8(mcMicroBuffer* buffer, Endianness endianness, uint64_t* array, const uint32_t size);
+bool deserialize_array_byte_2(mcMicroBuffer* buffer, mrEndianness endianness, uint16_t* array, const uint32_t size);
+bool deserialize_array_byte_4(mcMicroBuffer* buffer, mrEndianness endianness, uint32_t* array, const uint32_t size);
+bool deserialize_array_byte_8(mcMicroBuffer* buffer, mrEndianness endianness, uint64_t* array, const uint32_t size);
 
 #ifdef __cplusplus
 }

--- a/src/c/types/array_internals.h
+++ b/src/c/types/array_internals.h
@@ -25,15 +25,15 @@ extern "C" {
 // -------------------------------------------------------------------
 //                  INTERNAL SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
-bool mc_serialize_array_byte_1(mcMicroBuffer* buffer, const uint8_t* array, const uint32_t size);
-bool mc_serialize_array_byte_2(mcMicroBuffer* buffer, Endianness endianness, const uint16_t* array, const uint32_t size);
-bool mc_serialize_array_byte_4(mcMicroBuffer* buffer, Endianness endianness, const uint32_t* array, const uint32_t size);
-bool mc_serialize_array_byte_8(mcMicroBuffer* buffer, Endianness endianness, const uint64_t* array, const uint32_t size);
+bool serialize_array_byte_1(mcMicroBuffer* buffer, const uint8_t* array, const uint32_t size);
+bool serialize_array_byte_2(mcMicroBuffer* buffer, Endianness endianness, const uint16_t* array, const uint32_t size);
+bool serialize_array_byte_4(mcMicroBuffer* buffer, Endianness endianness, const uint32_t* array, const uint32_t size);
+bool serialize_array_byte_8(mcMicroBuffer* buffer, Endianness endianness, const uint64_t* array, const uint32_t size);
 
-bool mc_deserialize_array_byte_1(mcMicroBuffer* buffer, uint8_t* array, const uint32_t size);
-bool mc_deserialize_array_byte_2(mcMicroBuffer* buffer, Endianness endianness, uint16_t* array, const uint32_t size);
-bool mc_deserialize_array_byte_4(mcMicroBuffer* buffer, Endianness endianness, uint32_t* array, const uint32_t size);
-bool mc_deserialize_array_byte_8(mcMicroBuffer* buffer, Endianness endianness, uint64_t* array, const uint32_t size);
+bool deserialize_array_byte_1(mcMicroBuffer* buffer, uint8_t* array, const uint32_t size);
+bool deserialize_array_byte_2(mcMicroBuffer* buffer, Endianness endianness, uint16_t* array, const uint32_t size);
+bool deserialize_array_byte_4(mcMicroBuffer* buffer, Endianness endianness, uint32_t* array, const uint32_t size);
+bool deserialize_array_byte_8(mcMicroBuffer* buffer, Endianness endianness, uint64_t* array, const uint32_t size);
 
 #ifdef __cplusplus
 }

--- a/src/c/types/array_internals.h
+++ b/src/c/types/array_internals.h
@@ -25,10 +25,10 @@ extern "C" {
 // -------------------------------------------------------------------
 //                  INTERNAL SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
-bool serialize_array_byte_1(mcMicroBuffer* buffer, const uint8_t* array, const uint32_t size);
-bool serialize_array_byte_2(mcMicroBuffer* buffer, Endianness endianness, const uint16_t* array, const uint32_t size);
-bool serialize_array_byte_4(mcMicroBuffer* buffer, Endianness endianness, const uint32_t* array, const uint32_t size);
-bool serialize_array_byte_8(mcMicroBuffer* buffer, Endianness endianness, const uint64_t* array, const uint32_t size);
+bool mc_serialize_array_byte_1(mcMicroBuffer* buffer, const uint8_t* array, const uint32_t size);
+bool mc_serialize_array_byte_2(mcMicroBuffer* buffer, Endianness endianness, const uint16_t* array, const uint32_t size);
+bool mc_serialize_array_byte_4(mcMicroBuffer* buffer, Endianness endianness, const uint32_t* array, const uint32_t size);
+bool mc_serialize_array_byte_8(mcMicroBuffer* buffer, Endianness endianness, const uint64_t* array, const uint32_t size);
 
 bool mc_deserialize_array_byte_1(mcMicroBuffer* buffer, uint8_t* array, const uint32_t size);
 bool mc_deserialize_array_byte_2(mcMicroBuffer* buffer, Endianness endianness, uint16_t* array, const uint32_t size);

--- a/src/c/types/array_internals.h
+++ b/src/c/types/array_internals.h
@@ -30,10 +30,10 @@ bool serialize_array_byte_2(mcMicroBuffer* buffer, Endianness endianness, const 
 bool serialize_array_byte_4(mcMicroBuffer* buffer, Endianness endianness, const uint32_t* array, const uint32_t size);
 bool serialize_array_byte_8(mcMicroBuffer* buffer, Endianness endianness, const uint64_t* array, const uint32_t size);
 
-bool deserialize_array_byte_1(mcMicroBuffer* buffer, uint8_t* array, const uint32_t size);
-bool deserialize_array_byte_2(mcMicroBuffer* buffer, Endianness endianness, uint16_t* array, const uint32_t size);
-bool deserialize_array_byte_4(mcMicroBuffer* buffer, Endianness endianness, uint32_t* array, const uint32_t size);
-bool deserialize_array_byte_8(mcMicroBuffer* buffer, Endianness endianness, uint64_t* array, const uint32_t size);
+bool mc_deserialize_array_byte_1(mcMicroBuffer* buffer, uint8_t* array, const uint32_t size);
+bool mc_deserialize_array_byte_2(mcMicroBuffer* buffer, Endianness endianness, uint16_t* array, const uint32_t size);
+bool mc_deserialize_array_byte_4(mcMicroBuffer* buffer, Endianness endianness, uint32_t* array, const uint32_t size);
+bool mc_deserialize_array_byte_8(mcMicroBuffer* buffer, Endianness endianness, uint64_t* array, const uint32_t size);
 
 #ifdef __cplusplus
 }

--- a/src/c/types/array_internals.h
+++ b/src/c/types/array_internals.h
@@ -26,14 +26,14 @@ extern "C" {
 //                  INTERNAL SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
 bool serialize_array_byte_1(mcBuffer* buffer, const uint8_t* array, const uint32_t size);
-bool serialize_array_byte_2(mcBuffer* buffer, mrEndianness endianness, const uint16_t* array, const uint32_t size);
-bool serialize_array_byte_4(mcBuffer* buffer, mrEndianness endianness, const uint32_t* array, const uint32_t size);
-bool serialize_array_byte_8(mcBuffer* buffer, mrEndianness endianness, const uint64_t* array, const uint32_t size);
+bool serialize_array_byte_2(mcBuffer* buffer, mcEndianness endianness, const uint16_t* array, const uint32_t size);
+bool serialize_array_byte_4(mcBuffer* buffer, mcEndianness endianness, const uint32_t* array, const uint32_t size);
+bool serialize_array_byte_8(mcBuffer* buffer, mcEndianness endianness, const uint64_t* array, const uint32_t size);
 
 bool deserialize_array_byte_1(mcBuffer* buffer, uint8_t* array, const uint32_t size);
-bool deserialize_array_byte_2(mcBuffer* buffer, mrEndianness endianness, uint16_t* array, const uint32_t size);
-bool deserialize_array_byte_4(mcBuffer* buffer, mrEndianness endianness, uint32_t* array, const uint32_t size);
-bool deserialize_array_byte_8(mcBuffer* buffer, mrEndianness endianness, uint64_t* array, const uint32_t size);
+bool deserialize_array_byte_2(mcBuffer* buffer, mcEndianness endianness, uint16_t* array, const uint32_t size);
+bool deserialize_array_byte_4(mcBuffer* buffer, mcEndianness endianness, uint32_t* array, const uint32_t size);
+bool deserialize_array_byte_8(mcBuffer* buffer, mcEndianness endianness, uint64_t* array, const uint32_t size);
 
 #ifdef __cplusplus
 }

--- a/src/c/types/array_internals.h
+++ b/src/c/types/array_internals.h
@@ -25,15 +25,15 @@ extern "C" {
 // -------------------------------------------------------------------
 //                  INTERNAL SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
-bool serialize_array_byte_1(MicroBuffer* buffer, const uint8_t* array, const uint32_t size);
-bool serialize_array_byte_2(MicroBuffer* buffer, Endianness endianness, const uint16_t* array, const uint32_t size);
-bool serialize_array_byte_4(MicroBuffer* buffer, Endianness endianness, const uint32_t* array, const uint32_t size);
-bool serialize_array_byte_8(MicroBuffer* buffer, Endianness endianness, const uint64_t* array, const uint32_t size);
+bool serialize_array_byte_1(mcMicroBuffer* buffer, const uint8_t* array, const uint32_t size);
+bool serialize_array_byte_2(mcMicroBuffer* buffer, Endianness endianness, const uint16_t* array, const uint32_t size);
+bool serialize_array_byte_4(mcMicroBuffer* buffer, Endianness endianness, const uint32_t* array, const uint32_t size);
+bool serialize_array_byte_8(mcMicroBuffer* buffer, Endianness endianness, const uint64_t* array, const uint32_t size);
 
-bool deserialize_array_byte_1(MicroBuffer* buffer, uint8_t* array, const uint32_t size);
-bool deserialize_array_byte_2(MicroBuffer* buffer, Endianness endianness, uint16_t* array, const uint32_t size);
-bool deserialize_array_byte_4(MicroBuffer* buffer, Endianness endianness, uint32_t* array, const uint32_t size);
-bool deserialize_array_byte_8(MicroBuffer* buffer, Endianness endianness, uint64_t* array, const uint32_t size);
+bool deserialize_array_byte_1(mcMicroBuffer* buffer, uint8_t* array, const uint32_t size);
+bool deserialize_array_byte_2(mcMicroBuffer* buffer, Endianness endianness, uint16_t* array, const uint32_t size);
+bool deserialize_array_byte_4(mcMicroBuffer* buffer, Endianness endianness, uint32_t* array, const uint32_t size);
+bool deserialize_array_byte_8(mcMicroBuffer* buffer, Endianness endianness, uint64_t* array, const uint32_t size);
 
 #ifdef __cplusplus
 }

--- a/src/c/types/basic.c
+++ b/src/c/types/basic.c
@@ -23,7 +23,7 @@
 //                INTERNAL SERIALIZATION IMPLEMENTATION
 // -------------------------------------------------------------------
 
-bool mc_serialize_byte_1(mcMicroBuffer* mb, const uint8_t* byte)
+bool serialize_byte_1(mcMicroBuffer* mb, const uint8_t* byte)
 {
     uint32_t data_size = sizeof(uint8_t);
     if(check_buffer(mb, data_size))
@@ -36,7 +36,7 @@ bool mc_serialize_byte_1(mcMicroBuffer* mb, const uint8_t* byte)
     return !mb->error;
 }
 
-bool mc_serialize_byte_2(mcMicroBuffer* mb, const Endianness endianness, const uint16_t* bytes)
+bool serialize_byte_2(mcMicroBuffer* mb, const Endianness endianness, const uint16_t* bytes)
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t alignment = get_alignment_offset(mb, data_size);
@@ -62,7 +62,7 @@ bool mc_serialize_byte_2(mcMicroBuffer* mb, const Endianness endianness, const u
     return !mb->error;
 }
 
-bool mc_serialize_byte_4(mcMicroBuffer* mb, const Endianness endianness, const uint32_t* bytes)
+bool serialize_byte_4(mcMicroBuffer* mb, const Endianness endianness, const uint32_t* bytes)
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t alignment = get_alignment_offset(mb, data_size);
@@ -90,7 +90,7 @@ bool mc_serialize_byte_4(mcMicroBuffer* mb, const Endianness endianness, const u
     return !mb->error;
 }
 
-bool mc_serialize_byte_8(mcMicroBuffer* mb, const Endianness endianness, const uint64_t* bytes)
+bool serialize_byte_8(mcMicroBuffer* mb, const Endianness endianness, const uint64_t* bytes)
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t alignment = get_alignment_offset(mb, data_size);
@@ -122,7 +122,7 @@ bool mc_serialize_byte_8(mcMicroBuffer* mb, const Endianness endianness, const u
     return !mb->error;
 }
 
-bool mc_deserialize_byte_1(mcMicroBuffer* mb, uint8_t* byte)
+bool deserialize_byte_1(mcMicroBuffer* mb, uint8_t* byte)
 {
     uint32_t data_size = sizeof(uint8_t);
     if(check_buffer(mb, data_size))
@@ -135,7 +135,7 @@ bool mc_deserialize_byte_1(mcMicroBuffer* mb, uint8_t* byte)
     return !mb->error;
 }
 
-bool mc_deserialize_byte_2(mcMicroBuffer* mb, const Endianness endianness, uint16_t* bytes)
+bool deserialize_byte_2(mcMicroBuffer* mb, const Endianness endianness, uint16_t* bytes)
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t alignment = get_alignment_offset(mb, data_size);
@@ -161,7 +161,7 @@ bool mc_deserialize_byte_2(mcMicroBuffer* mb, const Endianness endianness, uint1
     return !mb->error;
 }
 
-bool mc_deserialize_byte_4(mcMicroBuffer* mb, const Endianness endianness, uint32_t* bytes)
+bool deserialize_byte_4(mcMicroBuffer* mb, const Endianness endianness, uint32_t* bytes)
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t alignment = get_alignment_offset(mb, data_size);
@@ -189,7 +189,7 @@ bool mc_deserialize_byte_4(mcMicroBuffer* mb, const Endianness endianness, uint3
     return !mb->error;
 }
 
-bool mc_deserialize_byte_8(mcMicroBuffer* mb, const Endianness endianness, uint64_t* bytes)
+bool deserialize_byte_8(mcMicroBuffer* mb, const Endianness endianness, uint64_t* bytes)
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t alignment = get_alignment_offset(mb, data_size);
@@ -227,201 +227,201 @@ bool mc_deserialize_byte_8(mcMicroBuffer* mb, const Endianness endianness, uint6
 
 bool mc_serialize_char(mcMicroBuffer* mb, const char value)
 {
-    return mc_serialize_byte_1(mb, (uint8_t*)&value);
+    return serialize_byte_1(mb, (uint8_t*)&value);
 }
 
 bool mc_serialize_bool(mcMicroBuffer* mb, const bool value)
 {
-    return mc_serialize_byte_1(mb, (uint8_t*)&value);
+    return serialize_byte_1(mb, (uint8_t*)&value);
 }
 
 bool mc_serialize_uint8_t(mcMicroBuffer* mb, const uint8_t value)
 {
-    return mc_serialize_byte_1(mb, &value);
+    return serialize_byte_1(mb, &value);
 }
 
 bool mc_serialize_uint16_t(mcMicroBuffer* mb, const uint16_t value)
 {
-    return mc_serialize_byte_2(mb, mb->endianness, &value);
+    return serialize_byte_2(mb, mb->endianness, &value);
 }
 
 bool mc_serialize_uint32_t(mcMicroBuffer* mb, const uint32_t value)
 {
-    return mc_serialize_byte_4(mb, mb->endianness, &value);
+    return serialize_byte_4(mb, mb->endianness, &value);
 }
 
 bool mc_serialize_uint64_t(mcMicroBuffer* mb, const uint64_t value)
 {
-    return mc_serialize_byte_8(mb, mb->endianness, &value);
+    return serialize_byte_8(mb, mb->endianness, &value);
 }
 
 bool mc_serialize_int8_t(mcMicroBuffer* mb, const int8_t value)
 {
-    return mc_serialize_byte_1(mb, (uint8_t*)&value);
+    return serialize_byte_1(mb, (uint8_t*)&value);
 }
 
 bool mc_serialize_int16_t(mcMicroBuffer* mb, const int16_t value)
 {
-    return mc_serialize_byte_2(mb, mb->endianness, (uint16_t*)&value);
+    return serialize_byte_2(mb, mb->endianness, (uint16_t*)&value);
 }
 
 bool mc_serialize_int32_t(mcMicroBuffer* mb, const int32_t value)
 {
-    return mc_serialize_byte_4(mb, mb->endianness, (uint32_t*)&value);
+    return serialize_byte_4(mb, mb->endianness, (uint32_t*)&value);
 }
 
 bool mc_serialize_int64_t(mcMicroBuffer* mb, const int64_t value)
 {
-    return mc_serialize_byte_8(mb, mb->endianness, (uint64_t*)&value);
+    return serialize_byte_8(mb, mb->endianness, (uint64_t*)&value);
 }
 
 bool mc_serialize_float(mcMicroBuffer* mb, const float value)
 {
-    return mc_serialize_byte_4(mb, mb->endianness, (uint32_t*)&value);
+    return serialize_byte_4(mb, mb->endianness, (uint32_t*)&value);
 }
 
 bool mc_serialize_double(mcMicroBuffer* mb, const double value)
 {
-    return mc_serialize_byte_8(mb, mb->endianness, (uint64_t*)&value);
+    return serialize_byte_8(mb, mb->endianness, (uint64_t*)&value);
 }
 
 bool mc_deserialize_char(mcMicroBuffer* mb, char* value)
 {
-    return mc_deserialize_byte_1(mb, (uint8_t*)value);
+    return deserialize_byte_1(mb, (uint8_t*)value);
 }
 
 bool mc_deserialize_bool(mcMicroBuffer* mb, bool* value)
 {
-    return mc_deserialize_byte_1(mb, (uint8_t*)value);
+    return deserialize_byte_1(mb, (uint8_t*)value);
 }
 
 bool mc_deserialize_uint8_t(mcMicroBuffer* mb, uint8_t* value)
 {
-    return mc_deserialize_byte_1(mb, value);
+    return deserialize_byte_1(mb, value);
 }
 
 bool mc_deserialize_uint16_t(mcMicroBuffer* mb, uint16_t* value)
 {
-    return mc_deserialize_byte_2(mb, mb->endianness, value);
+    return deserialize_byte_2(mb, mb->endianness, value);
 }
 
 bool mc_deserialize_uint32_t(mcMicroBuffer* mb, uint32_t* value)
 {
-    return mc_deserialize_byte_4(mb, mb->endianness, value);
+    return deserialize_byte_4(mb, mb->endianness, value);
 }
 
 bool mc_deserialize_uint64_t(mcMicroBuffer* mb, uint64_t* value)
 {
-    return mc_deserialize_byte_8(mb, mb->endianness, value);
+    return deserialize_byte_8(mb, mb->endianness, value);
 }
 
 bool mc_deserialize_int8_t(mcMicroBuffer* mb, int8_t* value)
 {
-    return mc_deserialize_byte_1(mb, (uint8_t*)value);
+    return deserialize_byte_1(mb, (uint8_t*)value);
 }
 
 bool mc_deserialize_int16_t(mcMicroBuffer* mb, int16_t* value)
 {
-    return mc_deserialize_byte_2(mb, mb->endianness, (uint16_t*)value);
+    return deserialize_byte_2(mb, mb->endianness, (uint16_t*)value);
 }
 
 bool mc_deserialize_int32_t(mcMicroBuffer* mb, int32_t* value)
 {
-    return mc_deserialize_byte_4(mb, mb->endianness, (uint32_t*)value);
+    return deserialize_byte_4(mb, mb->endianness, (uint32_t*)value);
 }
 
 bool mc_deserialize_int64_t(mcMicroBuffer* mb, int64_t* value)
 {
-    return mc_deserialize_byte_8(mb, mb->endianness, (uint64_t*)value);
+    return deserialize_byte_8(mb, mb->endianness, (uint64_t*)value);
 }
 
 bool mc_deserialize_float(mcMicroBuffer* mb, float* value)
 {
-    return mc_deserialize_byte_4(mb, mb->endianness, (uint32_t*)value);
+    return deserialize_byte_4(mb, mb->endianness, (uint32_t*)value);
 }
 
 bool mc_deserialize_double(mcMicroBuffer* mb, double* value)
 {
-    return mc_deserialize_byte_8(mb, mb->endianness, (uint64_t*)value);
+    return deserialize_byte_8(mb, mb->endianness, (uint64_t*)value);
 }
 
 bool mc_serialize_endian_uint16_t(mcMicroBuffer* mb, const Endianness endianness, const uint16_t value)
 {
-    return mc_serialize_byte_2(mb, endianness, &value);
+    return serialize_byte_2(mb, endianness, &value);
 }
 
 bool mc_serialize_endian_uint32_t(mcMicroBuffer* mb, const Endianness endianness, const uint32_t value)
 {
-    return mc_serialize_byte_4(mb, endianness, &value);
+    return serialize_byte_4(mb, endianness, &value);
 }
 
 bool mc_serialize_endian_uint64_t(mcMicroBuffer* mb, const Endianness endianness, const uint64_t value)
 {
-    return mc_serialize_byte_8(mb, endianness, &value);
+    return serialize_byte_8(mb, endianness, &value);
 }
 
 bool mc_serialize_endian_int16_t(mcMicroBuffer* mb, const Endianness endianness, const int16_t value)
 {
-    return mc_serialize_byte_2(mb, endianness, (uint16_t*)&value);
+    return serialize_byte_2(mb, endianness, (uint16_t*)&value);
 }
 
 bool mc_serialize_endian_int32_t(mcMicroBuffer* mb, const Endianness endianness, const int32_t value)
 {
-    return mc_serialize_byte_4(mb, endianness, (uint32_t*)&value);
+    return serialize_byte_4(mb, endianness, (uint32_t*)&value);
 }
 
 bool mc_serialize_endian_int64_t(mcMicroBuffer* mb, const Endianness endianness, const int64_t value)
 {
-    return mc_serialize_byte_8(mb, endianness, (uint64_t*)&value);
+    return serialize_byte_8(mb, endianness, (uint64_t*)&value);
 }
 
 bool mc_serialize_endian_float(mcMicroBuffer* mb, const Endianness endianness, const float value)
 {
-    return mc_serialize_byte_4(mb, endianness, (uint32_t*)&value);
+    return serialize_byte_4(mb, endianness, (uint32_t*)&value);
 }
 
 bool mc_serialize_endian_double(mcMicroBuffer* mb, const Endianness endianness, const double value)
 {
-    return mc_serialize_byte_8(mb, endianness, (uint64_t*)&value);
+    return serialize_byte_8(mb, endianness, (uint64_t*)&value);
 }
 
 bool mc_deserialize_endian_uint16_t(mcMicroBuffer* mb, const Endianness endianness, uint16_t* value)
 {
-    return mc_deserialize_byte_2(mb, endianness, value);
+    return deserialize_byte_2(mb, endianness, value);
 }
 
 bool mc_deserialize_endian_uint32_t(mcMicroBuffer* mb, const Endianness endianness, uint32_t* value)
 {
-    return mc_deserialize_byte_4(mb, endianness, value);
+    return deserialize_byte_4(mb, endianness, value);
 }
 
 bool mc_deserialize_endian_uint64_t(mcMicroBuffer* mb, const Endianness endianness, uint64_t* value)
 {
-    return mc_deserialize_byte_8(mb, endianness, value);
+    return deserialize_byte_8(mb, endianness, value);
 }
 
 bool mc_deserialize_endian_int16_t(mcMicroBuffer* mb, const Endianness endianness, int16_t* value)
 {
-    return mc_deserialize_byte_2(mb, endianness, (uint16_t*)value);
+    return deserialize_byte_2(mb, endianness, (uint16_t*)value);
 }
 
 bool mc_deserialize_endian_int32_t(mcMicroBuffer* mb, const Endianness endianness, int32_t* value)
 {
-    return mc_deserialize_byte_4(mb, endianness, (uint32_t*)value);
+    return deserialize_byte_4(mb, endianness, (uint32_t*)value);
 }
 
 bool mc_deserialize_endian_int64_t(mcMicroBuffer* mb, const Endianness endianness, int64_t* value)
 {
-    return mc_deserialize_byte_8(mb, endianness, (uint64_t*)value);
+    return deserialize_byte_8(mb, endianness, (uint64_t*)value);
 }
 
 bool mc_deserialize_endian_float(mcMicroBuffer* mb, const Endianness endianness, float* value)
 {
-    return mc_deserialize_byte_4(mb, endianness, (uint32_t*)value);
+    return deserialize_byte_4(mb, endianness, (uint32_t*)value);
 }
 
 bool mc_deserialize_endian_double(mcMicroBuffer* mb, const Endianness endianness, double* value)
 {
-    return mc_deserialize_byte_8(mb, endianness, (uint64_t*)value);
+    return deserialize_byte_8(mb, endianness, (uint64_t*)value);
 }
 

--- a/src/c/types/basic.c
+++ b/src/c/types/basic.c
@@ -122,7 +122,7 @@ bool serialize_byte_8(mcMicroBuffer* mb, const Endianness endianness, const uint
     return !mb->error;
 }
 
-bool deserialize_byte_1(mcMicroBuffer* mb, uint8_t* byte)
+bool mc_deserialize_byte_1(mcMicroBuffer* mb, uint8_t* byte)
 {
     uint32_t data_size = sizeof(uint8_t);
     if(check_buffer(mb, data_size))
@@ -135,7 +135,7 @@ bool deserialize_byte_1(mcMicroBuffer* mb, uint8_t* byte)
     return !mb->error;
 }
 
-bool deserialize_byte_2(mcMicroBuffer* mb, const Endianness endianness, uint16_t* bytes)
+bool mc_deserialize_byte_2(mcMicroBuffer* mb, const Endianness endianness, uint16_t* bytes)
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t alignment = get_alignment_offset(mb, data_size);
@@ -161,7 +161,7 @@ bool deserialize_byte_2(mcMicroBuffer* mb, const Endianness endianness, uint16_t
     return !mb->error;
 }
 
-bool deserialize_byte_4(mcMicroBuffer* mb, const Endianness endianness, uint32_t* bytes)
+bool mc_deserialize_byte_4(mcMicroBuffer* mb, const Endianness endianness, uint32_t* bytes)
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t alignment = get_alignment_offset(mb, data_size);
@@ -189,7 +189,7 @@ bool deserialize_byte_4(mcMicroBuffer* mb, const Endianness endianness, uint32_t
     return !mb->error;
 }
 
-bool deserialize_byte_8(mcMicroBuffer* mb, const Endianness endianness, uint64_t* bytes)
+bool mc_deserialize_byte_8(mcMicroBuffer* mb, const Endianness endianness, uint64_t* bytes)
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t alignment = get_alignment_offset(mb, data_size);
@@ -285,64 +285,64 @@ bool serialize_double(mcMicroBuffer* mb, const double value)
     return serialize_byte_8(mb, mb->endianness, (uint64_t*)&value);
 }
 
-bool deserialize_char(mcMicroBuffer* mb, char* value)
+bool mc_deserialize_char(mcMicroBuffer* mb, char* value)
 {
-    return deserialize_byte_1(mb, (uint8_t*)value);
+    return mc_deserialize_byte_1(mb, (uint8_t*)value);
 }
 
-bool deserialize_bool(mcMicroBuffer* mb, bool* value)
+bool mc_deserialize_bool(mcMicroBuffer* mb, bool* value)
 {
-    return deserialize_byte_1(mb, (uint8_t*)value);
+    return mc_deserialize_byte_1(mb, (uint8_t*)value);
 }
 
-bool deserialize_uint8_t(mcMicroBuffer* mb, uint8_t* value)
+bool mc_deserialize_uint8_t(mcMicroBuffer* mb, uint8_t* value)
 {
-    return deserialize_byte_1(mb, value);
+    return mc_deserialize_byte_1(mb, value);
 }
 
-bool deserialize_uint16_t(mcMicroBuffer* mb, uint16_t* value)
+bool mc_deserialize_uint16_t(mcMicroBuffer* mb, uint16_t* value)
 {
-    return deserialize_byte_2(mb, mb->endianness, value);
+    return mc_deserialize_byte_2(mb, mb->endianness, value);
 }
 
-bool deserialize_uint32_t(mcMicroBuffer* mb, uint32_t* value)
+bool mc_deserialize_uint32_t(mcMicroBuffer* mb, uint32_t* value)
 {
-    return deserialize_byte_4(mb, mb->endianness, value);
+    return mc_deserialize_byte_4(mb, mb->endianness, value);
 }
 
-bool deserialize_uint64_t(mcMicroBuffer* mb, uint64_t* value)
+bool mc_deserialize_uint64_t(mcMicroBuffer* mb, uint64_t* value)
 {
-    return deserialize_byte_8(mb, mb->endianness, value);
+    return mc_deserialize_byte_8(mb, mb->endianness, value);
 }
 
-bool deserialize_int8_t(mcMicroBuffer* mb, int8_t* value)
+bool mc_deserialize_int8_t(mcMicroBuffer* mb, int8_t* value)
 {
-    return deserialize_byte_1(mb, (uint8_t*)value);
+    return mc_deserialize_byte_1(mb, (uint8_t*)value);
 }
 
-bool deserialize_int16_t(mcMicroBuffer* mb, int16_t* value)
+bool mc_deserialize_int16_t(mcMicroBuffer* mb, int16_t* value)
 {
-    return deserialize_byte_2(mb, mb->endianness, (uint16_t*)value);
+    return mc_deserialize_byte_2(mb, mb->endianness, (uint16_t*)value);
 }
 
-bool deserialize_int32_t(mcMicroBuffer* mb, int32_t* value)
+bool mc_deserialize_int32_t(mcMicroBuffer* mb, int32_t* value)
 {
-    return deserialize_byte_4(mb, mb->endianness, (uint32_t*)value);
+    return mc_deserialize_byte_4(mb, mb->endianness, (uint32_t*)value);
 }
 
-bool deserialize_int64_t(mcMicroBuffer* mb, int64_t* value)
+bool mc_deserialize_int64_t(mcMicroBuffer* mb, int64_t* value)
 {
-    return deserialize_byte_8(mb, mb->endianness, (uint64_t*)value);
+    return mc_deserialize_byte_8(mb, mb->endianness, (uint64_t*)value);
 }
 
-bool deserialize_float(mcMicroBuffer* mb, float* value)
+bool mc_deserialize_float(mcMicroBuffer* mb, float* value)
 {
-    return deserialize_byte_4(mb, mb->endianness, (uint32_t*)value);
+    return mc_deserialize_byte_4(mb, mb->endianness, (uint32_t*)value);
 }
 
-bool deserialize_double(mcMicroBuffer* mb, double* value)
+bool mc_deserialize_double(mcMicroBuffer* mb, double* value)
 {
-    return deserialize_byte_8(mb, mb->endianness, (uint64_t*)value);
+    return mc_deserialize_byte_8(mb, mb->endianness, (uint64_t*)value);
 }
 
 bool serialize_endian_uint16_t(mcMicroBuffer* mb, const Endianness endianness, const uint16_t value)
@@ -385,43 +385,43 @@ bool serialize_endian_double(mcMicroBuffer* mb, const Endianness endianness, con
     return serialize_byte_8(mb, endianness, (uint64_t*)&value);
 }
 
-bool deserialize_endian_uint16_t(mcMicroBuffer* mb, const Endianness endianness, uint16_t* value)
+bool mc_deserialize_endian_uint16_t(mcMicroBuffer* mb, const Endianness endianness, uint16_t* value)
 {
-    return deserialize_byte_2(mb, endianness, value);
+    return mc_deserialize_byte_2(mb, endianness, value);
 }
 
-bool deserialize_endian_uint32_t(mcMicroBuffer* mb, const Endianness endianness, uint32_t* value)
+bool mc_deserialize_endian_uint32_t(mcMicroBuffer* mb, const Endianness endianness, uint32_t* value)
 {
-    return deserialize_byte_4(mb, endianness, value);
+    return mc_deserialize_byte_4(mb, endianness, value);
 }
 
-bool deserialize_endian_uint64_t(mcMicroBuffer* mb, const Endianness endianness, uint64_t* value)
+bool mc_deserialize_endian_uint64_t(mcMicroBuffer* mb, const Endianness endianness, uint64_t* value)
 {
-    return deserialize_byte_8(mb, endianness, value);
+    return mc_deserialize_byte_8(mb, endianness, value);
 }
 
-bool deserialize_endian_int16_t(mcMicroBuffer* mb, const Endianness endianness, int16_t* value)
+bool mc_deserialize_endian_int16_t(mcMicroBuffer* mb, const Endianness endianness, int16_t* value)
 {
-    return deserialize_byte_2(mb, endianness, (uint16_t*)value);
+    return mc_deserialize_byte_2(mb, endianness, (uint16_t*)value);
 }
 
-bool deserialize_endian_int32_t(mcMicroBuffer* mb, const Endianness endianness, int32_t* value)
+bool mc_deserialize_endian_int32_t(mcMicroBuffer* mb, const Endianness endianness, int32_t* value)
 {
-    return deserialize_byte_4(mb, endianness, (uint32_t*)value);
+    return mc_deserialize_byte_4(mb, endianness, (uint32_t*)value);
 }
 
-bool deserialize_endian_int64_t(mcMicroBuffer* mb, const Endianness endianness, int64_t* value)
+bool mc_deserialize_endian_int64_t(mcMicroBuffer* mb, const Endianness endianness, int64_t* value)
 {
-    return deserialize_byte_8(mb, endianness, (uint64_t*)value);
+    return mc_deserialize_byte_8(mb, endianness, (uint64_t*)value);
 }
 
-bool deserialize_endian_float(mcMicroBuffer* mb, const Endianness endianness, float* value)
+bool mc_deserialize_endian_float(mcMicroBuffer* mb, const Endianness endianness, float* value)
 {
-    return deserialize_byte_4(mb, endianness, (uint32_t*)value);
+    return mc_deserialize_byte_4(mb, endianness, (uint32_t*)value);
 }
 
-bool deserialize_endian_double(mcMicroBuffer* mb, const Endianness endianness, double* value)
+bool mc_deserialize_endian_double(mcMicroBuffer* mb, const Endianness endianness, double* value)
 {
-    return deserialize_byte_8(mb, endianness, (uint64_t*)value);
+    return mc_deserialize_byte_8(mb, endianness, (uint64_t*)value);
 }
 

--- a/src/c/types/basic.c
+++ b/src/c/types/basic.c
@@ -23,7 +23,7 @@
 //                INTERNAL SERIALIZATION IMPLEMENTATION
 // -------------------------------------------------------------------
 
-bool serialize_byte_1(mcMicroBuffer* mb, const uint8_t* byte)
+bool serialize_byte_1(mcBuffer* mb, const uint8_t* byte)
 {
     uint32_t data_size = sizeof(uint8_t);
     if(check_buffer(mb, data_size))
@@ -36,7 +36,7 @@ bool serialize_byte_1(mcMicroBuffer* mb, const uint8_t* byte)
     return !mb->error;
 }
 
-bool serialize_byte_2(mcMicroBuffer* mb, const mrEndianness endianness, const uint16_t* bytes)
+bool serialize_byte_2(mcBuffer* mb, const mrEndianness endianness, const uint16_t* bytes)
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t alignment = mc_micro_buffer_alignment(mb, data_size);
@@ -62,7 +62,7 @@ bool serialize_byte_2(mcMicroBuffer* mb, const mrEndianness endianness, const ui
     return !mb->error;
 }
 
-bool serialize_byte_4(mcMicroBuffer* mb, const mrEndianness endianness, const uint32_t* bytes)
+bool serialize_byte_4(mcBuffer* mb, const mrEndianness endianness, const uint32_t* bytes)
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t alignment = mc_micro_buffer_alignment(mb, data_size);
@@ -90,7 +90,7 @@ bool serialize_byte_4(mcMicroBuffer* mb, const mrEndianness endianness, const ui
     return !mb->error;
 }
 
-bool serialize_byte_8(mcMicroBuffer* mb, const mrEndianness endianness, const uint64_t* bytes)
+bool serialize_byte_8(mcBuffer* mb, const mrEndianness endianness, const uint64_t* bytes)
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t alignment = mc_micro_buffer_alignment(mb, data_size);
@@ -122,7 +122,7 @@ bool serialize_byte_8(mcMicroBuffer* mb, const mrEndianness endianness, const ui
     return !mb->error;
 }
 
-bool deserialize_byte_1(mcMicroBuffer* mb, uint8_t* byte)
+bool deserialize_byte_1(mcBuffer* mb, uint8_t* byte)
 {
     uint32_t data_size = sizeof(uint8_t);
     if(check_buffer(mb, data_size))
@@ -135,7 +135,7 @@ bool deserialize_byte_1(mcMicroBuffer* mb, uint8_t* byte)
     return !mb->error;
 }
 
-bool deserialize_byte_2(mcMicroBuffer* mb, const mrEndianness endianness, uint16_t* bytes)
+bool deserialize_byte_2(mcBuffer* mb, const mrEndianness endianness, uint16_t* bytes)
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t alignment = mc_micro_buffer_alignment(mb, data_size);
@@ -161,7 +161,7 @@ bool deserialize_byte_2(mcMicroBuffer* mb, const mrEndianness endianness, uint16
     return !mb->error;
 }
 
-bool deserialize_byte_4(mcMicroBuffer* mb, const mrEndianness endianness, uint32_t* bytes)
+bool deserialize_byte_4(mcBuffer* mb, const mrEndianness endianness, uint32_t* bytes)
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t alignment = mc_micro_buffer_alignment(mb, data_size);
@@ -189,7 +189,7 @@ bool deserialize_byte_4(mcMicroBuffer* mb, const mrEndianness endianness, uint32
     return !mb->error;
 }
 
-bool deserialize_byte_8(mcMicroBuffer* mb, const mrEndianness endianness, uint64_t* bytes)
+bool deserialize_byte_8(mcBuffer* mb, const mrEndianness endianness, uint64_t* bytes)
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t alignment = mc_micro_buffer_alignment(mb, data_size);
@@ -225,202 +225,202 @@ bool deserialize_byte_8(mcMicroBuffer* mb, const mrEndianness endianness, uint64
 //                  PUBLIC SERIALIZATION IMPLEMENTATION
 // -------------------------------------------------------------------
 
-bool mc_serialize_char(mcMicroBuffer* mb, const char value)
+bool mc_serialize_char(mcBuffer* mb, const char value)
 {
     return serialize_byte_1(mb, (uint8_t*)&value);
 }
 
-bool mc_serialize_bool(mcMicroBuffer* mb, const bool value)
+bool mc_serialize_bool(mcBuffer* mb, const bool value)
 {
     return serialize_byte_1(mb, (uint8_t*)&value);
 }
 
-bool mc_serialize_uint8_t(mcMicroBuffer* mb, const uint8_t value)
+bool mc_serialize_uint8_t(mcBuffer* mb, const uint8_t value)
 {
     return serialize_byte_1(mb, &value);
 }
 
-bool mc_serialize_uint16_t(mcMicroBuffer* mb, const uint16_t value)
+bool mc_serialize_uint16_t(mcBuffer* mb, const uint16_t value)
 {
     return serialize_byte_2(mb, mb->endianness, &value);
 }
 
-bool mc_serialize_uint32_t(mcMicroBuffer* mb, const uint32_t value)
+bool mc_serialize_uint32_t(mcBuffer* mb, const uint32_t value)
 {
     return serialize_byte_4(mb, mb->endianness, &value);
 }
 
-bool mc_serialize_uint64_t(mcMicroBuffer* mb, const uint64_t value)
+bool mc_serialize_uint64_t(mcBuffer* mb, const uint64_t value)
 {
     return serialize_byte_8(mb, mb->endianness, &value);
 }
 
-bool mc_serialize_int8_t(mcMicroBuffer* mb, const int8_t value)
+bool mc_serialize_int8_t(mcBuffer* mb, const int8_t value)
 {
     return serialize_byte_1(mb, (uint8_t*)&value);
 }
 
-bool mc_serialize_int16_t(mcMicroBuffer* mb, const int16_t value)
+bool mc_serialize_int16_t(mcBuffer* mb, const int16_t value)
 {
     return serialize_byte_2(mb, mb->endianness, (uint16_t*)&value);
 }
 
-bool mc_serialize_int32_t(mcMicroBuffer* mb, const int32_t value)
+bool mc_serialize_int32_t(mcBuffer* mb, const int32_t value)
 {
     return serialize_byte_4(mb, mb->endianness, (uint32_t*)&value);
 }
 
-bool mc_serialize_int64_t(mcMicroBuffer* mb, const int64_t value)
+bool mc_serialize_int64_t(mcBuffer* mb, const int64_t value)
 {
     return serialize_byte_8(mb, mb->endianness, (uint64_t*)&value);
 }
 
-bool mc_serialize_float(mcMicroBuffer* mb, const float value)
+bool mc_serialize_float(mcBuffer* mb, const float value)
 {
     return serialize_byte_4(mb, mb->endianness, (uint32_t*)&value);
 }
 
-bool mc_serialize_double(mcMicroBuffer* mb, const double value)
+bool mc_serialize_double(mcBuffer* mb, const double value)
 {
     return serialize_byte_8(mb, mb->endianness, (uint64_t*)&value);
 }
 
-bool mc_deserialize_char(mcMicroBuffer* mb, char* value)
+bool mc_deserialize_char(mcBuffer* mb, char* value)
 {
     return deserialize_byte_1(mb, (uint8_t*)value);
 }
 
-bool mc_deserialize_bool(mcMicroBuffer* mb, bool* value)
+bool mc_deserialize_bool(mcBuffer* mb, bool* value)
 {
     return deserialize_byte_1(mb, (uint8_t*)value);
 }
 
-bool mc_deserialize_uint8_t(mcMicroBuffer* mb, uint8_t* value)
+bool mc_deserialize_uint8_t(mcBuffer* mb, uint8_t* value)
 {
     return deserialize_byte_1(mb, value);
 }
 
-bool mc_deserialize_uint16_t(mcMicroBuffer* mb, uint16_t* value)
+bool mc_deserialize_uint16_t(mcBuffer* mb, uint16_t* value)
 {
     return deserialize_byte_2(mb, mb->endianness, value);
 }
 
-bool mc_deserialize_uint32_t(mcMicroBuffer* mb, uint32_t* value)
+bool mc_deserialize_uint32_t(mcBuffer* mb, uint32_t* value)
 {
     return deserialize_byte_4(mb, mb->endianness, value);
 }
 
-bool mc_deserialize_uint64_t(mcMicroBuffer* mb, uint64_t* value)
+bool mc_deserialize_uint64_t(mcBuffer* mb, uint64_t* value)
 {
     return deserialize_byte_8(mb, mb->endianness, value);
 }
 
-bool mc_deserialize_int8_t(mcMicroBuffer* mb, int8_t* value)
+bool mc_deserialize_int8_t(mcBuffer* mb, int8_t* value)
 {
     return deserialize_byte_1(mb, (uint8_t*)value);
 }
 
-bool mc_deserialize_int16_t(mcMicroBuffer* mb, int16_t* value)
+bool mc_deserialize_int16_t(mcBuffer* mb, int16_t* value)
 {
     return deserialize_byte_2(mb, mb->endianness, (uint16_t*)value);
 }
 
-bool mc_deserialize_int32_t(mcMicroBuffer* mb, int32_t* value)
+bool mc_deserialize_int32_t(mcBuffer* mb, int32_t* value)
 {
     return deserialize_byte_4(mb, mb->endianness, (uint32_t*)value);
 }
 
-bool mc_deserialize_int64_t(mcMicroBuffer* mb, int64_t* value)
+bool mc_deserialize_int64_t(mcBuffer* mb, int64_t* value)
 {
     return deserialize_byte_8(mb, mb->endianness, (uint64_t*)value);
 }
 
-bool mc_deserialize_float(mcMicroBuffer* mb, float* value)
+bool mc_deserialize_float(mcBuffer* mb, float* value)
 {
     return deserialize_byte_4(mb, mb->endianness, (uint32_t*)value);
 }
 
-bool mc_deserialize_double(mcMicroBuffer* mb, double* value)
+bool mc_deserialize_double(mcBuffer* mb, double* value)
 {
     return deserialize_byte_8(mb, mb->endianness, (uint64_t*)value);
 }
 
-bool mc_serialize_endian_uint16_t(mcMicroBuffer* mb, const mrEndianness endianness, const uint16_t value)
+bool mc_serialize_endian_uint16_t(mcBuffer* mb, const mrEndianness endianness, const uint16_t value)
 {
     return serialize_byte_2(mb, endianness, &value);
 }
 
-bool mc_serialize_endian_uint32_t(mcMicroBuffer* mb, const mrEndianness endianness, const uint32_t value)
+bool mc_serialize_endian_uint32_t(mcBuffer* mb, const mrEndianness endianness, const uint32_t value)
 {
     return serialize_byte_4(mb, endianness, &value);
 }
 
-bool mc_serialize_endian_uint64_t(mcMicroBuffer* mb, const mrEndianness endianness, const uint64_t value)
+bool mc_serialize_endian_uint64_t(mcBuffer* mb, const mrEndianness endianness, const uint64_t value)
 {
     return serialize_byte_8(mb, endianness, &value);
 }
 
-bool mc_serialize_endian_int16_t(mcMicroBuffer* mb, const mrEndianness endianness, const int16_t value)
+bool mc_serialize_endian_int16_t(mcBuffer* mb, const mrEndianness endianness, const int16_t value)
 {
     return serialize_byte_2(mb, endianness, (uint16_t*)&value);
 }
 
-bool mc_serialize_endian_int32_t(mcMicroBuffer* mb, const mrEndianness endianness, const int32_t value)
+bool mc_serialize_endian_int32_t(mcBuffer* mb, const mrEndianness endianness, const int32_t value)
 {
     return serialize_byte_4(mb, endianness, (uint32_t*)&value);
 }
 
-bool mc_serialize_endian_int64_t(mcMicroBuffer* mb, const mrEndianness endianness, const int64_t value)
+bool mc_serialize_endian_int64_t(mcBuffer* mb, const mrEndianness endianness, const int64_t value)
 {
     return serialize_byte_8(mb, endianness, (uint64_t*)&value);
 }
 
-bool mc_serialize_endian_float(mcMicroBuffer* mb, const mrEndianness endianness, const float value)
+bool mc_serialize_endian_float(mcBuffer* mb, const mrEndianness endianness, const float value)
 {
     return serialize_byte_4(mb, endianness, (uint32_t*)&value);
 }
 
-bool mc_serialize_endian_double(mcMicroBuffer* mb, const mrEndianness endianness, const double value)
+bool mc_serialize_endian_double(mcBuffer* mb, const mrEndianness endianness, const double value)
 {
     return serialize_byte_8(mb, endianness, (uint64_t*)&value);
 }
 
-bool mc_deserialize_endian_uint16_t(mcMicroBuffer* mb, const mrEndianness endianness, uint16_t* value)
+bool mc_deserialize_endian_uint16_t(mcBuffer* mb, const mrEndianness endianness, uint16_t* value)
 {
     return deserialize_byte_2(mb, endianness, value);
 }
 
-bool mc_deserialize_endian_uint32_t(mcMicroBuffer* mb, const mrEndianness endianness, uint32_t* value)
+bool mc_deserialize_endian_uint32_t(mcBuffer* mb, const mrEndianness endianness, uint32_t* value)
 {
     return deserialize_byte_4(mb, endianness, value);
 }
 
-bool mc_deserialize_endian_uint64_t(mcMicroBuffer* mb, const mrEndianness endianness, uint64_t* value)
+bool mc_deserialize_endian_uint64_t(mcBuffer* mb, const mrEndianness endianness, uint64_t* value)
 {
     return deserialize_byte_8(mb, endianness, value);
 }
 
-bool mc_deserialize_endian_int16_t(mcMicroBuffer* mb, const mrEndianness endianness, int16_t* value)
+bool mc_deserialize_endian_int16_t(mcBuffer* mb, const mrEndianness endianness, int16_t* value)
 {
     return deserialize_byte_2(mb, endianness, (uint16_t*)value);
 }
 
-bool mc_deserialize_endian_int32_t(mcMicroBuffer* mb, const mrEndianness endianness, int32_t* value)
+bool mc_deserialize_endian_int32_t(mcBuffer* mb, const mrEndianness endianness, int32_t* value)
 {
     return deserialize_byte_4(mb, endianness, (uint32_t*)value);
 }
 
-bool mc_deserialize_endian_int64_t(mcMicroBuffer* mb, const mrEndianness endianness, int64_t* value)
+bool mc_deserialize_endian_int64_t(mcBuffer* mb, const mrEndianness endianness, int64_t* value)
 {
     return deserialize_byte_8(mb, endianness, (uint64_t*)value);
 }
 
-bool mc_deserialize_endian_float(mcMicroBuffer* mb, const mrEndianness endianness, float* value)
+bool mc_deserialize_endian_float(mcBuffer* mb, const mrEndianness endianness, float* value)
 {
     return deserialize_byte_4(mb, endianness, (uint32_t*)value);
 }
 
-bool mc_deserialize_endian_double(mcMicroBuffer* mb, const mrEndianness endianness, double* value)
+bool mc_deserialize_endian_double(mcBuffer* mb, const mrEndianness endianness, double* value)
 {
     return deserialize_byte_8(mb, endianness, (uint64_t*)value);
 }

--- a/src/c/types/basic.c
+++ b/src/c/types/basic.c
@@ -36,7 +36,7 @@ bool serialize_byte_1(mcBuffer* mb, const uint8_t* byte)
     return !mb->error;
 }
 
-bool serialize_byte_2(mcBuffer* mb, const mrEndianness endianness, const uint16_t* bytes)
+bool serialize_byte_2(mcBuffer* mb, const mcEndianness endianness, const uint16_t* bytes)
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t alignment = mc_buffer_alignment(mb, data_size);
@@ -62,7 +62,7 @@ bool serialize_byte_2(mcBuffer* mb, const mrEndianness endianness, const uint16_
     return !mb->error;
 }
 
-bool serialize_byte_4(mcBuffer* mb, const mrEndianness endianness, const uint32_t* bytes)
+bool serialize_byte_4(mcBuffer* mb, const mcEndianness endianness, const uint32_t* bytes)
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t alignment = mc_buffer_alignment(mb, data_size);
@@ -90,7 +90,7 @@ bool serialize_byte_4(mcBuffer* mb, const mrEndianness endianness, const uint32_
     return !mb->error;
 }
 
-bool serialize_byte_8(mcBuffer* mb, const mrEndianness endianness, const uint64_t* bytes)
+bool serialize_byte_8(mcBuffer* mb, const mcEndianness endianness, const uint64_t* bytes)
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t alignment = mc_buffer_alignment(mb, data_size);
@@ -135,7 +135,7 @@ bool deserialize_byte_1(mcBuffer* mb, uint8_t* byte)
     return !mb->error;
 }
 
-bool deserialize_byte_2(mcBuffer* mb, const mrEndianness endianness, uint16_t* bytes)
+bool deserialize_byte_2(mcBuffer* mb, const mcEndianness endianness, uint16_t* bytes)
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t alignment = mc_buffer_alignment(mb, data_size);
@@ -161,7 +161,7 @@ bool deserialize_byte_2(mcBuffer* mb, const mrEndianness endianness, uint16_t* b
     return !mb->error;
 }
 
-bool deserialize_byte_4(mcBuffer* mb, const mrEndianness endianness, uint32_t* bytes)
+bool deserialize_byte_4(mcBuffer* mb, const mcEndianness endianness, uint32_t* bytes)
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t alignment = mc_buffer_alignment(mb, data_size);
@@ -189,7 +189,7 @@ bool deserialize_byte_4(mcBuffer* mb, const mrEndianness endianness, uint32_t* b
     return !mb->error;
 }
 
-bool deserialize_byte_8(mcBuffer* mb, const mrEndianness endianness, uint64_t* bytes)
+bool deserialize_byte_8(mcBuffer* mb, const mcEndianness endianness, uint64_t* bytes)
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t alignment = mc_buffer_alignment(mb, data_size);
@@ -345,82 +345,82 @@ bool mc_deserialize_double(mcBuffer* mb, double* value)
     return deserialize_byte_8(mb, mb->endianness, (uint64_t*)value);
 }
 
-bool mc_serialize_endian_uint16_t(mcBuffer* mb, const mrEndianness endianness, const uint16_t value)
+bool mc_serialize_endian_uint16_t(mcBuffer* mb, const mcEndianness endianness, const uint16_t value)
 {
     return serialize_byte_2(mb, endianness, &value);
 }
 
-bool mc_serialize_endian_uint32_t(mcBuffer* mb, const mrEndianness endianness, const uint32_t value)
+bool mc_serialize_endian_uint32_t(mcBuffer* mb, const mcEndianness endianness, const uint32_t value)
 {
     return serialize_byte_4(mb, endianness, &value);
 }
 
-bool mc_serialize_endian_uint64_t(mcBuffer* mb, const mrEndianness endianness, const uint64_t value)
+bool mc_serialize_endian_uint64_t(mcBuffer* mb, const mcEndianness endianness, const uint64_t value)
 {
     return serialize_byte_8(mb, endianness, &value);
 }
 
-bool mc_serialize_endian_int16_t(mcBuffer* mb, const mrEndianness endianness, const int16_t value)
+bool mc_serialize_endian_int16_t(mcBuffer* mb, const mcEndianness endianness, const int16_t value)
 {
     return serialize_byte_2(mb, endianness, (uint16_t*)&value);
 }
 
-bool mc_serialize_endian_int32_t(mcBuffer* mb, const mrEndianness endianness, const int32_t value)
+bool mc_serialize_endian_int32_t(mcBuffer* mb, const mcEndianness endianness, const int32_t value)
 {
     return serialize_byte_4(mb, endianness, (uint32_t*)&value);
 }
 
-bool mc_serialize_endian_int64_t(mcBuffer* mb, const mrEndianness endianness, const int64_t value)
+bool mc_serialize_endian_int64_t(mcBuffer* mb, const mcEndianness endianness, const int64_t value)
 {
     return serialize_byte_8(mb, endianness, (uint64_t*)&value);
 }
 
-bool mc_serialize_endian_float(mcBuffer* mb, const mrEndianness endianness, const float value)
+bool mc_serialize_endian_float(mcBuffer* mb, const mcEndianness endianness, const float value)
 {
     return serialize_byte_4(mb, endianness, (uint32_t*)&value);
 }
 
-bool mc_serialize_endian_double(mcBuffer* mb, const mrEndianness endianness, const double value)
+bool mc_serialize_endian_double(mcBuffer* mb, const mcEndianness endianness, const double value)
 {
     return serialize_byte_8(mb, endianness, (uint64_t*)&value);
 }
 
-bool mc_deserialize_endian_uint16_t(mcBuffer* mb, const mrEndianness endianness, uint16_t* value)
+bool mc_deserialize_endian_uint16_t(mcBuffer* mb, const mcEndianness endianness, uint16_t* value)
 {
     return deserialize_byte_2(mb, endianness, value);
 }
 
-bool mc_deserialize_endian_uint32_t(mcBuffer* mb, const mrEndianness endianness, uint32_t* value)
+bool mc_deserialize_endian_uint32_t(mcBuffer* mb, const mcEndianness endianness, uint32_t* value)
 {
     return deserialize_byte_4(mb, endianness, value);
 }
 
-bool mc_deserialize_endian_uint64_t(mcBuffer* mb, const mrEndianness endianness, uint64_t* value)
+bool mc_deserialize_endian_uint64_t(mcBuffer* mb, const mcEndianness endianness, uint64_t* value)
 {
     return deserialize_byte_8(mb, endianness, value);
 }
 
-bool mc_deserialize_endian_int16_t(mcBuffer* mb, const mrEndianness endianness, int16_t* value)
+bool mc_deserialize_endian_int16_t(mcBuffer* mb, const mcEndianness endianness, int16_t* value)
 {
     return deserialize_byte_2(mb, endianness, (uint16_t*)value);
 }
 
-bool mc_deserialize_endian_int32_t(mcBuffer* mb, const mrEndianness endianness, int32_t* value)
+bool mc_deserialize_endian_int32_t(mcBuffer* mb, const mcEndianness endianness, int32_t* value)
 {
     return deserialize_byte_4(mb, endianness, (uint32_t*)value);
 }
 
-bool mc_deserialize_endian_int64_t(mcBuffer* mb, const mrEndianness endianness, int64_t* value)
+bool mc_deserialize_endian_int64_t(mcBuffer* mb, const mcEndianness endianness, int64_t* value)
 {
     return deserialize_byte_8(mb, endianness, (uint64_t*)value);
 }
 
-bool mc_deserialize_endian_float(mcBuffer* mb, const mrEndianness endianness, float* value)
+bool mc_deserialize_endian_float(mcBuffer* mb, const mcEndianness endianness, float* value)
 {
     return deserialize_byte_4(mb, endianness, (uint32_t*)value);
 }
 
-bool mc_deserialize_endian_double(mcBuffer* mb, const mrEndianness endianness, double* value)
+bool mc_deserialize_endian_double(mcBuffer* mb, const mcEndianness endianness, double* value)
 {
     return deserialize_byte_8(mb, endianness, (uint64_t*)value);
 }

--- a/src/c/types/basic.c
+++ b/src/c/types/basic.c
@@ -39,7 +39,7 @@ bool serialize_byte_1(mcMicroBuffer* mb, const uint8_t* byte)
 bool serialize_byte_2(mcMicroBuffer* mb, const Endianness endianness, const uint16_t* bytes)
 {
     uint32_t data_size = sizeof(uint16_t);
-    uint32_t alignment = get_alignment_offset(mb, data_size);
+    uint32_t alignment = mc_micro_buffer_alignment(mb, data_size);
 
     if(check_buffer(mb, alignment + data_size))
     {
@@ -65,7 +65,7 @@ bool serialize_byte_2(mcMicroBuffer* mb, const Endianness endianness, const uint
 bool serialize_byte_4(mcMicroBuffer* mb, const Endianness endianness, const uint32_t* bytes)
 {
     uint32_t data_size = sizeof(uint32_t);
-    uint32_t alignment = get_alignment_offset(mb, data_size);
+    uint32_t alignment = mc_micro_buffer_alignment(mb, data_size);
 
     if(check_buffer(mb, alignment + data_size))
     {
@@ -93,7 +93,7 @@ bool serialize_byte_4(mcMicroBuffer* mb, const Endianness endianness, const uint
 bool serialize_byte_8(mcMicroBuffer* mb, const Endianness endianness, const uint64_t* bytes)
 {
     uint32_t data_size = sizeof(uint64_t);
-    uint32_t alignment = get_alignment_offset(mb, data_size);
+    uint32_t alignment = mc_micro_buffer_alignment(mb, data_size);
 
     if(check_buffer(mb, alignment + data_size))
     {
@@ -138,7 +138,7 @@ bool deserialize_byte_1(mcMicroBuffer* mb, uint8_t* byte)
 bool deserialize_byte_2(mcMicroBuffer* mb, const Endianness endianness, uint16_t* bytes)
 {
     uint32_t data_size = sizeof(uint16_t);
-    uint32_t alignment = get_alignment_offset(mb, data_size);
+    uint32_t alignment = mc_micro_buffer_alignment(mb, data_size);
 
     if(check_buffer(mb, alignment + data_size))
     {
@@ -164,7 +164,7 @@ bool deserialize_byte_2(mcMicroBuffer* mb, const Endianness endianness, uint16_t
 bool deserialize_byte_4(mcMicroBuffer* mb, const Endianness endianness, uint32_t* bytes)
 {
     uint32_t data_size = sizeof(uint32_t);
-    uint32_t alignment = get_alignment_offset(mb, data_size);
+    uint32_t alignment = mc_micro_buffer_alignment(mb, data_size);
 
     if(check_buffer(mb, alignment + data_size))
     {
@@ -192,7 +192,7 @@ bool deserialize_byte_4(mcMicroBuffer* mb, const Endianness endianness, uint32_t
 bool deserialize_byte_8(mcMicroBuffer* mb, const Endianness endianness, uint64_t* bytes)
 {
     uint32_t data_size = sizeof(uint64_t);
-    uint32_t alignment = get_alignment_offset(mb, data_size);
+    uint32_t alignment = mc_micro_buffer_alignment(mb, data_size);
 
     if(check_buffer(mb, alignment + data_size))
     {

--- a/src/c/types/basic.c
+++ b/src/c/types/basic.c
@@ -36,7 +36,7 @@ bool serialize_byte_1(mcMicroBuffer* mb, const uint8_t* byte)
     return !mb->error;
 }
 
-bool serialize_byte_2(mcMicroBuffer* mb, const Endianness endianness, const uint16_t* bytes)
+bool serialize_byte_2(mcMicroBuffer* mb, const mrEndianness endianness, const uint16_t* bytes)
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t alignment = mc_micro_buffer_alignment(mb, data_size);
@@ -45,7 +45,7 @@ bool serialize_byte_2(mcMicroBuffer* mb, const Endianness endianness, const uint
     {
         mb->iterator += alignment;
 
-        if(MACHINE_ENDIANNESS == endianness)
+        if(MC_MACHINE_ENDIANNESS == endianness)
         {
             memcpy(mb->iterator, bytes, data_size);
         }
@@ -62,7 +62,7 @@ bool serialize_byte_2(mcMicroBuffer* mb, const Endianness endianness, const uint
     return !mb->error;
 }
 
-bool serialize_byte_4(mcMicroBuffer* mb, const Endianness endianness, const uint32_t* bytes)
+bool serialize_byte_4(mcMicroBuffer* mb, const mrEndianness endianness, const uint32_t* bytes)
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t alignment = mc_micro_buffer_alignment(mb, data_size);
@@ -71,7 +71,7 @@ bool serialize_byte_4(mcMicroBuffer* mb, const Endianness endianness, const uint
     {
         mb->iterator += alignment;
 
-        if(MACHINE_ENDIANNESS == endianness)
+        if(MC_MACHINE_ENDIANNESS == endianness)
         {
             memcpy(mb->iterator, bytes, data_size);
         }
@@ -90,7 +90,7 @@ bool serialize_byte_4(mcMicroBuffer* mb, const Endianness endianness, const uint
     return !mb->error;
 }
 
-bool serialize_byte_8(mcMicroBuffer* mb, const Endianness endianness, const uint64_t* bytes)
+bool serialize_byte_8(mcMicroBuffer* mb, const mrEndianness endianness, const uint64_t* bytes)
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t alignment = mc_micro_buffer_alignment(mb, data_size);
@@ -99,7 +99,7 @@ bool serialize_byte_8(mcMicroBuffer* mb, const Endianness endianness, const uint
     {
         mb->iterator += alignment;
 
-        if(MACHINE_ENDIANNESS == endianness)
+        if(MC_MACHINE_ENDIANNESS == endianness)
         {
             memcpy(mb->iterator, bytes, data_size);
         }
@@ -135,7 +135,7 @@ bool deserialize_byte_1(mcMicroBuffer* mb, uint8_t* byte)
     return !mb->error;
 }
 
-bool deserialize_byte_2(mcMicroBuffer* mb, const Endianness endianness, uint16_t* bytes)
+bool deserialize_byte_2(mcMicroBuffer* mb, const mrEndianness endianness, uint16_t* bytes)
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t alignment = mc_micro_buffer_alignment(mb, data_size);
@@ -144,7 +144,7 @@ bool deserialize_byte_2(mcMicroBuffer* mb, const Endianness endianness, uint16_t
     {
         mb->iterator += alignment;
 
-        if(MACHINE_ENDIANNESS == endianness)
+        if(MC_MACHINE_ENDIANNESS == endianness)
         {
             memcpy(bytes, mb->iterator, data_size);
         }
@@ -161,7 +161,7 @@ bool deserialize_byte_2(mcMicroBuffer* mb, const Endianness endianness, uint16_t
     return !mb->error;
 }
 
-bool deserialize_byte_4(mcMicroBuffer* mb, const Endianness endianness, uint32_t* bytes)
+bool deserialize_byte_4(mcMicroBuffer* mb, const mrEndianness endianness, uint32_t* bytes)
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t alignment = mc_micro_buffer_alignment(mb, data_size);
@@ -170,7 +170,7 @@ bool deserialize_byte_4(mcMicroBuffer* mb, const Endianness endianness, uint32_t
     {
         mb->iterator += alignment;
 
-        if(MACHINE_ENDIANNESS == endianness)
+        if(MC_MACHINE_ENDIANNESS == endianness)
         {
             memcpy(bytes, mb->iterator, data_size);
         }
@@ -189,7 +189,7 @@ bool deserialize_byte_4(mcMicroBuffer* mb, const Endianness endianness, uint32_t
     return !mb->error;
 }
 
-bool deserialize_byte_8(mcMicroBuffer* mb, const Endianness endianness, uint64_t* bytes)
+bool deserialize_byte_8(mcMicroBuffer* mb, const mrEndianness endianness, uint64_t* bytes)
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t alignment = mc_micro_buffer_alignment(mb, data_size);
@@ -198,7 +198,7 @@ bool deserialize_byte_8(mcMicroBuffer* mb, const Endianness endianness, uint64_t
     {
         mb->iterator += alignment;
 
-        if(MACHINE_ENDIANNESS == endianness)
+        if(MC_MACHINE_ENDIANNESS == endianness)
         {
             memcpy(bytes, mb->iterator, data_size);
         }
@@ -345,82 +345,82 @@ bool mc_deserialize_double(mcMicroBuffer* mb, double* value)
     return deserialize_byte_8(mb, mb->endianness, (uint64_t*)value);
 }
 
-bool mc_serialize_endian_uint16_t(mcMicroBuffer* mb, const Endianness endianness, const uint16_t value)
+bool mc_serialize_endian_uint16_t(mcMicroBuffer* mb, const mrEndianness endianness, const uint16_t value)
 {
     return serialize_byte_2(mb, endianness, &value);
 }
 
-bool mc_serialize_endian_uint32_t(mcMicroBuffer* mb, const Endianness endianness, const uint32_t value)
+bool mc_serialize_endian_uint32_t(mcMicroBuffer* mb, const mrEndianness endianness, const uint32_t value)
 {
     return serialize_byte_4(mb, endianness, &value);
 }
 
-bool mc_serialize_endian_uint64_t(mcMicroBuffer* mb, const Endianness endianness, const uint64_t value)
+bool mc_serialize_endian_uint64_t(mcMicroBuffer* mb, const mrEndianness endianness, const uint64_t value)
 {
     return serialize_byte_8(mb, endianness, &value);
 }
 
-bool mc_serialize_endian_int16_t(mcMicroBuffer* mb, const Endianness endianness, const int16_t value)
+bool mc_serialize_endian_int16_t(mcMicroBuffer* mb, const mrEndianness endianness, const int16_t value)
 {
     return serialize_byte_2(mb, endianness, (uint16_t*)&value);
 }
 
-bool mc_serialize_endian_int32_t(mcMicroBuffer* mb, const Endianness endianness, const int32_t value)
+bool mc_serialize_endian_int32_t(mcMicroBuffer* mb, const mrEndianness endianness, const int32_t value)
 {
     return serialize_byte_4(mb, endianness, (uint32_t*)&value);
 }
 
-bool mc_serialize_endian_int64_t(mcMicroBuffer* mb, const Endianness endianness, const int64_t value)
+bool mc_serialize_endian_int64_t(mcMicroBuffer* mb, const mrEndianness endianness, const int64_t value)
 {
     return serialize_byte_8(mb, endianness, (uint64_t*)&value);
 }
 
-bool mc_serialize_endian_float(mcMicroBuffer* mb, const Endianness endianness, const float value)
+bool mc_serialize_endian_float(mcMicroBuffer* mb, const mrEndianness endianness, const float value)
 {
     return serialize_byte_4(mb, endianness, (uint32_t*)&value);
 }
 
-bool mc_serialize_endian_double(mcMicroBuffer* mb, const Endianness endianness, const double value)
+bool mc_serialize_endian_double(mcMicroBuffer* mb, const mrEndianness endianness, const double value)
 {
     return serialize_byte_8(mb, endianness, (uint64_t*)&value);
 }
 
-bool mc_deserialize_endian_uint16_t(mcMicroBuffer* mb, const Endianness endianness, uint16_t* value)
+bool mc_deserialize_endian_uint16_t(mcMicroBuffer* mb, const mrEndianness endianness, uint16_t* value)
 {
     return deserialize_byte_2(mb, endianness, value);
 }
 
-bool mc_deserialize_endian_uint32_t(mcMicroBuffer* mb, const Endianness endianness, uint32_t* value)
+bool mc_deserialize_endian_uint32_t(mcMicroBuffer* mb, const mrEndianness endianness, uint32_t* value)
 {
     return deserialize_byte_4(mb, endianness, value);
 }
 
-bool mc_deserialize_endian_uint64_t(mcMicroBuffer* mb, const Endianness endianness, uint64_t* value)
+bool mc_deserialize_endian_uint64_t(mcMicroBuffer* mb, const mrEndianness endianness, uint64_t* value)
 {
     return deserialize_byte_8(mb, endianness, value);
 }
 
-bool mc_deserialize_endian_int16_t(mcMicroBuffer* mb, const Endianness endianness, int16_t* value)
+bool mc_deserialize_endian_int16_t(mcMicroBuffer* mb, const mrEndianness endianness, int16_t* value)
 {
     return deserialize_byte_2(mb, endianness, (uint16_t*)value);
 }
 
-bool mc_deserialize_endian_int32_t(mcMicroBuffer* mb, const Endianness endianness, int32_t* value)
+bool mc_deserialize_endian_int32_t(mcMicroBuffer* mb, const mrEndianness endianness, int32_t* value)
 {
     return deserialize_byte_4(mb, endianness, (uint32_t*)value);
 }
 
-bool mc_deserialize_endian_int64_t(mcMicroBuffer* mb, const Endianness endianness, int64_t* value)
+bool mc_deserialize_endian_int64_t(mcMicroBuffer* mb, const mrEndianness endianness, int64_t* value)
 {
     return deserialize_byte_8(mb, endianness, (uint64_t*)value);
 }
 
-bool mc_deserialize_endian_float(mcMicroBuffer* mb, const Endianness endianness, float* value)
+bool mc_deserialize_endian_float(mcMicroBuffer* mb, const mrEndianness endianness, float* value)
 {
     return deserialize_byte_4(mb, endianness, (uint32_t*)value);
 }
 
-bool mc_deserialize_endian_double(mcMicroBuffer* mb, const Endianness endianness, double* value)
+bool mc_deserialize_endian_double(mcMicroBuffer* mb, const mrEndianness endianness, double* value)
 {
     return deserialize_byte_8(mb, endianness, (uint64_t*)value);
 }

--- a/src/c/types/basic.c
+++ b/src/c/types/basic.c
@@ -39,7 +39,7 @@ bool serialize_byte_1(mcBuffer* mb, const uint8_t* byte)
 bool serialize_byte_2(mcBuffer* mb, const mrEndianness endianness, const uint16_t* bytes)
 {
     uint32_t data_size = sizeof(uint16_t);
-    uint32_t alignment = mc_micro_buffer_alignment(mb, data_size);
+    uint32_t alignment = mc_buffer_alignment(mb, data_size);
 
     if(check_buffer(mb, alignment + data_size))
     {
@@ -65,7 +65,7 @@ bool serialize_byte_2(mcBuffer* mb, const mrEndianness endianness, const uint16_
 bool serialize_byte_4(mcBuffer* mb, const mrEndianness endianness, const uint32_t* bytes)
 {
     uint32_t data_size = sizeof(uint32_t);
-    uint32_t alignment = mc_micro_buffer_alignment(mb, data_size);
+    uint32_t alignment = mc_buffer_alignment(mb, data_size);
 
     if(check_buffer(mb, alignment + data_size))
     {
@@ -93,7 +93,7 @@ bool serialize_byte_4(mcBuffer* mb, const mrEndianness endianness, const uint32_
 bool serialize_byte_8(mcBuffer* mb, const mrEndianness endianness, const uint64_t* bytes)
 {
     uint32_t data_size = sizeof(uint64_t);
-    uint32_t alignment = mc_micro_buffer_alignment(mb, data_size);
+    uint32_t alignment = mc_buffer_alignment(mb, data_size);
 
     if(check_buffer(mb, alignment + data_size))
     {
@@ -138,7 +138,7 @@ bool deserialize_byte_1(mcBuffer* mb, uint8_t* byte)
 bool deserialize_byte_2(mcBuffer* mb, const mrEndianness endianness, uint16_t* bytes)
 {
     uint32_t data_size = sizeof(uint16_t);
-    uint32_t alignment = mc_micro_buffer_alignment(mb, data_size);
+    uint32_t alignment = mc_buffer_alignment(mb, data_size);
 
     if(check_buffer(mb, alignment + data_size))
     {
@@ -164,7 +164,7 @@ bool deserialize_byte_2(mcBuffer* mb, const mrEndianness endianness, uint16_t* b
 bool deserialize_byte_4(mcBuffer* mb, const mrEndianness endianness, uint32_t* bytes)
 {
     uint32_t data_size = sizeof(uint32_t);
-    uint32_t alignment = mc_micro_buffer_alignment(mb, data_size);
+    uint32_t alignment = mc_buffer_alignment(mb, data_size);
 
     if(check_buffer(mb, alignment + data_size))
     {
@@ -192,7 +192,7 @@ bool deserialize_byte_4(mcBuffer* mb, const mrEndianness endianness, uint32_t* b
 bool deserialize_byte_8(mcBuffer* mb, const mrEndianness endianness, uint64_t* bytes)
 {
     uint32_t data_size = sizeof(uint64_t);
-    uint32_t alignment = mc_micro_buffer_alignment(mb, data_size);
+    uint32_t alignment = mc_buffer_alignment(mb, data_size);
 
     if(check_buffer(mb, alignment + data_size))
     {

--- a/src/c/types/basic.c
+++ b/src/c/types/basic.c
@@ -23,7 +23,7 @@
 //                INTERNAL SERIALIZATION IMPLEMENTATION
 // -------------------------------------------------------------------
 
-bool serialize_byte_1(mcMicroBuffer* mb, const uint8_t* byte)
+bool mc_serialize_byte_1(mcMicroBuffer* mb, const uint8_t* byte)
 {
     uint32_t data_size = sizeof(uint8_t);
     if(check_buffer(mb, data_size))
@@ -36,7 +36,7 @@ bool serialize_byte_1(mcMicroBuffer* mb, const uint8_t* byte)
     return !mb->error;
 }
 
-bool serialize_byte_2(mcMicroBuffer* mb, const Endianness endianness, const uint16_t* bytes)
+bool mc_serialize_byte_2(mcMicroBuffer* mb, const Endianness endianness, const uint16_t* bytes)
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t alignment = get_alignment_offset(mb, data_size);
@@ -62,7 +62,7 @@ bool serialize_byte_2(mcMicroBuffer* mb, const Endianness endianness, const uint
     return !mb->error;
 }
 
-bool serialize_byte_4(mcMicroBuffer* mb, const Endianness endianness, const uint32_t* bytes)
+bool mc_serialize_byte_4(mcMicroBuffer* mb, const Endianness endianness, const uint32_t* bytes)
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t alignment = get_alignment_offset(mb, data_size);
@@ -90,7 +90,7 @@ bool serialize_byte_4(mcMicroBuffer* mb, const Endianness endianness, const uint
     return !mb->error;
 }
 
-bool serialize_byte_8(mcMicroBuffer* mb, const Endianness endianness, const uint64_t* bytes)
+bool mc_serialize_byte_8(mcMicroBuffer* mb, const Endianness endianness, const uint64_t* bytes)
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t alignment = get_alignment_offset(mb, data_size);
@@ -225,64 +225,64 @@ bool mc_deserialize_byte_8(mcMicroBuffer* mb, const Endianness endianness, uint6
 //                  PUBLIC SERIALIZATION IMPLEMENTATION
 // -------------------------------------------------------------------
 
-bool serialize_char(mcMicroBuffer* mb, const char value)
+bool mc_serialize_char(mcMicroBuffer* mb, const char value)
 {
-    return serialize_byte_1(mb, (uint8_t*)&value);
+    return mc_serialize_byte_1(mb, (uint8_t*)&value);
 }
 
-bool serialize_bool(mcMicroBuffer* mb, const bool value)
+bool mc_serialize_bool(mcMicroBuffer* mb, const bool value)
 {
-    return serialize_byte_1(mb, (uint8_t*)&value);
+    return mc_serialize_byte_1(mb, (uint8_t*)&value);
 }
 
-bool serialize_uint8_t(mcMicroBuffer* mb, const uint8_t value)
+bool mc_serialize_uint8_t(mcMicroBuffer* mb, const uint8_t value)
 {
-    return serialize_byte_1(mb, &value);
+    return mc_serialize_byte_1(mb, &value);
 }
 
-bool serialize_uint16_t(mcMicroBuffer* mb, const uint16_t value)
+bool mc_serialize_uint16_t(mcMicroBuffer* mb, const uint16_t value)
 {
-    return serialize_byte_2(mb, mb->endianness, &value);
+    return mc_serialize_byte_2(mb, mb->endianness, &value);
 }
 
-bool serialize_uint32_t(mcMicroBuffer* mb, const uint32_t value)
+bool mc_serialize_uint32_t(mcMicroBuffer* mb, const uint32_t value)
 {
-    return serialize_byte_4(mb, mb->endianness, &value);
+    return mc_serialize_byte_4(mb, mb->endianness, &value);
 }
 
-bool serialize_uint64_t(mcMicroBuffer* mb, const uint64_t value)
+bool mc_serialize_uint64_t(mcMicroBuffer* mb, const uint64_t value)
 {
-    return serialize_byte_8(mb, mb->endianness, &value);
+    return mc_serialize_byte_8(mb, mb->endianness, &value);
 }
 
-bool serialize_int8_t(mcMicroBuffer* mb, const int8_t value)
+bool mc_serialize_int8_t(mcMicroBuffer* mb, const int8_t value)
 {
-    return serialize_byte_1(mb, (uint8_t*)&value);
+    return mc_serialize_byte_1(mb, (uint8_t*)&value);
 }
 
-bool serialize_int16_t(mcMicroBuffer* mb, const int16_t value)
+bool mc_serialize_int16_t(mcMicroBuffer* mb, const int16_t value)
 {
-    return serialize_byte_2(mb, mb->endianness, (uint16_t*)&value);
+    return mc_serialize_byte_2(mb, mb->endianness, (uint16_t*)&value);
 }
 
-bool serialize_int32_t(mcMicroBuffer* mb, const int32_t value)
+bool mc_serialize_int32_t(mcMicroBuffer* mb, const int32_t value)
 {
-    return serialize_byte_4(mb, mb->endianness, (uint32_t*)&value);
+    return mc_serialize_byte_4(mb, mb->endianness, (uint32_t*)&value);
 }
 
-bool serialize_int64_t(mcMicroBuffer* mb, const int64_t value)
+bool mc_serialize_int64_t(mcMicroBuffer* mb, const int64_t value)
 {
-    return serialize_byte_8(mb, mb->endianness, (uint64_t*)&value);
+    return mc_serialize_byte_8(mb, mb->endianness, (uint64_t*)&value);
 }
 
-bool serialize_float(mcMicroBuffer* mb, const float value)
+bool mc_serialize_float(mcMicroBuffer* mb, const float value)
 {
-    return serialize_byte_4(mb, mb->endianness, (uint32_t*)&value);
+    return mc_serialize_byte_4(mb, mb->endianness, (uint32_t*)&value);
 }
 
-bool serialize_double(mcMicroBuffer* mb, const double value)
+bool mc_serialize_double(mcMicroBuffer* mb, const double value)
 {
-    return serialize_byte_8(mb, mb->endianness, (uint64_t*)&value);
+    return mc_serialize_byte_8(mb, mb->endianness, (uint64_t*)&value);
 }
 
 bool mc_deserialize_char(mcMicroBuffer* mb, char* value)
@@ -345,44 +345,44 @@ bool mc_deserialize_double(mcMicroBuffer* mb, double* value)
     return mc_deserialize_byte_8(mb, mb->endianness, (uint64_t*)value);
 }
 
-bool serialize_endian_uint16_t(mcMicroBuffer* mb, const Endianness endianness, const uint16_t value)
+bool mc_serialize_endian_uint16_t(mcMicroBuffer* mb, const Endianness endianness, const uint16_t value)
 {
-    return serialize_byte_2(mb, endianness, &value);
+    return mc_serialize_byte_2(mb, endianness, &value);
 }
 
-bool serialize_endian_uint32_t(mcMicroBuffer* mb, const Endianness endianness, const uint32_t value)
+bool mc_serialize_endian_uint32_t(mcMicroBuffer* mb, const Endianness endianness, const uint32_t value)
 {
-    return serialize_byte_4(mb, endianness, &value);
+    return mc_serialize_byte_4(mb, endianness, &value);
 }
 
-bool serialize_endian_uint64_t(mcMicroBuffer* mb, const Endianness endianness, const uint64_t value)
+bool mc_serialize_endian_uint64_t(mcMicroBuffer* mb, const Endianness endianness, const uint64_t value)
 {
-    return serialize_byte_8(mb, endianness, &value);
+    return mc_serialize_byte_8(mb, endianness, &value);
 }
 
-bool serialize_endian_int16_t(mcMicroBuffer* mb, const Endianness endianness, const int16_t value)
+bool mc_serialize_endian_int16_t(mcMicroBuffer* mb, const Endianness endianness, const int16_t value)
 {
-    return serialize_byte_2(mb, endianness, (uint16_t*)&value);
+    return mc_serialize_byte_2(mb, endianness, (uint16_t*)&value);
 }
 
-bool serialize_endian_int32_t(mcMicroBuffer* mb, const Endianness endianness, const int32_t value)
+bool mc_serialize_endian_int32_t(mcMicroBuffer* mb, const Endianness endianness, const int32_t value)
 {
-    return serialize_byte_4(mb, endianness, (uint32_t*)&value);
+    return mc_serialize_byte_4(mb, endianness, (uint32_t*)&value);
 }
 
-bool serialize_endian_int64_t(mcMicroBuffer* mb, const Endianness endianness, const int64_t value)
+bool mc_serialize_endian_int64_t(mcMicroBuffer* mb, const Endianness endianness, const int64_t value)
 {
-    return serialize_byte_8(mb, endianness, (uint64_t*)&value);
+    return mc_serialize_byte_8(mb, endianness, (uint64_t*)&value);
 }
 
-bool serialize_endian_float(mcMicroBuffer* mb, const Endianness endianness, const float value)
+bool mc_serialize_endian_float(mcMicroBuffer* mb, const Endianness endianness, const float value)
 {
-    return serialize_byte_4(mb, endianness, (uint32_t*)&value);
+    return mc_serialize_byte_4(mb, endianness, (uint32_t*)&value);
 }
 
-bool serialize_endian_double(mcMicroBuffer* mb, const Endianness endianness, const double value)
+bool mc_serialize_endian_double(mcMicroBuffer* mb, const Endianness endianness, const double value)
 {
-    return serialize_byte_8(mb, endianness, (uint64_t*)&value);
+    return mc_serialize_byte_8(mb, endianness, (uint64_t*)&value);
 }
 
 bool mc_deserialize_endian_uint16_t(mcMicroBuffer* mb, const Endianness endianness, uint16_t* value)

--- a/src/c/types/basic.c
+++ b/src/c/types/basic.c
@@ -23,7 +23,7 @@
 //                INTERNAL SERIALIZATION IMPLEMENTATION
 // -------------------------------------------------------------------
 
-bool serialize_byte_1(MicroBuffer* mb, const uint8_t* byte)
+bool serialize_byte_1(mcMicroBuffer* mb, const uint8_t* byte)
 {
     uint32_t data_size = sizeof(uint8_t);
     if(check_buffer(mb, data_size))
@@ -36,7 +36,7 @@ bool serialize_byte_1(MicroBuffer* mb, const uint8_t* byte)
     return !mb->error;
 }
 
-bool serialize_byte_2(MicroBuffer* mb, const Endianness endianness, const uint16_t* bytes)
+bool serialize_byte_2(mcMicroBuffer* mb, const Endianness endianness, const uint16_t* bytes)
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t alignment = get_alignment_offset(mb, data_size);
@@ -62,7 +62,7 @@ bool serialize_byte_2(MicroBuffer* mb, const Endianness endianness, const uint16
     return !mb->error;
 }
 
-bool serialize_byte_4(MicroBuffer* mb, const Endianness endianness, const uint32_t* bytes)
+bool serialize_byte_4(mcMicroBuffer* mb, const Endianness endianness, const uint32_t* bytes)
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t alignment = get_alignment_offset(mb, data_size);
@@ -90,7 +90,7 @@ bool serialize_byte_4(MicroBuffer* mb, const Endianness endianness, const uint32
     return !mb->error;
 }
 
-bool serialize_byte_8(MicroBuffer* mb, const Endianness endianness, const uint64_t* bytes)
+bool serialize_byte_8(mcMicroBuffer* mb, const Endianness endianness, const uint64_t* bytes)
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t alignment = get_alignment_offset(mb, data_size);
@@ -122,7 +122,7 @@ bool serialize_byte_8(MicroBuffer* mb, const Endianness endianness, const uint64
     return !mb->error;
 }
 
-bool deserialize_byte_1(MicroBuffer* mb, uint8_t* byte)
+bool deserialize_byte_1(mcMicroBuffer* mb, uint8_t* byte)
 {
     uint32_t data_size = sizeof(uint8_t);
     if(check_buffer(mb, data_size))
@@ -135,7 +135,7 @@ bool deserialize_byte_1(MicroBuffer* mb, uint8_t* byte)
     return !mb->error;
 }
 
-bool deserialize_byte_2(MicroBuffer* mb, const Endianness endianness, uint16_t* bytes)
+bool deserialize_byte_2(mcMicroBuffer* mb, const Endianness endianness, uint16_t* bytes)
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t alignment = get_alignment_offset(mb, data_size);
@@ -161,7 +161,7 @@ bool deserialize_byte_2(MicroBuffer* mb, const Endianness endianness, uint16_t* 
     return !mb->error;
 }
 
-bool deserialize_byte_4(MicroBuffer* mb, const Endianness endianness, uint32_t* bytes)
+bool deserialize_byte_4(mcMicroBuffer* mb, const Endianness endianness, uint32_t* bytes)
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t alignment = get_alignment_offset(mb, data_size);
@@ -189,7 +189,7 @@ bool deserialize_byte_4(MicroBuffer* mb, const Endianness endianness, uint32_t* 
     return !mb->error;
 }
 
-bool deserialize_byte_8(MicroBuffer* mb, const Endianness endianness, uint64_t* bytes)
+bool deserialize_byte_8(mcMicroBuffer* mb, const Endianness endianness, uint64_t* bytes)
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t alignment = get_alignment_offset(mb, data_size);
@@ -225,202 +225,202 @@ bool deserialize_byte_8(MicroBuffer* mb, const Endianness endianness, uint64_t* 
 //                  PUBLIC SERIALIZATION IMPLEMENTATION
 // -------------------------------------------------------------------
 
-bool serialize_char(MicroBuffer* mb, const char value)
+bool serialize_char(mcMicroBuffer* mb, const char value)
 {
     return serialize_byte_1(mb, (uint8_t*)&value);
 }
 
-bool serialize_bool(MicroBuffer* mb, const bool value)
+bool serialize_bool(mcMicroBuffer* mb, const bool value)
 {
     return serialize_byte_1(mb, (uint8_t*)&value);
 }
 
-bool serialize_uint8_t(MicroBuffer* mb, const uint8_t value)
+bool serialize_uint8_t(mcMicroBuffer* mb, const uint8_t value)
 {
     return serialize_byte_1(mb, &value);
 }
 
-bool serialize_uint16_t(MicroBuffer* mb, const uint16_t value)
+bool serialize_uint16_t(mcMicroBuffer* mb, const uint16_t value)
 {
     return serialize_byte_2(mb, mb->endianness, &value);
 }
 
-bool serialize_uint32_t(MicroBuffer* mb, const uint32_t value)
+bool serialize_uint32_t(mcMicroBuffer* mb, const uint32_t value)
 {
     return serialize_byte_4(mb, mb->endianness, &value);
 }
 
-bool serialize_uint64_t(MicroBuffer* mb, const uint64_t value)
+bool serialize_uint64_t(mcMicroBuffer* mb, const uint64_t value)
 {
     return serialize_byte_8(mb, mb->endianness, &value);
 }
 
-bool serialize_int8_t(MicroBuffer* mb, const int8_t value)
+bool serialize_int8_t(mcMicroBuffer* mb, const int8_t value)
 {
     return serialize_byte_1(mb, (uint8_t*)&value);
 }
 
-bool serialize_int16_t(MicroBuffer* mb, const int16_t value)
+bool serialize_int16_t(mcMicroBuffer* mb, const int16_t value)
 {
     return serialize_byte_2(mb, mb->endianness, (uint16_t*)&value);
 }
 
-bool serialize_int32_t(MicroBuffer* mb, const int32_t value)
+bool serialize_int32_t(mcMicroBuffer* mb, const int32_t value)
 {
     return serialize_byte_4(mb, mb->endianness, (uint32_t*)&value);
 }
 
-bool serialize_int64_t(MicroBuffer* mb, const int64_t value)
+bool serialize_int64_t(mcMicroBuffer* mb, const int64_t value)
 {
     return serialize_byte_8(mb, mb->endianness, (uint64_t*)&value);
 }
 
-bool serialize_float(MicroBuffer* mb, const float value)
+bool serialize_float(mcMicroBuffer* mb, const float value)
 {
     return serialize_byte_4(mb, mb->endianness, (uint32_t*)&value);
 }
 
-bool serialize_double(MicroBuffer* mb, const double value)
+bool serialize_double(mcMicroBuffer* mb, const double value)
 {
     return serialize_byte_8(mb, mb->endianness, (uint64_t*)&value);
 }
 
-bool deserialize_char(MicroBuffer* mb, char* value)
+bool deserialize_char(mcMicroBuffer* mb, char* value)
 {
     return deserialize_byte_1(mb, (uint8_t*)value);
 }
 
-bool deserialize_bool(MicroBuffer* mb, bool* value)
+bool deserialize_bool(mcMicroBuffer* mb, bool* value)
 {
     return deserialize_byte_1(mb, (uint8_t*)value);
 }
 
-bool deserialize_uint8_t(MicroBuffer* mb, uint8_t* value)
+bool deserialize_uint8_t(mcMicroBuffer* mb, uint8_t* value)
 {
     return deserialize_byte_1(mb, value);
 }
 
-bool deserialize_uint16_t(MicroBuffer* mb, uint16_t* value)
+bool deserialize_uint16_t(mcMicroBuffer* mb, uint16_t* value)
 {
     return deserialize_byte_2(mb, mb->endianness, value);
 }
 
-bool deserialize_uint32_t(MicroBuffer* mb, uint32_t* value)
+bool deserialize_uint32_t(mcMicroBuffer* mb, uint32_t* value)
 {
     return deserialize_byte_4(mb, mb->endianness, value);
 }
 
-bool deserialize_uint64_t(MicroBuffer* mb, uint64_t* value)
+bool deserialize_uint64_t(mcMicroBuffer* mb, uint64_t* value)
 {
     return deserialize_byte_8(mb, mb->endianness, value);
 }
 
-bool deserialize_int8_t(MicroBuffer* mb, int8_t* value)
+bool deserialize_int8_t(mcMicroBuffer* mb, int8_t* value)
 {
     return deserialize_byte_1(mb, (uint8_t*)value);
 }
 
-bool deserialize_int16_t(MicroBuffer* mb, int16_t* value)
+bool deserialize_int16_t(mcMicroBuffer* mb, int16_t* value)
 {
     return deserialize_byte_2(mb, mb->endianness, (uint16_t*)value);
 }
 
-bool deserialize_int32_t(MicroBuffer* mb, int32_t* value)
+bool deserialize_int32_t(mcMicroBuffer* mb, int32_t* value)
 {
     return deserialize_byte_4(mb, mb->endianness, (uint32_t*)value);
 }
 
-bool deserialize_int64_t(MicroBuffer* mb, int64_t* value)
+bool deserialize_int64_t(mcMicroBuffer* mb, int64_t* value)
 {
     return deserialize_byte_8(mb, mb->endianness, (uint64_t*)value);
 }
 
-bool deserialize_float(MicroBuffer* mb, float* value)
+bool deserialize_float(mcMicroBuffer* mb, float* value)
 {
     return deserialize_byte_4(mb, mb->endianness, (uint32_t*)value);
 }
 
-bool deserialize_double(MicroBuffer* mb, double* value)
+bool deserialize_double(mcMicroBuffer* mb, double* value)
 {
     return deserialize_byte_8(mb, mb->endianness, (uint64_t*)value);
 }
 
-bool serialize_endian_uint16_t(MicroBuffer* mb, const Endianness endianness, const uint16_t value)
+bool serialize_endian_uint16_t(mcMicroBuffer* mb, const Endianness endianness, const uint16_t value)
 {
     return serialize_byte_2(mb, endianness, &value);
 }
 
-bool serialize_endian_uint32_t(MicroBuffer* mb, const Endianness endianness, const uint32_t value)
+bool serialize_endian_uint32_t(mcMicroBuffer* mb, const Endianness endianness, const uint32_t value)
 {
     return serialize_byte_4(mb, endianness, &value);
 }
 
-bool serialize_endian_uint64_t(MicroBuffer* mb, const Endianness endianness, const uint64_t value)
+bool serialize_endian_uint64_t(mcMicroBuffer* mb, const Endianness endianness, const uint64_t value)
 {
     return serialize_byte_8(mb, endianness, &value);
 }
 
-bool serialize_endian_int16_t(MicroBuffer* mb, const Endianness endianness, const int16_t value)
+bool serialize_endian_int16_t(mcMicroBuffer* mb, const Endianness endianness, const int16_t value)
 {
     return serialize_byte_2(mb, endianness, (uint16_t*)&value);
 }
 
-bool serialize_endian_int32_t(MicroBuffer* mb, const Endianness endianness, const int32_t value)
+bool serialize_endian_int32_t(mcMicroBuffer* mb, const Endianness endianness, const int32_t value)
 {
     return serialize_byte_4(mb, endianness, (uint32_t*)&value);
 }
 
-bool serialize_endian_int64_t(MicroBuffer* mb, const Endianness endianness, const int64_t value)
+bool serialize_endian_int64_t(mcMicroBuffer* mb, const Endianness endianness, const int64_t value)
 {
     return serialize_byte_8(mb, endianness, (uint64_t*)&value);
 }
 
-bool serialize_endian_float(MicroBuffer* mb, const Endianness endianness, const float value)
+bool serialize_endian_float(mcMicroBuffer* mb, const Endianness endianness, const float value)
 {
     return serialize_byte_4(mb, endianness, (uint32_t*)&value);
 }
 
-bool serialize_endian_double(MicroBuffer* mb, const Endianness endianness, const double value)
+bool serialize_endian_double(mcMicroBuffer* mb, const Endianness endianness, const double value)
 {
     return serialize_byte_8(mb, endianness, (uint64_t*)&value);
 }
 
-bool deserialize_endian_uint16_t(MicroBuffer* mb, const Endianness endianness, uint16_t* value)
+bool deserialize_endian_uint16_t(mcMicroBuffer* mb, const Endianness endianness, uint16_t* value)
 {
     return deserialize_byte_2(mb, endianness, value);
 }
 
-bool deserialize_endian_uint32_t(MicroBuffer* mb, const Endianness endianness, uint32_t* value)
+bool deserialize_endian_uint32_t(mcMicroBuffer* mb, const Endianness endianness, uint32_t* value)
 {
     return deserialize_byte_4(mb, endianness, value);
 }
 
-bool deserialize_endian_uint64_t(MicroBuffer* mb, const Endianness endianness, uint64_t* value)
+bool deserialize_endian_uint64_t(mcMicroBuffer* mb, const Endianness endianness, uint64_t* value)
 {
     return deserialize_byte_8(mb, endianness, value);
 }
 
-bool deserialize_endian_int16_t(MicroBuffer* mb, const Endianness endianness, int16_t* value)
+bool deserialize_endian_int16_t(mcMicroBuffer* mb, const Endianness endianness, int16_t* value)
 {
     return deserialize_byte_2(mb, endianness, (uint16_t*)value);
 }
 
-bool deserialize_endian_int32_t(MicroBuffer* mb, const Endianness endianness, int32_t* value)
+bool deserialize_endian_int32_t(mcMicroBuffer* mb, const Endianness endianness, int32_t* value)
 {
     return deserialize_byte_4(mb, endianness, (uint32_t*)value);
 }
 
-bool deserialize_endian_int64_t(MicroBuffer* mb, const Endianness endianness, int64_t* value)
+bool deserialize_endian_int64_t(mcMicroBuffer* mb, const Endianness endianness, int64_t* value)
 {
     return deserialize_byte_8(mb, endianness, (uint64_t*)value);
 }
 
-bool deserialize_endian_float(MicroBuffer* mb, const Endianness endianness, float* value)
+bool deserialize_endian_float(mcMicroBuffer* mb, const Endianness endianness, float* value)
 {
     return deserialize_byte_4(mb, endianness, (uint32_t*)value);
 }
 
-bool deserialize_endian_double(MicroBuffer* mb, const Endianness endianness, double* value)
+bool deserialize_endian_double(mcMicroBuffer* mb, const Endianness endianness, double* value)
 {
     return deserialize_byte_8(mb, endianness, (uint64_t*)value);
 }

--- a/src/c/types/basic_internals.h
+++ b/src/c/types/basic_internals.h
@@ -25,14 +25,14 @@ extern "C" {
 //                  INTERNAL SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
 bool serialize_byte_1(mcMicroBuffer* buffer, const uint8_t* byte);
-bool serialize_byte_2(mcMicroBuffer* buffer, Endianness endianness, const uint16_t* bytes);
-bool serialize_byte_4(mcMicroBuffer* buffer, Endianness endianness, const uint32_t* bytes);
-bool serialize_byte_8(mcMicroBuffer* buffer, Endianness endianness, const uint64_t* bytes);
+bool serialize_byte_2(mcMicroBuffer* buffer, mrEndianness endianness, const uint16_t* bytes);
+bool serialize_byte_4(mcMicroBuffer* buffer, mrEndianness endianness, const uint32_t* bytes);
+bool serialize_byte_8(mcMicroBuffer* buffer, mrEndianness endianness, const uint64_t* bytes);
 
 bool deserialize_byte_1(mcMicroBuffer* buffer, uint8_t* byte);
-bool deserialize_byte_2(mcMicroBuffer* buffer, Endianness endianness, uint16_t* bytes);
-bool deserialize_byte_4(mcMicroBuffer* buffer, Endianness endianness, uint32_t* bytes);
-bool deserialize_byte_8(mcMicroBuffer* buffer, Endianness endianness, uint64_t* bytes);
+bool deserialize_byte_2(mcMicroBuffer* buffer, mrEndianness endianness, uint16_t* bytes);
+bool deserialize_byte_4(mcMicroBuffer* buffer, mrEndianness endianness, uint32_t* bytes);
+bool deserialize_byte_8(mcMicroBuffer* buffer, mrEndianness endianness, uint64_t* bytes);
 
 #ifdef __cplusplus
 }

--- a/src/c/types/basic_internals.h
+++ b/src/c/types/basic_internals.h
@@ -24,15 +24,15 @@ extern "C" {
 // -------------------------------------------------------------------
 //                  INTERNAL SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
-bool mc_serialize_byte_1(mcMicroBuffer* buffer, const uint8_t* byte);
-bool mc_serialize_byte_2(mcMicroBuffer* buffer, Endianness endianness, const uint16_t* bytes);
-bool mc_serialize_byte_4(mcMicroBuffer* buffer, Endianness endianness, const uint32_t* bytes);
-bool mc_serialize_byte_8(mcMicroBuffer* buffer, Endianness endianness, const uint64_t* bytes);
+bool serialize_byte_1(mcMicroBuffer* buffer, const uint8_t* byte);
+bool serialize_byte_2(mcMicroBuffer* buffer, Endianness endianness, const uint16_t* bytes);
+bool serialize_byte_4(mcMicroBuffer* buffer, Endianness endianness, const uint32_t* bytes);
+bool serialize_byte_8(mcMicroBuffer* buffer, Endianness endianness, const uint64_t* bytes);
 
-bool mc_deserialize_byte_1(mcMicroBuffer* buffer, uint8_t* byte);
-bool mc_deserialize_byte_2(mcMicroBuffer* buffer, Endianness endianness, uint16_t* bytes);
-bool mc_deserialize_byte_4(mcMicroBuffer* buffer, Endianness endianness, uint32_t* bytes);
-bool mc_deserialize_byte_8(mcMicroBuffer* buffer, Endianness endianness, uint64_t* bytes);
+bool deserialize_byte_1(mcMicroBuffer* buffer, uint8_t* byte);
+bool deserialize_byte_2(mcMicroBuffer* buffer, Endianness endianness, uint16_t* bytes);
+bool deserialize_byte_4(mcMicroBuffer* buffer, Endianness endianness, uint32_t* bytes);
+bool deserialize_byte_8(mcMicroBuffer* buffer, Endianness endianness, uint64_t* bytes);
 
 #ifdef __cplusplus
 }

--- a/src/c/types/basic_internals.h
+++ b/src/c/types/basic_internals.h
@@ -24,10 +24,10 @@ extern "C" {
 // -------------------------------------------------------------------
 //                  INTERNAL SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
-bool serialize_byte_1(mcMicroBuffer* buffer, const uint8_t* byte);
-bool serialize_byte_2(mcMicroBuffer* buffer, Endianness endianness, const uint16_t* bytes);
-bool serialize_byte_4(mcMicroBuffer* buffer, Endianness endianness, const uint32_t* bytes);
-bool serialize_byte_8(mcMicroBuffer* buffer, Endianness endianness, const uint64_t* bytes);
+bool mc_serialize_byte_1(mcMicroBuffer* buffer, const uint8_t* byte);
+bool mc_serialize_byte_2(mcMicroBuffer* buffer, Endianness endianness, const uint16_t* bytes);
+bool mc_serialize_byte_4(mcMicroBuffer* buffer, Endianness endianness, const uint32_t* bytes);
+bool mc_serialize_byte_8(mcMicroBuffer* buffer, Endianness endianness, const uint64_t* bytes);
 
 bool mc_deserialize_byte_1(mcMicroBuffer* buffer, uint8_t* byte);
 bool mc_deserialize_byte_2(mcMicroBuffer* buffer, Endianness endianness, uint16_t* bytes);

--- a/src/c/types/basic_internals.h
+++ b/src/c/types/basic_internals.h
@@ -24,15 +24,15 @@ extern "C" {
 // -------------------------------------------------------------------
 //                  INTERNAL SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
-bool serialize_byte_1(mcMicroBuffer* buffer, const uint8_t* byte);
-bool serialize_byte_2(mcMicroBuffer* buffer, mrEndianness endianness, const uint16_t* bytes);
-bool serialize_byte_4(mcMicroBuffer* buffer, mrEndianness endianness, const uint32_t* bytes);
-bool serialize_byte_8(mcMicroBuffer* buffer, mrEndianness endianness, const uint64_t* bytes);
+bool serialize_byte_1(mcBuffer* buffer, const uint8_t* byte);
+bool serialize_byte_2(mcBuffer* buffer, mrEndianness endianness, const uint16_t* bytes);
+bool serialize_byte_4(mcBuffer* buffer, mrEndianness endianness, const uint32_t* bytes);
+bool serialize_byte_8(mcBuffer* buffer, mrEndianness endianness, const uint64_t* bytes);
 
-bool deserialize_byte_1(mcMicroBuffer* buffer, uint8_t* byte);
-bool deserialize_byte_2(mcMicroBuffer* buffer, mrEndianness endianness, uint16_t* bytes);
-bool deserialize_byte_4(mcMicroBuffer* buffer, mrEndianness endianness, uint32_t* bytes);
-bool deserialize_byte_8(mcMicroBuffer* buffer, mrEndianness endianness, uint64_t* bytes);
+bool deserialize_byte_1(mcBuffer* buffer, uint8_t* byte);
+bool deserialize_byte_2(mcBuffer* buffer, mrEndianness endianness, uint16_t* bytes);
+bool deserialize_byte_4(mcBuffer* buffer, mrEndianness endianness, uint32_t* bytes);
+bool deserialize_byte_8(mcBuffer* buffer, mrEndianness endianness, uint64_t* bytes);
 
 #ifdef __cplusplus
 }

--- a/src/c/types/basic_internals.h
+++ b/src/c/types/basic_internals.h
@@ -29,10 +29,10 @@ bool serialize_byte_2(mcMicroBuffer* buffer, Endianness endianness, const uint16
 bool serialize_byte_4(mcMicroBuffer* buffer, Endianness endianness, const uint32_t* bytes);
 bool serialize_byte_8(mcMicroBuffer* buffer, Endianness endianness, const uint64_t* bytes);
 
-bool deserialize_byte_1(mcMicroBuffer* buffer, uint8_t* byte);
-bool deserialize_byte_2(mcMicroBuffer* buffer, Endianness endianness, uint16_t* bytes);
-bool deserialize_byte_4(mcMicroBuffer* buffer, Endianness endianness, uint32_t* bytes);
-bool deserialize_byte_8(mcMicroBuffer* buffer, Endianness endianness, uint64_t* bytes);
+bool mc_deserialize_byte_1(mcMicroBuffer* buffer, uint8_t* byte);
+bool mc_deserialize_byte_2(mcMicroBuffer* buffer, Endianness endianness, uint16_t* bytes);
+bool mc_deserialize_byte_4(mcMicroBuffer* buffer, Endianness endianness, uint32_t* bytes);
+bool mc_deserialize_byte_8(mcMicroBuffer* buffer, Endianness endianness, uint64_t* bytes);
 
 #ifdef __cplusplus
 }

--- a/src/c/types/basic_internals.h
+++ b/src/c/types/basic_internals.h
@@ -25,14 +25,14 @@ extern "C" {
 //                  INTERNAL SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
 bool serialize_byte_1(mcBuffer* buffer, const uint8_t* byte);
-bool serialize_byte_2(mcBuffer* buffer, mrEndianness endianness, const uint16_t* bytes);
-bool serialize_byte_4(mcBuffer* buffer, mrEndianness endianness, const uint32_t* bytes);
-bool serialize_byte_8(mcBuffer* buffer, mrEndianness endianness, const uint64_t* bytes);
+bool serialize_byte_2(mcBuffer* buffer, mcEndianness endianness, const uint16_t* bytes);
+bool serialize_byte_4(mcBuffer* buffer, mcEndianness endianness, const uint32_t* bytes);
+bool serialize_byte_8(mcBuffer* buffer, mcEndianness endianness, const uint64_t* bytes);
 
 bool deserialize_byte_1(mcBuffer* buffer, uint8_t* byte);
-bool deserialize_byte_2(mcBuffer* buffer, mrEndianness endianness, uint16_t* bytes);
-bool deserialize_byte_4(mcBuffer* buffer, mrEndianness endianness, uint32_t* bytes);
-bool deserialize_byte_8(mcBuffer* buffer, mrEndianness endianness, uint64_t* bytes);
+bool deserialize_byte_2(mcBuffer* buffer, mcEndianness endianness, uint16_t* bytes);
+bool deserialize_byte_4(mcBuffer* buffer, mcEndianness endianness, uint32_t* bytes);
+bool deserialize_byte_8(mcBuffer* buffer, mcEndianness endianness, uint64_t* bytes);
 
 #ifdef __cplusplus
 }

--- a/src/c/types/basic_internals.h
+++ b/src/c/types/basic_internals.h
@@ -24,15 +24,15 @@ extern "C" {
 // -------------------------------------------------------------------
 //                  INTERNAL SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
-bool serialize_byte_1(MicroBuffer* buffer, const uint8_t* byte);
-bool serialize_byte_2(MicroBuffer* buffer, Endianness endianness, const uint16_t* bytes);
-bool serialize_byte_4(MicroBuffer* buffer, Endianness endianness, const uint32_t* bytes);
-bool serialize_byte_8(MicroBuffer* buffer, Endianness endianness, const uint64_t* bytes);
+bool serialize_byte_1(mcMicroBuffer* buffer, const uint8_t* byte);
+bool serialize_byte_2(mcMicroBuffer* buffer, Endianness endianness, const uint16_t* bytes);
+bool serialize_byte_4(mcMicroBuffer* buffer, Endianness endianness, const uint32_t* bytes);
+bool serialize_byte_8(mcMicroBuffer* buffer, Endianness endianness, const uint64_t* bytes);
 
-bool deserialize_byte_1(MicroBuffer* buffer, uint8_t* byte);
-bool deserialize_byte_2(MicroBuffer* buffer, Endianness endianness, uint16_t* bytes);
-bool deserialize_byte_4(MicroBuffer* buffer, Endianness endianness, uint32_t* bytes);
-bool deserialize_byte_8(MicroBuffer* buffer, Endianness endianness, uint64_t* bytes);
+bool deserialize_byte_1(mcMicroBuffer* buffer, uint8_t* byte);
+bool deserialize_byte_2(mcMicroBuffer* buffer, Endianness endianness, uint16_t* bytes);
+bool deserialize_byte_4(mcMicroBuffer* buffer, Endianness endianness, uint32_t* bytes);
+bool deserialize_byte_8(mcMicroBuffer* buffer, Endianness endianness, uint64_t* bytes);
 
 #ifdef __cplusplus
 }

--- a/src/c/types/sequence.c
+++ b/src/c/types/sequence.c
@@ -37,28 +37,28 @@ static inline void mc_deserialize_sequence_header(mcMicroBuffer* mb, Endianness 
 
 
 
-bool serialize_sequence_byte_1(mcMicroBuffer* mb, Endianness endianness, const uint8_t* array, const uint32_t size)
+bool mc_serialize_sequence_byte_1(mcMicroBuffer* mb, Endianness endianness, const uint8_t* array, const uint32_t size)
 {
-    serialize_endian_uint32_t(mb, endianness, size);
-    return serialize_array_byte_1(mb, array, size);
+    mc_serialize_endian_uint32_t(mb, endianness, size);
+    return mc_serialize_array_byte_1(mb, array, size);
 }
 
-bool serialize_sequence_byte_2(mcMicroBuffer* mb, Endianness endianness, const uint16_t* array, const uint32_t size)
+bool mc_serialize_sequence_byte_2(mcMicroBuffer* mb, Endianness endianness, const uint16_t* array, const uint32_t size)
 {
-    serialize_endian_uint32_t(mb, endianness, size);
-    return serialize_array_byte_2(mb, endianness, array, size);
+    mc_serialize_endian_uint32_t(mb, endianness, size);
+    return mc_serialize_array_byte_2(mb, endianness, array, size);
 }
 
-bool serialize_sequence_byte_4(mcMicroBuffer* mb, Endianness endianness, const uint32_t* array, const uint32_t size)
+bool mc_serialize_sequence_byte_4(mcMicroBuffer* mb, Endianness endianness, const uint32_t* array, const uint32_t size)
 {
-    serialize_endian_uint32_t(mb, endianness, size);
-    return serialize_array_byte_4(mb, endianness, array, size);
+    mc_serialize_endian_uint32_t(mb, endianness, size);
+    return mc_serialize_array_byte_4(mb, endianness, array, size);
 }
 
-bool serialize_sequence_byte_8(mcMicroBuffer* mb, Endianness endianness, const uint64_t* array, const uint32_t size)
+bool mc_serialize_sequence_byte_8(mcMicroBuffer* mb, Endianness endianness, const uint64_t* array, const uint32_t size)
 {
-    serialize_endian_uint32_t(mb, endianness, size);
-    return serialize_array_byte_8(mb, endianness, array, size);
+    mc_serialize_endian_uint32_t(mb, endianness, size);
+    return mc_serialize_array_byte_8(mb, endianness, array, size);
 }
 
 bool mc_deserialize_sequence_byte_1(mcMicroBuffer* mb, Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
@@ -89,64 +89,64 @@ bool mc_deserialize_sequence_byte_8(mcMicroBuffer* mb, Endianness endianness, ui
 //              PUBLIC SERIALIZATION IMPLEMENTATIONS
 // -------------------------------------------------------------------
 
-bool serialize_sequence_char(mcMicroBuffer* mb, const char* array, const uint32_t size)
+bool mc_serialize_sequence_char(mcMicroBuffer* mb, const char* array, const uint32_t size)
 {
-    return serialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, size);
+    return mc_serialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, size);
 }
 
-bool serialize_sequence_bool(mcMicroBuffer* mb, const bool* array, const uint32_t size)
+bool mc_serialize_sequence_bool(mcMicroBuffer* mb, const bool* array, const uint32_t size)
 {
-    return serialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, size);
+    return mc_serialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, size);
 }
 
-bool serialize_sequence_uint8_t(mcMicroBuffer* mb, const uint8_t* array, const uint32_t size)
+bool mc_serialize_sequence_uint8_t(mcMicroBuffer* mb, const uint8_t* array, const uint32_t size)
 {
-    return serialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, size);
+    return mc_serialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, size);
 }
 
-bool serialize_sequence_uint16_t(mcMicroBuffer* mb, const uint16_t* array, const uint32_t size)
+bool mc_serialize_sequence_uint16_t(mcMicroBuffer* mb, const uint16_t* array, const uint32_t size)
 {
-    return serialize_sequence_byte_2(mb, mb->endianness, (uint16_t*)array, size);
+    return mc_serialize_sequence_byte_2(mb, mb->endianness, (uint16_t*)array, size);
 }
 
-bool serialize_sequence_uint32_t(mcMicroBuffer* mb, const uint32_t* array, const uint32_t size)
+bool mc_serialize_sequence_uint32_t(mcMicroBuffer* mb, const uint32_t* array, const uint32_t size)
 {
-    return serialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, size);
+    return mc_serialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, size);
 }
 
-bool serialize_sequence_uint64_t(mcMicroBuffer* mb, const uint64_t* array, const uint32_t size)
+bool mc_serialize_sequence_uint64_t(mcMicroBuffer* mb, const uint64_t* array, const uint32_t size)
 {
-    return serialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, size);
+    return mc_serialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
-bool serialize_sequence_int8_t(mcMicroBuffer* mb, const int8_t* array, const uint32_t size)
+bool mc_serialize_sequence_int8_t(mcMicroBuffer* mb, const int8_t* array, const uint32_t size)
 {
-    return serialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, size);
+    return mc_serialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, size);
 }
 
-bool serialize_sequence_int16_t(mcMicroBuffer* mb, const int16_t* array, const uint32_t size)
+bool mc_serialize_sequence_int16_t(mcMicroBuffer* mb, const int16_t* array, const uint32_t size)
 {
-    return serialize_sequence_byte_2(mb, mb->endianness, (uint16_t*)array, size);
+    return mc_serialize_sequence_byte_2(mb, mb->endianness, (uint16_t*)array, size);
 }
 
-bool serialize_sequence_int32_t(mcMicroBuffer* mb, const int32_t* array, const uint32_t size)
+bool mc_serialize_sequence_int32_t(mcMicroBuffer* mb, const int32_t* array, const uint32_t size)
 {
-    return serialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, size);
+    return mc_serialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, size);
 }
 
-bool serialize_sequence_int64_t(mcMicroBuffer* mb, const int64_t* array, const uint32_t size)
+bool mc_serialize_sequence_int64_t(mcMicroBuffer* mb, const int64_t* array, const uint32_t size)
 {
-    return serialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, size);
+    return mc_serialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
-bool serialize_sequence_float(mcMicroBuffer* mb, const float* array, const uint32_t size)
+bool mc_serialize_sequence_float(mcMicroBuffer* mb, const float* array, const uint32_t size)
 {
-    return serialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, size);
+    return mc_serialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, size);
 }
 
-bool serialize_sequence_double(mcMicroBuffer* mb, const double* array, const uint32_t size)
+bool mc_serialize_sequence_double(mcMicroBuffer* mb, const double* array, const uint32_t size)
 {
-    return serialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, size);
+    return mc_serialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
 bool mc_deserialize_sequence_char(mcMicroBuffer* mb, char* array, const uint32_t array_capacity, uint32_t* size)
@@ -209,64 +209,64 @@ bool mc_deserialize_sequence_double(mcMicroBuffer* mb, double* array, const uint
     return mc_deserialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, array_capacity, size);
 }
 
-bool serialize_endian_sequence_char(mcMicroBuffer* mb, const Endianness endianness, const char* array, const uint32_t size)
+bool mc_serialize_endian_sequence_char(mcMicroBuffer* mb, const Endianness endianness, const char* array, const uint32_t size)
 {
-    return serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
+    return mc_serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
 }
 
-bool serialize_endian_sequence_bool(mcMicroBuffer* mb, const Endianness endianness, const bool* array, const uint32_t size)
+bool mc_serialize_endian_sequence_bool(mcMicroBuffer* mb, const Endianness endianness, const bool* array, const uint32_t size)
 {
-    return serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
+    return mc_serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
 }
 
-bool serialize_endian_sequence_uint8_t(mcMicroBuffer* mb, const Endianness endianness, const uint8_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_uint8_t(mcMicroBuffer* mb, const Endianness endianness, const uint8_t* array, const uint32_t size)
 {
-    return serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
+    return mc_serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
 }
 
-bool serialize_endian_sequence_uint16_t(mcMicroBuffer* mb, const Endianness endianness, const uint16_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_uint16_t(mcMicroBuffer* mb, const Endianness endianness, const uint16_t* array, const uint32_t size)
 {
-    return serialize_sequence_byte_2(mb, endianness, (uint16_t*)array, size);
+    return mc_serialize_sequence_byte_2(mb, endianness, (uint16_t*)array, size);
 }
 
-bool serialize_endian_sequence_uint32_t(mcMicroBuffer* mb, const Endianness endianness, const uint32_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_uint32_t(mcMicroBuffer* mb, const Endianness endianness, const uint32_t* array, const uint32_t size)
 {
-    return serialize_sequence_byte_4(mb, endianness, (uint32_t*)array, size);
+    return mc_serialize_sequence_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool serialize_endian_sequence_uint64_t(mcMicroBuffer* mb, const Endianness endianness, const uint64_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_uint64_t(mcMicroBuffer* mb, const Endianness endianness, const uint64_t* array, const uint32_t size)
 {
-    return serialize_sequence_byte_8(mb, endianness, (uint64_t*)array, size);
+    return mc_serialize_sequence_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool serialize_endian_sequence_int8_t(mcMicroBuffer* mb, const Endianness endianness, const int8_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_int8_t(mcMicroBuffer* mb, const Endianness endianness, const int8_t* array, const uint32_t size)
 {
-    return serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
+    return mc_serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
 }
 
-bool serialize_endian_sequence_int16_t(mcMicroBuffer* mb, const Endianness endianness, const int16_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_int16_t(mcMicroBuffer* mb, const Endianness endianness, const int16_t* array, const uint32_t size)
 {
-    return serialize_sequence_byte_2(mb, endianness, (uint16_t*)array, size);
+    return mc_serialize_sequence_byte_2(mb, endianness, (uint16_t*)array, size);
 }
 
-bool serialize_endian_sequence_int32_t(mcMicroBuffer* mb, const Endianness endianness, const int32_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_int32_t(mcMicroBuffer* mb, const Endianness endianness, const int32_t* array, const uint32_t size)
 {
-    return serialize_sequence_byte_4(mb, endianness, (uint32_t*)array, size);
+    return mc_serialize_sequence_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool serialize_endian_sequence_int64_t(mcMicroBuffer* mb, const Endianness endianness, const int64_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_int64_t(mcMicroBuffer* mb, const Endianness endianness, const int64_t* array, const uint32_t size)
 {
-    return serialize_sequence_byte_8(mb, endianness, (uint64_t*)array, size);
+    return mc_serialize_sequence_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool serialize_endian_sequence_float(mcMicroBuffer* mb, const Endianness endianness, const float* array, const uint32_t size)
+bool mc_serialize_endian_sequence_float(mcMicroBuffer* mb, const Endianness endianness, const float* array, const uint32_t size)
 {
-    return serialize_sequence_byte_4(mb, endianness, (uint32_t*)array, size);
+    return mc_serialize_sequence_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool serialize_endian_sequence_double(mcMicroBuffer* mb, const Endianness endianness, const double* array, const uint32_t size)
+bool mc_serialize_endian_sequence_double(mcMicroBuffer* mb, const Endianness endianness, const double* array, const uint32_t size)
 {
-    return serialize_sequence_byte_8(mb, endianness, (uint64_t*)array, size);
+    return mc_serialize_sequence_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
 bool mc_deserialize_endian_sequence_char(mcMicroBuffer* mb, const Endianness endianness, char* array, const uint32_t array_capacity, uint32_t* size)

--- a/src/c/types/sequence.c
+++ b/src/c/types/sequence.c
@@ -22,7 +22,7 @@
 // -------------------------------------------------------------------
 //                INTERNAL UTIL IMPLEMENTATION
 // -------------------------------------------------------------------
-static inline void mc_deserialize_sequence_header(mcMicroBuffer* mb, Endianness endianness, uint32_t capacity, uint32_t* size)
+static inline void deserialize_sequence_header(mcMicroBuffer* mb, Endianness endianness, uint32_t capacity, uint32_t* size)
 {
     mc_deserialize_endian_uint32_t(mb, endianness, size);
     if(*size > capacity)
@@ -34,55 +34,52 @@ static inline void mc_deserialize_sequence_header(mcMicroBuffer* mb, Endianness 
 // -------------------------------------------------------------------
 //                INTERNAL SERIALIZATION IMPLEMENTATION
 // -------------------------------------------------------------------
-
-
-
-bool mc_serialize_sequence_byte_1(mcMicroBuffer* mb, Endianness endianness, const uint8_t* array, const uint32_t size)
+bool serialize_sequence_byte_1(mcMicroBuffer* mb, Endianness endianness, const uint8_t* array, const uint32_t size)
 {
     mc_serialize_endian_uint32_t(mb, endianness, size);
-    return mc_serialize_array_byte_1(mb, array, size);
+    return serialize_array_byte_1(mb, array, size);
 }
 
-bool mc_serialize_sequence_byte_2(mcMicroBuffer* mb, Endianness endianness, const uint16_t* array, const uint32_t size)
+bool serialize_sequence_byte_2(mcMicroBuffer* mb, Endianness endianness, const uint16_t* array, const uint32_t size)
 {
     mc_serialize_endian_uint32_t(mb, endianness, size);
-    return mc_serialize_array_byte_2(mb, endianness, array, size);
+    return serialize_array_byte_2(mb, endianness, array, size);
 }
 
-bool mc_serialize_sequence_byte_4(mcMicroBuffer* mb, Endianness endianness, const uint32_t* array, const uint32_t size)
+bool serialize_sequence_byte_4(mcMicroBuffer* mb, Endianness endianness, const uint32_t* array, const uint32_t size)
 {
     mc_serialize_endian_uint32_t(mb, endianness, size);
-    return mc_serialize_array_byte_4(mb, endianness, array, size);
+    return serialize_array_byte_4(mb, endianness, array, size);
 }
 
-bool mc_serialize_sequence_byte_8(mcMicroBuffer* mb, Endianness endianness, const uint64_t* array, const uint32_t size)
+bool serialize_sequence_byte_8(mcMicroBuffer* mb, Endianness endianness, const uint64_t* array, const uint32_t size)
 {
     mc_serialize_endian_uint32_t(mb, endianness, size);
-    return mc_serialize_array_byte_8(mb, endianness, array, size);
+    return serialize_array_byte_8(mb, endianness, array, size);
 }
 
-bool mc_deserialize_sequence_byte_1(mcMicroBuffer* mb, Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_byte_1(mcMicroBuffer* mb, Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    mc_deserialize_sequence_header(mb, endianness, array_capacity, size);
-    return mc_deserialize_array_byte_1(mb, array, *size);
+    deserialize_sequence_header(mb, endianness, array_capacity, size);
+    return deserialize_array_byte_1(mb, array, *size);
 }
 
-bool mc_deserialize_sequence_byte_2(mcMicroBuffer* mb, Endianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_byte_2(mcMicroBuffer* mb, Endianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    mc_deserialize_sequence_header(mb, endianness, array_capacity, size);
-    return mc_deserialize_array_byte_2(mb, endianness, array, *size);
+    deserialize_sequence_header(mb, endianness, array_capacity, size);
+    return deserialize_array_byte_2(mb, endianness, array, *size);
 }
 
-bool mc_deserialize_sequence_byte_4(mcMicroBuffer* mb, Endianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_byte_4(mcMicroBuffer* mb, Endianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    mc_deserialize_sequence_header(mb, endianness, array_capacity, size);
-    return mc_deserialize_array_byte_4(mb, endianness, array, *size);
+    deserialize_sequence_header(mb, endianness, array_capacity, size);
+    return deserialize_array_byte_4(mb, endianness, array, *size);
 }
 
-bool mc_deserialize_sequence_byte_8(mcMicroBuffer* mb, Endianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_byte_8(mcMicroBuffer* mb, Endianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    mc_deserialize_sequence_header(mb, endianness, array_capacity, size);
-    return mc_deserialize_array_byte_8(mb, endianness, array, *size);
+    deserialize_sequence_header(mb, endianness, array_capacity, size);
+    return deserialize_array_byte_8(mb, endianness, array, *size);
 }
 
 // -------------------------------------------------------------------
@@ -91,241 +88,241 @@ bool mc_deserialize_sequence_byte_8(mcMicroBuffer* mb, Endianness endianness, ui
 
 bool mc_serialize_sequence_char(mcMicroBuffer* mb, const char* array, const uint32_t size)
 {
-    return mc_serialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, size);
+    return serialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, size);
 }
 
 bool mc_serialize_sequence_bool(mcMicroBuffer* mb, const bool* array, const uint32_t size)
 {
-    return mc_serialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, size);
+    return serialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, size);
 }
 
 bool mc_serialize_sequence_uint8_t(mcMicroBuffer* mb, const uint8_t* array, const uint32_t size)
 {
-    return mc_serialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, size);
+    return serialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, size);
 }
 
 bool mc_serialize_sequence_uint16_t(mcMicroBuffer* mb, const uint16_t* array, const uint32_t size)
 {
-    return mc_serialize_sequence_byte_2(mb, mb->endianness, (uint16_t*)array, size);
+    return serialize_sequence_byte_2(mb, mb->endianness, (uint16_t*)array, size);
 }
 
 bool mc_serialize_sequence_uint32_t(mcMicroBuffer* mb, const uint32_t* array, const uint32_t size)
 {
-    return mc_serialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, size);
+    return serialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, size);
 }
 
 bool mc_serialize_sequence_uint64_t(mcMicroBuffer* mb, const uint64_t* array, const uint32_t size)
 {
-    return mc_serialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, size);
+    return serialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
 bool mc_serialize_sequence_int8_t(mcMicroBuffer* mb, const int8_t* array, const uint32_t size)
 {
-    return mc_serialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, size);
+    return serialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, size);
 }
 
 bool mc_serialize_sequence_int16_t(mcMicroBuffer* mb, const int16_t* array, const uint32_t size)
 {
-    return mc_serialize_sequence_byte_2(mb, mb->endianness, (uint16_t*)array, size);
+    return serialize_sequence_byte_2(mb, mb->endianness, (uint16_t*)array, size);
 }
 
 bool mc_serialize_sequence_int32_t(mcMicroBuffer* mb, const int32_t* array, const uint32_t size)
 {
-    return mc_serialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, size);
+    return serialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, size);
 }
 
 bool mc_serialize_sequence_int64_t(mcMicroBuffer* mb, const int64_t* array, const uint32_t size)
 {
-    return mc_serialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, size);
+    return serialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
 bool mc_serialize_sequence_float(mcMicroBuffer* mb, const float* array, const uint32_t size)
 {
-    return mc_serialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, size);
+    return serialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, size);
 }
 
 bool mc_serialize_sequence_double(mcMicroBuffer* mb, const double* array, const uint32_t size)
 {
-    return mc_serialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, size);
+    return serialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
 bool mc_deserialize_sequence_char(mcMicroBuffer* mb, char* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return mc_deserialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, array_capacity, size);
+    return deserialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, array_capacity, size);
 }
 
 bool mc_deserialize_sequence_bool(mcMicroBuffer* mb, bool* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return mc_deserialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, array_capacity, size);
+    return deserialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, array_capacity, size);
 }
 
 bool mc_deserialize_sequence_uint8_t(mcMicroBuffer* mb, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return mc_deserialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, array_capacity, size);
+    return deserialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, array_capacity, size);
 }
 
 bool mc_deserialize_sequence_uint16_t(mcMicroBuffer* mb, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return mc_deserialize_sequence_byte_2(mb, mb->endianness, (uint16_t*)array, array_capacity, size);
+    return deserialize_sequence_byte_2(mb, mb->endianness, (uint16_t*)array, array_capacity, size);
 }
 
 bool mc_deserialize_sequence_uint32_t(mcMicroBuffer* mb, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return mc_deserialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, array_capacity, size);
+    return deserialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, array_capacity, size);
 }
 
 bool mc_deserialize_sequence_uint64_t(mcMicroBuffer* mb, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return mc_deserialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, array_capacity, size);
+    return deserialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, array_capacity, size);
 }
 
 bool mc_deserialize_sequence_int8_t(mcMicroBuffer* mb, int8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return mc_deserialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, array_capacity, size);
+    return deserialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, array_capacity, size);
 }
 
 bool mc_deserialize_sequence_int16_t(mcMicroBuffer* mb, int16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return mc_deserialize_sequence_byte_2(mb, mb->endianness, (uint16_t*)array, array_capacity, size);
+    return deserialize_sequence_byte_2(mb, mb->endianness, (uint16_t*)array, array_capacity, size);
 }
 
 bool mc_deserialize_sequence_int32_t(mcMicroBuffer* mb, int32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return mc_deserialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, array_capacity, size);
+    return deserialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, array_capacity, size);
 }
 
 bool mc_deserialize_sequence_int64_t(mcMicroBuffer* mb, int64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return mc_deserialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, array_capacity, size);
+    return deserialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, array_capacity, size);
 }
 
 bool mc_deserialize_sequence_float(mcMicroBuffer* mb, float* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return mc_deserialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, array_capacity, size);
+    return deserialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, array_capacity, size);
 }
 
 bool mc_deserialize_sequence_double(mcMicroBuffer* mb, double* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return mc_deserialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, array_capacity, size);
+    return deserialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, array_capacity, size);
 }
 
 bool mc_serialize_endian_sequence_char(mcMicroBuffer* mb, const Endianness endianness, const char* array, const uint32_t size)
 {
-    return mc_serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
+    return serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
 }
 
 bool mc_serialize_endian_sequence_bool(mcMicroBuffer* mb, const Endianness endianness, const bool* array, const uint32_t size)
 {
-    return mc_serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
+    return serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
 }
 
 bool mc_serialize_endian_sequence_uint8_t(mcMicroBuffer* mb, const Endianness endianness, const uint8_t* array, const uint32_t size)
 {
-    return mc_serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
+    return serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
 }
 
 bool mc_serialize_endian_sequence_uint16_t(mcMicroBuffer* mb, const Endianness endianness, const uint16_t* array, const uint32_t size)
 {
-    return mc_serialize_sequence_byte_2(mb, endianness, (uint16_t*)array, size);
+    return serialize_sequence_byte_2(mb, endianness, (uint16_t*)array, size);
 }
 
 bool mc_serialize_endian_sequence_uint32_t(mcMicroBuffer* mb, const Endianness endianness, const uint32_t* array, const uint32_t size)
 {
-    return mc_serialize_sequence_byte_4(mb, endianness, (uint32_t*)array, size);
+    return serialize_sequence_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
 bool mc_serialize_endian_sequence_uint64_t(mcMicroBuffer* mb, const Endianness endianness, const uint64_t* array, const uint32_t size)
 {
-    return mc_serialize_sequence_byte_8(mb, endianness, (uint64_t*)array, size);
+    return serialize_sequence_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
 bool mc_serialize_endian_sequence_int8_t(mcMicroBuffer* mb, const Endianness endianness, const int8_t* array, const uint32_t size)
 {
-    return mc_serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
+    return serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
 }
 
 bool mc_serialize_endian_sequence_int16_t(mcMicroBuffer* mb, const Endianness endianness, const int16_t* array, const uint32_t size)
 {
-    return mc_serialize_sequence_byte_2(mb, endianness, (uint16_t*)array, size);
+    return serialize_sequence_byte_2(mb, endianness, (uint16_t*)array, size);
 }
 
 bool mc_serialize_endian_sequence_int32_t(mcMicroBuffer* mb, const Endianness endianness, const int32_t* array, const uint32_t size)
 {
-    return mc_serialize_sequence_byte_4(mb, endianness, (uint32_t*)array, size);
+    return serialize_sequence_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
 bool mc_serialize_endian_sequence_int64_t(mcMicroBuffer* mb, const Endianness endianness, const int64_t* array, const uint32_t size)
 {
-    return mc_serialize_sequence_byte_8(mb, endianness, (uint64_t*)array, size);
+    return serialize_sequence_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
 bool mc_serialize_endian_sequence_float(mcMicroBuffer* mb, const Endianness endianness, const float* array, const uint32_t size)
 {
-    return mc_serialize_sequence_byte_4(mb, endianness, (uint32_t*)array, size);
+    return serialize_sequence_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
 bool mc_serialize_endian_sequence_double(mcMicroBuffer* mb, const Endianness endianness, const double* array, const uint32_t size)
 {
-    return mc_serialize_sequence_byte_8(mb, endianness, (uint64_t*)array, size);
+    return serialize_sequence_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
 bool mc_deserialize_endian_sequence_char(mcMicroBuffer* mb, const Endianness endianness, char* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return mc_deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
+    return deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
 }
 
 bool mc_deserialize_endian_sequence_bool(mcMicroBuffer* mb, const Endianness endianness, bool* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return mc_deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
+    return deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
 }
 
 bool mc_deserialize_endian_sequence_uint8_t(mcMicroBuffer* mb, const Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return mc_deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
+    return deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
 }
 
 bool mc_deserialize_endian_sequence_uint16_t(mcMicroBuffer* mb, const Endianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return mc_deserialize_sequence_byte_2(mb, endianness, (uint16_t*)array, array_capacity, size);
+    return deserialize_sequence_byte_2(mb, endianness, (uint16_t*)array, array_capacity, size);
 }
 
 bool mc_deserialize_endian_sequence_uint32_t(mcMicroBuffer* mb, const Endianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return mc_deserialize_sequence_byte_4(mb, endianness, (uint32_t*)array, array_capacity, size);
+    return deserialize_sequence_byte_4(mb, endianness, (uint32_t*)array, array_capacity, size);
 }
 
 bool mc_deserialize_endian_sequence_uint64_t(mcMicroBuffer* mb, const Endianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return mc_deserialize_sequence_byte_8(mb, endianness, (uint64_t*)array, array_capacity, size);
+    return deserialize_sequence_byte_8(mb, endianness, (uint64_t*)array, array_capacity, size);
 }
 
 bool mc_deserialize_endian_sequence_int8_t(mcMicroBuffer* mb, const Endianness endianness, int8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return mc_deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
+    return deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
 }
 
 bool mc_deserialize_endian_sequence_int16_t(mcMicroBuffer* mb, const Endianness endianness, int16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return mc_deserialize_sequence_byte_2(mb, endianness, (uint16_t*)array, array_capacity, size);
+    return deserialize_sequence_byte_2(mb, endianness, (uint16_t*)array, array_capacity, size);
 }
 
 bool mc_deserialize_endian_sequence_int32_t(mcMicroBuffer* mb, const Endianness endianness, int32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return mc_deserialize_sequence_byte_4(mb, endianness, (uint32_t*)array, array_capacity, size);
+    return deserialize_sequence_byte_4(mb, endianness, (uint32_t*)array, array_capacity, size);
 }
 
 bool mc_deserialize_endian_sequence_int64_t(mcMicroBuffer* mb, const Endianness endianness, int64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return mc_deserialize_sequence_byte_8(mb, endianness, (uint64_t*)array, array_capacity, size);
+    return deserialize_sequence_byte_8(mb, endianness, (uint64_t*)array, array_capacity, size);
 }
 
 bool mc_deserialize_endian_sequence_float(mcMicroBuffer* mb, const Endianness endianness, float* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return mc_deserialize_sequence_byte_4(mb, endianness, (uint32_t*)array, array_capacity, size);
+    return deserialize_sequence_byte_4(mb, endianness, (uint32_t*)array, array_capacity, size);
 }
 
 bool mc_deserialize_endian_sequence_double(mcMicroBuffer* mb, const Endianness endianness, double* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return mc_deserialize_sequence_byte_8(mb, endianness, (uint64_t*)array, array_capacity, size);
+    return deserialize_sequence_byte_8(mb, endianness, (uint64_t*)array, array_capacity, size);
 }
 

--- a/src/c/types/sequence.c
+++ b/src/c/types/sequence.c
@@ -22,9 +22,9 @@
 // -------------------------------------------------------------------
 //                INTERNAL UTIL IMPLEMENTATION
 // -------------------------------------------------------------------
-static inline void deserialize_sequence_header(mcMicroBuffer* mb, Endianness endianness, uint32_t capacity, uint32_t* size)
+static inline void mc_deserialize_sequence_header(mcMicroBuffer* mb, Endianness endianness, uint32_t capacity, uint32_t* size)
 {
-    deserialize_endian_uint32_t(mb, endianness, size);
+    mc_deserialize_endian_uint32_t(mb, endianness, size);
     if(*size > capacity)
     {
         mb->error = true;
@@ -61,28 +61,28 @@ bool serialize_sequence_byte_8(mcMicroBuffer* mb, Endianness endianness, const u
     return serialize_array_byte_8(mb, endianness, array, size);
 }
 
-bool deserialize_sequence_byte_1(mcMicroBuffer* mb, Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_sequence_byte_1(mcMicroBuffer* mb, Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    deserialize_sequence_header(mb, endianness, array_capacity, size);
-    return deserialize_array_byte_1(mb, array, *size);
+    mc_deserialize_sequence_header(mb, endianness, array_capacity, size);
+    return mc_deserialize_array_byte_1(mb, array, *size);
 }
 
-bool deserialize_sequence_byte_2(mcMicroBuffer* mb, Endianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_sequence_byte_2(mcMicroBuffer* mb, Endianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    deserialize_sequence_header(mb, endianness, array_capacity, size);
-    return deserialize_array_byte_2(mb, endianness, array, *size);
+    mc_deserialize_sequence_header(mb, endianness, array_capacity, size);
+    return mc_deserialize_array_byte_2(mb, endianness, array, *size);
 }
 
-bool deserialize_sequence_byte_4(mcMicroBuffer* mb, Endianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_sequence_byte_4(mcMicroBuffer* mb, Endianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    deserialize_sequence_header(mb, endianness, array_capacity, size);
-    return deserialize_array_byte_4(mb, endianness, array, *size);
+    mc_deserialize_sequence_header(mb, endianness, array_capacity, size);
+    return mc_deserialize_array_byte_4(mb, endianness, array, *size);
 }
 
-bool deserialize_sequence_byte_8(mcMicroBuffer* mb, Endianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_sequence_byte_8(mcMicroBuffer* mb, Endianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    deserialize_sequence_header(mb, endianness, array_capacity, size);
-    return deserialize_array_byte_8(mb, endianness, array, *size);
+    mc_deserialize_sequence_header(mb, endianness, array_capacity, size);
+    return mc_deserialize_array_byte_8(mb, endianness, array, *size);
 }
 
 // -------------------------------------------------------------------
@@ -149,64 +149,64 @@ bool serialize_sequence_double(mcMicroBuffer* mb, const double* array, const uin
     return serialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
-bool deserialize_sequence_char(mcMicroBuffer* mb, char* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_sequence_char(mcMicroBuffer* mb, char* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return deserialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, array_capacity, size);
+    return mc_deserialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool deserialize_sequence_bool(mcMicroBuffer* mb, bool* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_sequence_bool(mcMicroBuffer* mb, bool* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return deserialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, array_capacity, size);
+    return mc_deserialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool deserialize_sequence_uint8_t(mcMicroBuffer* mb, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_sequence_uint8_t(mcMicroBuffer* mb, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return deserialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, array_capacity, size);
+    return mc_deserialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool deserialize_sequence_uint16_t(mcMicroBuffer* mb, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_sequence_uint16_t(mcMicroBuffer* mb, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return deserialize_sequence_byte_2(mb, mb->endianness, (uint16_t*)array, array_capacity, size);
+    return mc_deserialize_sequence_byte_2(mb, mb->endianness, (uint16_t*)array, array_capacity, size);
 }
 
-bool deserialize_sequence_uint32_t(mcMicroBuffer* mb, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_sequence_uint32_t(mcMicroBuffer* mb, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return deserialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, array_capacity, size);
+    return mc_deserialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool deserialize_sequence_uint64_t(mcMicroBuffer* mb, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_sequence_uint64_t(mcMicroBuffer* mb, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return deserialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, array_capacity, size);
+    return mc_deserialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, array_capacity, size);
 }
 
-bool deserialize_sequence_int8_t(mcMicroBuffer* mb, int8_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_sequence_int8_t(mcMicroBuffer* mb, int8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return deserialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, array_capacity, size);
+    return mc_deserialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool deserialize_sequence_int16_t(mcMicroBuffer* mb, int16_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_sequence_int16_t(mcMicroBuffer* mb, int16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return deserialize_sequence_byte_2(mb, mb->endianness, (uint16_t*)array, array_capacity, size);
+    return mc_deserialize_sequence_byte_2(mb, mb->endianness, (uint16_t*)array, array_capacity, size);
 }
 
-bool deserialize_sequence_int32_t(mcMicroBuffer* mb, int32_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_sequence_int32_t(mcMicroBuffer* mb, int32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return deserialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, array_capacity, size);
+    return mc_deserialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool deserialize_sequence_int64_t(mcMicroBuffer* mb, int64_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_sequence_int64_t(mcMicroBuffer* mb, int64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return deserialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, array_capacity, size);
+    return mc_deserialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, array_capacity, size);
 }
 
-bool deserialize_sequence_float(mcMicroBuffer* mb, float* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_sequence_float(mcMicroBuffer* mb, float* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return deserialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, array_capacity, size);
+    return mc_deserialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool deserialize_sequence_double(mcMicroBuffer* mb, double* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_sequence_double(mcMicroBuffer* mb, double* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return deserialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, array_capacity, size);
+    return mc_deserialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, array_capacity, size);
 }
 
 bool serialize_endian_sequence_char(mcMicroBuffer* mb, const Endianness endianness, const char* array, const uint32_t size)
@@ -269,63 +269,63 @@ bool serialize_endian_sequence_double(mcMicroBuffer* mb, const Endianness endian
     return serialize_sequence_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool deserialize_endian_sequence_char(mcMicroBuffer* mb, const Endianness endianness, char* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_char(mcMicroBuffer* mb, const Endianness endianness, char* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
+    return mc_deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool deserialize_endian_sequence_bool(mcMicroBuffer* mb, const Endianness endianness, bool* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_bool(mcMicroBuffer* mb, const Endianness endianness, bool* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
+    return mc_deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool deserialize_endian_sequence_uint8_t(mcMicroBuffer* mb, const Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_uint8_t(mcMicroBuffer* mb, const Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
+    return mc_deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool deserialize_endian_sequence_uint16_t(mcMicroBuffer* mb, const Endianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_uint16_t(mcMicroBuffer* mb, const Endianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return deserialize_sequence_byte_2(mb, endianness, (uint16_t*)array, array_capacity, size);
+    return mc_deserialize_sequence_byte_2(mb, endianness, (uint16_t*)array, array_capacity, size);
 }
 
-bool deserialize_endian_sequence_uint32_t(mcMicroBuffer* mb, const Endianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_uint32_t(mcMicroBuffer* mb, const Endianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return deserialize_sequence_byte_4(mb, endianness, (uint32_t*)array, array_capacity, size);
+    return mc_deserialize_sequence_byte_4(mb, endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool deserialize_endian_sequence_uint64_t(mcMicroBuffer* mb, const Endianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_uint64_t(mcMicroBuffer* mb, const Endianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return deserialize_sequence_byte_8(mb, endianness, (uint64_t*)array, array_capacity, size);
+    return mc_deserialize_sequence_byte_8(mb, endianness, (uint64_t*)array, array_capacity, size);
 }
 
-bool deserialize_endian_sequence_int8_t(mcMicroBuffer* mb, const Endianness endianness, int8_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_int8_t(mcMicroBuffer* mb, const Endianness endianness, int8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
+    return mc_deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool deserialize_endian_sequence_int16_t(mcMicroBuffer* mb, const Endianness endianness, int16_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_int16_t(mcMicroBuffer* mb, const Endianness endianness, int16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return deserialize_sequence_byte_2(mb, endianness, (uint16_t*)array, array_capacity, size);
+    return mc_deserialize_sequence_byte_2(mb, endianness, (uint16_t*)array, array_capacity, size);
 }
 
-bool deserialize_endian_sequence_int32_t(mcMicroBuffer* mb, const Endianness endianness, int32_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_int32_t(mcMicroBuffer* mb, const Endianness endianness, int32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return deserialize_sequence_byte_4(mb, endianness, (uint32_t*)array, array_capacity, size);
+    return mc_deserialize_sequence_byte_4(mb, endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool deserialize_endian_sequence_int64_t(mcMicroBuffer* mb, const Endianness endianness, int64_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_int64_t(mcMicroBuffer* mb, const Endianness endianness, int64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return deserialize_sequence_byte_8(mb, endianness, (uint64_t*)array, array_capacity, size);
+    return mc_deserialize_sequence_byte_8(mb, endianness, (uint64_t*)array, array_capacity, size);
 }
 
-bool deserialize_endian_sequence_float(mcMicroBuffer* mb, const Endianness endianness, float* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_float(mcMicroBuffer* mb, const Endianness endianness, float* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return deserialize_sequence_byte_4(mb, endianness, (uint32_t*)array, array_capacity, size);
+    return mc_deserialize_sequence_byte_4(mb, endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool deserialize_endian_sequence_double(mcMicroBuffer* mb, const Endianness endianness, double* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_double(mcMicroBuffer* mb, const Endianness endianness, double* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return deserialize_sequence_byte_8(mb, endianness, (uint64_t*)array, array_capacity, size);
+    return mc_deserialize_sequence_byte_8(mb, endianness, (uint64_t*)array, array_capacity, size);
 }
 

--- a/src/c/types/sequence.c
+++ b/src/c/types/sequence.c
@@ -22,7 +22,7 @@
 // -------------------------------------------------------------------
 //                INTERNAL UTIL IMPLEMENTATION
 // -------------------------------------------------------------------
-static inline void deserialize_sequence_header(mcMicroBuffer* mb, mrEndianness endianness, uint32_t capacity, uint32_t* size)
+static inline void deserialize_sequence_header(mcBuffer* mb, mrEndianness endianness, uint32_t capacity, uint32_t* size)
 {
     mc_deserialize_endian_uint32_t(mb, endianness, size);
     if(*size > capacity)
@@ -34,49 +34,49 @@ static inline void deserialize_sequence_header(mcMicroBuffer* mb, mrEndianness e
 // -------------------------------------------------------------------
 //                INTERNAL SERIALIZATION IMPLEMENTATION
 // -------------------------------------------------------------------
-bool serialize_sequence_byte_1(mcMicroBuffer* mb, mrEndianness endianness, const uint8_t* array, const uint32_t size)
+bool serialize_sequence_byte_1(mcBuffer* mb, mrEndianness endianness, const uint8_t* array, const uint32_t size)
 {
     mc_serialize_endian_uint32_t(mb, endianness, size);
     return serialize_array_byte_1(mb, array, size);
 }
 
-bool serialize_sequence_byte_2(mcMicroBuffer* mb, mrEndianness endianness, const uint16_t* array, const uint32_t size)
+bool serialize_sequence_byte_2(mcBuffer* mb, mrEndianness endianness, const uint16_t* array, const uint32_t size)
 {
     mc_serialize_endian_uint32_t(mb, endianness, size);
     return serialize_array_byte_2(mb, endianness, array, size);
 }
 
-bool serialize_sequence_byte_4(mcMicroBuffer* mb, mrEndianness endianness, const uint32_t* array, const uint32_t size)
+bool serialize_sequence_byte_4(mcBuffer* mb, mrEndianness endianness, const uint32_t* array, const uint32_t size)
 {
     mc_serialize_endian_uint32_t(mb, endianness, size);
     return serialize_array_byte_4(mb, endianness, array, size);
 }
 
-bool serialize_sequence_byte_8(mcMicroBuffer* mb, mrEndianness endianness, const uint64_t* array, const uint32_t size)
+bool serialize_sequence_byte_8(mcBuffer* mb, mrEndianness endianness, const uint64_t* array, const uint32_t size)
 {
     mc_serialize_endian_uint32_t(mb, endianness, size);
     return serialize_array_byte_8(mb, endianness, array, size);
 }
 
-bool deserialize_sequence_byte_1(mcMicroBuffer* mb, mrEndianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_byte_1(mcBuffer* mb, mrEndianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     deserialize_sequence_header(mb, endianness, array_capacity, size);
     return deserialize_array_byte_1(mb, array, *size);
 }
 
-bool deserialize_sequence_byte_2(mcMicroBuffer* mb, mrEndianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_byte_2(mcBuffer* mb, mrEndianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     deserialize_sequence_header(mb, endianness, array_capacity, size);
     return deserialize_array_byte_2(mb, endianness, array, *size);
 }
 
-bool deserialize_sequence_byte_4(mcMicroBuffer* mb, mrEndianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_byte_4(mcBuffer* mb, mrEndianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     deserialize_sequence_header(mb, endianness, array_capacity, size);
     return deserialize_array_byte_4(mb, endianness, array, *size);
 }
 
-bool deserialize_sequence_byte_8(mcMicroBuffer* mb, mrEndianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_byte_8(mcBuffer* mb, mrEndianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     deserialize_sequence_header(mb, endianness, array_capacity, size);
     return deserialize_array_byte_8(mb, endianness, array, *size);
@@ -86,242 +86,242 @@ bool deserialize_sequence_byte_8(mcMicroBuffer* mb, mrEndianness endianness, uin
 //              PUBLIC SERIALIZATION IMPLEMENTATIONS
 // -------------------------------------------------------------------
 
-bool mc_serialize_sequence_char(mcMicroBuffer* mb, const char* array, const uint32_t size)
+bool mc_serialize_sequence_char(mcBuffer* mb, const char* array, const uint32_t size)
 {
     return serialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, size);
 }
 
-bool mc_serialize_sequence_bool(mcMicroBuffer* mb, const bool* array, const uint32_t size)
+bool mc_serialize_sequence_bool(mcBuffer* mb, const bool* array, const uint32_t size)
 {
     return serialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, size);
 }
 
-bool mc_serialize_sequence_uint8_t(mcMicroBuffer* mb, const uint8_t* array, const uint32_t size)
+bool mc_serialize_sequence_uint8_t(mcBuffer* mb, const uint8_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, size);
 }
 
-bool mc_serialize_sequence_uint16_t(mcMicroBuffer* mb, const uint16_t* array, const uint32_t size)
+bool mc_serialize_sequence_uint16_t(mcBuffer* mb, const uint16_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_2(mb, mb->endianness, (uint16_t*)array, size);
 }
 
-bool mc_serialize_sequence_uint32_t(mcMicroBuffer* mb, const uint32_t* array, const uint32_t size)
+bool mc_serialize_sequence_uint32_t(mcBuffer* mb, const uint32_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, size);
 }
 
-bool mc_serialize_sequence_uint64_t(mcMicroBuffer* mb, const uint64_t* array, const uint32_t size)
+bool mc_serialize_sequence_uint64_t(mcBuffer* mb, const uint64_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
-bool mc_serialize_sequence_int8_t(mcMicroBuffer* mb, const int8_t* array, const uint32_t size)
+bool mc_serialize_sequence_int8_t(mcBuffer* mb, const int8_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, size);
 }
 
-bool mc_serialize_sequence_int16_t(mcMicroBuffer* mb, const int16_t* array, const uint32_t size)
+bool mc_serialize_sequence_int16_t(mcBuffer* mb, const int16_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_2(mb, mb->endianness, (uint16_t*)array, size);
 }
 
-bool mc_serialize_sequence_int32_t(mcMicroBuffer* mb, const int32_t* array, const uint32_t size)
+bool mc_serialize_sequence_int32_t(mcBuffer* mb, const int32_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, size);
 }
 
-bool mc_serialize_sequence_int64_t(mcMicroBuffer* mb, const int64_t* array, const uint32_t size)
+bool mc_serialize_sequence_int64_t(mcBuffer* mb, const int64_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
-bool mc_serialize_sequence_float(mcMicroBuffer* mb, const float* array, const uint32_t size)
+bool mc_serialize_sequence_float(mcBuffer* mb, const float* array, const uint32_t size)
 {
     return serialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, size);
 }
 
-bool mc_serialize_sequence_double(mcMicroBuffer* mb, const double* array, const uint32_t size)
+bool mc_serialize_sequence_double(mcBuffer* mb, const double* array, const uint32_t size)
 {
     return serialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
-bool mc_deserialize_sequence_char(mcMicroBuffer* mb, char* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_sequence_char(mcBuffer* mb, char* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_sequence_bool(mcMicroBuffer* mb, bool* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_sequence_bool(mcBuffer* mb, bool* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_sequence_uint8_t(mcMicroBuffer* mb, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_sequence_uint8_t(mcBuffer* mb, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_sequence_uint16_t(mcMicroBuffer* mb, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_sequence_uint16_t(mcBuffer* mb, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_2(mb, mb->endianness, (uint16_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_sequence_uint32_t(mcMicroBuffer* mb, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_sequence_uint32_t(mcBuffer* mb, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_sequence_uint64_t(mcMicroBuffer* mb, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_sequence_uint64_t(mcBuffer* mb, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_sequence_int8_t(mcMicroBuffer* mb, int8_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_sequence_int8_t(mcBuffer* mb, int8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_sequence_int16_t(mcMicroBuffer* mb, int16_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_sequence_int16_t(mcBuffer* mb, int16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_2(mb, mb->endianness, (uint16_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_sequence_int32_t(mcMicroBuffer* mb, int32_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_sequence_int32_t(mcBuffer* mb, int32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_sequence_int64_t(mcMicroBuffer* mb, int64_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_sequence_int64_t(mcBuffer* mb, int64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_sequence_float(mcMicroBuffer* mb, float* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_sequence_float(mcBuffer* mb, float* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_sequence_double(mcMicroBuffer* mb, double* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_sequence_double(mcBuffer* mb, double* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, array_capacity, size);
 }
 
-bool mc_serialize_endian_sequence_char(mcMicroBuffer* mb, const mrEndianness endianness, const char* array, const uint32_t size)
+bool mc_serialize_endian_sequence_char(mcBuffer* mb, const mrEndianness endianness, const char* array, const uint32_t size)
 {
     return serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_bool(mcMicroBuffer* mb, const mrEndianness endianness, const bool* array, const uint32_t size)
+bool mc_serialize_endian_sequence_bool(mcBuffer* mb, const mrEndianness endianness, const bool* array, const uint32_t size)
 {
     return serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_uint8_t(mcMicroBuffer* mb, const mrEndianness endianness, const uint8_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_uint8_t(mcBuffer* mb, const mrEndianness endianness, const uint8_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_uint16_t(mcMicroBuffer* mb, const mrEndianness endianness, const uint16_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_uint16_t(mcBuffer* mb, const mrEndianness endianness, const uint16_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_2(mb, endianness, (uint16_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_uint32_t(mcMicroBuffer* mb, const mrEndianness endianness, const uint32_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_uint32_t(mcBuffer* mb, const mrEndianness endianness, const uint32_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_uint64_t(mcMicroBuffer* mb, const mrEndianness endianness, const uint64_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_uint64_t(mcBuffer* mb, const mrEndianness endianness, const uint64_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_int8_t(mcMicroBuffer* mb, const mrEndianness endianness, const int8_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_int8_t(mcBuffer* mb, const mrEndianness endianness, const int8_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_int16_t(mcMicroBuffer* mb, const mrEndianness endianness, const int16_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_int16_t(mcBuffer* mb, const mrEndianness endianness, const int16_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_2(mb, endianness, (uint16_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_int32_t(mcMicroBuffer* mb, const mrEndianness endianness, const int32_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_int32_t(mcBuffer* mb, const mrEndianness endianness, const int32_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_int64_t(mcMicroBuffer* mb, const mrEndianness endianness, const int64_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_int64_t(mcBuffer* mb, const mrEndianness endianness, const int64_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_float(mcMicroBuffer* mb, const mrEndianness endianness, const float* array, const uint32_t size)
+bool mc_serialize_endian_sequence_float(mcBuffer* mb, const mrEndianness endianness, const float* array, const uint32_t size)
 {
     return serialize_sequence_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_double(mcMicroBuffer* mb, const mrEndianness endianness, const double* array, const uint32_t size)
+bool mc_serialize_endian_sequence_double(mcBuffer* mb, const mrEndianness endianness, const double* array, const uint32_t size)
 {
     return serialize_sequence_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool mc_deserialize_endian_sequence_char(mcMicroBuffer* mb, const mrEndianness endianness, char* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_char(mcBuffer* mb, const mrEndianness endianness, char* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_bool(mcMicroBuffer* mb, const mrEndianness endianness, bool* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_bool(mcBuffer* mb, const mrEndianness endianness, bool* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_uint8_t(mcMicroBuffer* mb, const mrEndianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_uint8_t(mcBuffer* mb, const mrEndianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_uint16_t(mcMicroBuffer* mb, const mrEndianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_uint16_t(mcBuffer* mb, const mrEndianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_2(mb, endianness, (uint16_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_uint32_t(mcMicroBuffer* mb, const mrEndianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_uint32_t(mcBuffer* mb, const mrEndianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_4(mb, endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_uint64_t(mcMicroBuffer* mb, const mrEndianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_uint64_t(mcBuffer* mb, const mrEndianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_8(mb, endianness, (uint64_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_int8_t(mcMicroBuffer* mb, const mrEndianness endianness, int8_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_int8_t(mcBuffer* mb, const mrEndianness endianness, int8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_int16_t(mcMicroBuffer* mb, const mrEndianness endianness, int16_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_int16_t(mcBuffer* mb, const mrEndianness endianness, int16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_2(mb, endianness, (uint16_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_int32_t(mcMicroBuffer* mb, const mrEndianness endianness, int32_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_int32_t(mcBuffer* mb, const mrEndianness endianness, int32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_4(mb, endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_int64_t(mcMicroBuffer* mb, const mrEndianness endianness, int64_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_int64_t(mcBuffer* mb, const mrEndianness endianness, int64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_8(mb, endianness, (uint64_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_float(mcMicroBuffer* mb, const mrEndianness endianness, float* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_float(mcBuffer* mb, const mrEndianness endianness, float* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_4(mb, endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_double(mcMicroBuffer* mb, const mrEndianness endianness, double* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_double(mcBuffer* mb, const mrEndianness endianness, double* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_8(mb, endianness, (uint64_t*)array, array_capacity, size);
 }

--- a/src/c/types/sequence.c
+++ b/src/c/types/sequence.c
@@ -22,7 +22,7 @@
 // -------------------------------------------------------------------
 //                INTERNAL UTIL IMPLEMENTATION
 // -------------------------------------------------------------------
-static inline void deserialize_sequence_header(mcMicroBuffer* mb, Endianness endianness, uint32_t capacity, uint32_t* size)
+static inline void deserialize_sequence_header(mcMicroBuffer* mb, mrEndianness endianness, uint32_t capacity, uint32_t* size)
 {
     mc_deserialize_endian_uint32_t(mb, endianness, size);
     if(*size > capacity)
@@ -34,49 +34,49 @@ static inline void deserialize_sequence_header(mcMicroBuffer* mb, Endianness end
 // -------------------------------------------------------------------
 //                INTERNAL SERIALIZATION IMPLEMENTATION
 // -------------------------------------------------------------------
-bool serialize_sequence_byte_1(mcMicroBuffer* mb, Endianness endianness, const uint8_t* array, const uint32_t size)
+bool serialize_sequence_byte_1(mcMicroBuffer* mb, mrEndianness endianness, const uint8_t* array, const uint32_t size)
 {
     mc_serialize_endian_uint32_t(mb, endianness, size);
     return serialize_array_byte_1(mb, array, size);
 }
 
-bool serialize_sequence_byte_2(mcMicroBuffer* mb, Endianness endianness, const uint16_t* array, const uint32_t size)
+bool serialize_sequence_byte_2(mcMicroBuffer* mb, mrEndianness endianness, const uint16_t* array, const uint32_t size)
 {
     mc_serialize_endian_uint32_t(mb, endianness, size);
     return serialize_array_byte_2(mb, endianness, array, size);
 }
 
-bool serialize_sequence_byte_4(mcMicroBuffer* mb, Endianness endianness, const uint32_t* array, const uint32_t size)
+bool serialize_sequence_byte_4(mcMicroBuffer* mb, mrEndianness endianness, const uint32_t* array, const uint32_t size)
 {
     mc_serialize_endian_uint32_t(mb, endianness, size);
     return serialize_array_byte_4(mb, endianness, array, size);
 }
 
-bool serialize_sequence_byte_8(mcMicroBuffer* mb, Endianness endianness, const uint64_t* array, const uint32_t size)
+bool serialize_sequence_byte_8(mcMicroBuffer* mb, mrEndianness endianness, const uint64_t* array, const uint32_t size)
 {
     mc_serialize_endian_uint32_t(mb, endianness, size);
     return serialize_array_byte_8(mb, endianness, array, size);
 }
 
-bool deserialize_sequence_byte_1(mcMicroBuffer* mb, Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_byte_1(mcMicroBuffer* mb, mrEndianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     deserialize_sequence_header(mb, endianness, array_capacity, size);
     return deserialize_array_byte_1(mb, array, *size);
 }
 
-bool deserialize_sequence_byte_2(mcMicroBuffer* mb, Endianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_byte_2(mcMicroBuffer* mb, mrEndianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     deserialize_sequence_header(mb, endianness, array_capacity, size);
     return deserialize_array_byte_2(mb, endianness, array, *size);
 }
 
-bool deserialize_sequence_byte_4(mcMicroBuffer* mb, Endianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_byte_4(mcMicroBuffer* mb, mrEndianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     deserialize_sequence_header(mb, endianness, array_capacity, size);
     return deserialize_array_byte_4(mb, endianness, array, *size);
 }
 
-bool deserialize_sequence_byte_8(mcMicroBuffer* mb, Endianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_byte_8(mcMicroBuffer* mb, mrEndianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     deserialize_sequence_header(mb, endianness, array_capacity, size);
     return deserialize_array_byte_8(mb, endianness, array, *size);
@@ -206,122 +206,122 @@ bool mc_deserialize_sequence_double(mcMicroBuffer* mb, double* array, const uint
     return deserialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, array_capacity, size);
 }
 
-bool mc_serialize_endian_sequence_char(mcMicroBuffer* mb, const Endianness endianness, const char* array, const uint32_t size)
+bool mc_serialize_endian_sequence_char(mcMicroBuffer* mb, const mrEndianness endianness, const char* array, const uint32_t size)
 {
     return serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_bool(mcMicroBuffer* mb, const Endianness endianness, const bool* array, const uint32_t size)
+bool mc_serialize_endian_sequence_bool(mcMicroBuffer* mb, const mrEndianness endianness, const bool* array, const uint32_t size)
 {
     return serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_uint8_t(mcMicroBuffer* mb, const Endianness endianness, const uint8_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_uint8_t(mcMicroBuffer* mb, const mrEndianness endianness, const uint8_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_uint16_t(mcMicroBuffer* mb, const Endianness endianness, const uint16_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_uint16_t(mcMicroBuffer* mb, const mrEndianness endianness, const uint16_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_2(mb, endianness, (uint16_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_uint32_t(mcMicroBuffer* mb, const Endianness endianness, const uint32_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_uint32_t(mcMicroBuffer* mb, const mrEndianness endianness, const uint32_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_uint64_t(mcMicroBuffer* mb, const Endianness endianness, const uint64_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_uint64_t(mcMicroBuffer* mb, const mrEndianness endianness, const uint64_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_int8_t(mcMicroBuffer* mb, const Endianness endianness, const int8_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_int8_t(mcMicroBuffer* mb, const mrEndianness endianness, const int8_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_int16_t(mcMicroBuffer* mb, const Endianness endianness, const int16_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_int16_t(mcMicroBuffer* mb, const mrEndianness endianness, const int16_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_2(mb, endianness, (uint16_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_int32_t(mcMicroBuffer* mb, const Endianness endianness, const int32_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_int32_t(mcMicroBuffer* mb, const mrEndianness endianness, const int32_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_int64_t(mcMicroBuffer* mb, const Endianness endianness, const int64_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_int64_t(mcMicroBuffer* mb, const mrEndianness endianness, const int64_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_float(mcMicroBuffer* mb, const Endianness endianness, const float* array, const uint32_t size)
+bool mc_serialize_endian_sequence_float(mcMicroBuffer* mb, const mrEndianness endianness, const float* array, const uint32_t size)
 {
     return serialize_sequence_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_double(mcMicroBuffer* mb, const Endianness endianness, const double* array, const uint32_t size)
+bool mc_serialize_endian_sequence_double(mcMicroBuffer* mb, const mrEndianness endianness, const double* array, const uint32_t size)
 {
     return serialize_sequence_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool mc_deserialize_endian_sequence_char(mcMicroBuffer* mb, const Endianness endianness, char* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_char(mcMicroBuffer* mb, const mrEndianness endianness, char* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_bool(mcMicroBuffer* mb, const Endianness endianness, bool* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_bool(mcMicroBuffer* mb, const mrEndianness endianness, bool* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_uint8_t(mcMicroBuffer* mb, const Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_uint8_t(mcMicroBuffer* mb, const mrEndianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_uint16_t(mcMicroBuffer* mb, const Endianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_uint16_t(mcMicroBuffer* mb, const mrEndianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_2(mb, endianness, (uint16_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_uint32_t(mcMicroBuffer* mb, const Endianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_uint32_t(mcMicroBuffer* mb, const mrEndianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_4(mb, endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_uint64_t(mcMicroBuffer* mb, const Endianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_uint64_t(mcMicroBuffer* mb, const mrEndianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_8(mb, endianness, (uint64_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_int8_t(mcMicroBuffer* mb, const Endianness endianness, int8_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_int8_t(mcMicroBuffer* mb, const mrEndianness endianness, int8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_int16_t(mcMicroBuffer* mb, const Endianness endianness, int16_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_int16_t(mcMicroBuffer* mb, const mrEndianness endianness, int16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_2(mb, endianness, (uint16_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_int32_t(mcMicroBuffer* mb, const Endianness endianness, int32_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_int32_t(mcMicroBuffer* mb, const mrEndianness endianness, int32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_4(mb, endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_int64_t(mcMicroBuffer* mb, const Endianness endianness, int64_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_int64_t(mcMicroBuffer* mb, const mrEndianness endianness, int64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_8(mb, endianness, (uint64_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_float(mcMicroBuffer* mb, const Endianness endianness, float* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_float(mcMicroBuffer* mb, const mrEndianness endianness, float* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_4(mb, endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_double(mcMicroBuffer* mb, const Endianness endianness, double* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_double(mcMicroBuffer* mb, const mrEndianness endianness, double* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_8(mb, endianness, (uint64_t*)array, array_capacity, size);
 }

--- a/src/c/types/sequence.c
+++ b/src/c/types/sequence.c
@@ -22,7 +22,7 @@
 // -------------------------------------------------------------------
 //                INTERNAL UTIL IMPLEMENTATION
 // -------------------------------------------------------------------
-static inline void deserialize_sequence_header(mcBuffer* mb, mrEndianness endianness, uint32_t capacity, uint32_t* size)
+static inline void deserialize_sequence_header(mcBuffer* mb, mcEndianness endianness, uint32_t capacity, uint32_t* size)
 {
     mc_deserialize_endian_uint32_t(mb, endianness, size);
     if(*size > capacity)
@@ -34,49 +34,49 @@ static inline void deserialize_sequence_header(mcBuffer* mb, mrEndianness endian
 // -------------------------------------------------------------------
 //                INTERNAL SERIALIZATION IMPLEMENTATION
 // -------------------------------------------------------------------
-bool serialize_sequence_byte_1(mcBuffer* mb, mrEndianness endianness, const uint8_t* array, const uint32_t size)
+bool serialize_sequence_byte_1(mcBuffer* mb, mcEndianness endianness, const uint8_t* array, const uint32_t size)
 {
     mc_serialize_endian_uint32_t(mb, endianness, size);
     return serialize_array_byte_1(mb, array, size);
 }
 
-bool serialize_sequence_byte_2(mcBuffer* mb, mrEndianness endianness, const uint16_t* array, const uint32_t size)
+bool serialize_sequence_byte_2(mcBuffer* mb, mcEndianness endianness, const uint16_t* array, const uint32_t size)
 {
     mc_serialize_endian_uint32_t(mb, endianness, size);
     return serialize_array_byte_2(mb, endianness, array, size);
 }
 
-bool serialize_sequence_byte_4(mcBuffer* mb, mrEndianness endianness, const uint32_t* array, const uint32_t size)
+bool serialize_sequence_byte_4(mcBuffer* mb, mcEndianness endianness, const uint32_t* array, const uint32_t size)
 {
     mc_serialize_endian_uint32_t(mb, endianness, size);
     return serialize_array_byte_4(mb, endianness, array, size);
 }
 
-bool serialize_sequence_byte_8(mcBuffer* mb, mrEndianness endianness, const uint64_t* array, const uint32_t size)
+bool serialize_sequence_byte_8(mcBuffer* mb, mcEndianness endianness, const uint64_t* array, const uint32_t size)
 {
     mc_serialize_endian_uint32_t(mb, endianness, size);
     return serialize_array_byte_8(mb, endianness, array, size);
 }
 
-bool deserialize_sequence_byte_1(mcBuffer* mb, mrEndianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_byte_1(mcBuffer* mb, mcEndianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     deserialize_sequence_header(mb, endianness, array_capacity, size);
     return deserialize_array_byte_1(mb, array, *size);
 }
 
-bool deserialize_sequence_byte_2(mcBuffer* mb, mrEndianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_byte_2(mcBuffer* mb, mcEndianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     deserialize_sequence_header(mb, endianness, array_capacity, size);
     return deserialize_array_byte_2(mb, endianness, array, *size);
 }
 
-bool deserialize_sequence_byte_4(mcBuffer* mb, mrEndianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_byte_4(mcBuffer* mb, mcEndianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     deserialize_sequence_header(mb, endianness, array_capacity, size);
     return deserialize_array_byte_4(mb, endianness, array, *size);
 }
 
-bool deserialize_sequence_byte_8(mcBuffer* mb, mrEndianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_byte_8(mcBuffer* mb, mcEndianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     deserialize_sequence_header(mb, endianness, array_capacity, size);
     return deserialize_array_byte_8(mb, endianness, array, *size);
@@ -206,122 +206,122 @@ bool mc_deserialize_sequence_double(mcBuffer* mb, double* array, const uint32_t 
     return deserialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, array_capacity, size);
 }
 
-bool mc_serialize_endian_sequence_char(mcBuffer* mb, const mrEndianness endianness, const char* array, const uint32_t size)
+bool mc_serialize_endian_sequence_char(mcBuffer* mb, const mcEndianness endianness, const char* array, const uint32_t size)
 {
     return serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_bool(mcBuffer* mb, const mrEndianness endianness, const bool* array, const uint32_t size)
+bool mc_serialize_endian_sequence_bool(mcBuffer* mb, const mcEndianness endianness, const bool* array, const uint32_t size)
 {
     return serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_uint8_t(mcBuffer* mb, const mrEndianness endianness, const uint8_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_uint8_t(mcBuffer* mb, const mcEndianness endianness, const uint8_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_uint16_t(mcBuffer* mb, const mrEndianness endianness, const uint16_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_uint16_t(mcBuffer* mb, const mcEndianness endianness, const uint16_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_2(mb, endianness, (uint16_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_uint32_t(mcBuffer* mb, const mrEndianness endianness, const uint32_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_uint32_t(mcBuffer* mb, const mcEndianness endianness, const uint32_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_uint64_t(mcBuffer* mb, const mrEndianness endianness, const uint64_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_uint64_t(mcBuffer* mb, const mcEndianness endianness, const uint64_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_int8_t(mcBuffer* mb, const mrEndianness endianness, const int8_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_int8_t(mcBuffer* mb, const mcEndianness endianness, const int8_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_int16_t(mcBuffer* mb, const mrEndianness endianness, const int16_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_int16_t(mcBuffer* mb, const mcEndianness endianness, const int16_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_2(mb, endianness, (uint16_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_int32_t(mcBuffer* mb, const mrEndianness endianness, const int32_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_int32_t(mcBuffer* mb, const mcEndianness endianness, const int32_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_int64_t(mcBuffer* mb, const mrEndianness endianness, const int64_t* array, const uint32_t size)
+bool mc_serialize_endian_sequence_int64_t(mcBuffer* mb, const mcEndianness endianness, const int64_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_float(mcBuffer* mb, const mrEndianness endianness, const float* array, const uint32_t size)
+bool mc_serialize_endian_sequence_float(mcBuffer* mb, const mcEndianness endianness, const float* array, const uint32_t size)
 {
     return serialize_sequence_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool mc_serialize_endian_sequence_double(mcBuffer* mb, const mrEndianness endianness, const double* array, const uint32_t size)
+bool mc_serialize_endian_sequence_double(mcBuffer* mb, const mcEndianness endianness, const double* array, const uint32_t size)
 {
     return serialize_sequence_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool mc_deserialize_endian_sequence_char(mcBuffer* mb, const mrEndianness endianness, char* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_char(mcBuffer* mb, const mcEndianness endianness, char* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_bool(mcBuffer* mb, const mrEndianness endianness, bool* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_bool(mcBuffer* mb, const mcEndianness endianness, bool* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_uint8_t(mcBuffer* mb, const mrEndianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_uint8_t(mcBuffer* mb, const mcEndianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_uint16_t(mcBuffer* mb, const mrEndianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_uint16_t(mcBuffer* mb, const mcEndianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_2(mb, endianness, (uint16_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_uint32_t(mcBuffer* mb, const mrEndianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_uint32_t(mcBuffer* mb, const mcEndianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_4(mb, endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_uint64_t(mcBuffer* mb, const mrEndianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_uint64_t(mcBuffer* mb, const mcEndianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_8(mb, endianness, (uint64_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_int8_t(mcBuffer* mb, const mrEndianness endianness, int8_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_int8_t(mcBuffer* mb, const mcEndianness endianness, int8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_int16_t(mcBuffer* mb, const mrEndianness endianness, int16_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_int16_t(mcBuffer* mb, const mcEndianness endianness, int16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_2(mb, endianness, (uint16_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_int32_t(mcBuffer* mb, const mrEndianness endianness, int32_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_int32_t(mcBuffer* mb, const mcEndianness endianness, int32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_4(mb, endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_int64_t(mcBuffer* mb, const mrEndianness endianness, int64_t* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_int64_t(mcBuffer* mb, const mcEndianness endianness, int64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_8(mb, endianness, (uint64_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_float(mcBuffer* mb, const mrEndianness endianness, float* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_float(mcBuffer* mb, const mcEndianness endianness, float* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_4(mb, endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool mc_deserialize_endian_sequence_double(mcBuffer* mb, const mrEndianness endianness, double* array, const uint32_t array_capacity, uint32_t* size)
+bool mc_deserialize_endian_sequence_double(mcBuffer* mb, const mcEndianness endianness, double* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_8(mb, endianness, (uint64_t*)array, array_capacity, size);
 }

--- a/src/c/types/sequence.c
+++ b/src/c/types/sequence.c
@@ -22,7 +22,7 @@
 // -------------------------------------------------------------------
 //                INTERNAL UTIL IMPLEMENTATION
 // -------------------------------------------------------------------
-static inline void deserialize_sequence_header(MicroBuffer* mb, Endianness endianness, uint32_t capacity, uint32_t* size)
+static inline void deserialize_sequence_header(mcMicroBuffer* mb, Endianness endianness, uint32_t capacity, uint32_t* size)
 {
     deserialize_endian_uint32_t(mb, endianness, size);
     if(*size > capacity)
@@ -37,49 +37,49 @@ static inline void deserialize_sequence_header(MicroBuffer* mb, Endianness endia
 
 
 
-bool serialize_sequence_byte_1(MicroBuffer* mb, Endianness endianness, const uint8_t* array, const uint32_t size)
+bool serialize_sequence_byte_1(mcMicroBuffer* mb, Endianness endianness, const uint8_t* array, const uint32_t size)
 {
     serialize_endian_uint32_t(mb, endianness, size);
     return serialize_array_byte_1(mb, array, size);
 }
 
-bool serialize_sequence_byte_2(MicroBuffer* mb, Endianness endianness, const uint16_t* array, const uint32_t size)
+bool serialize_sequence_byte_2(mcMicroBuffer* mb, Endianness endianness, const uint16_t* array, const uint32_t size)
 {
     serialize_endian_uint32_t(mb, endianness, size);
     return serialize_array_byte_2(mb, endianness, array, size);
 }
 
-bool serialize_sequence_byte_4(MicroBuffer* mb, Endianness endianness, const uint32_t* array, const uint32_t size)
+bool serialize_sequence_byte_4(mcMicroBuffer* mb, Endianness endianness, const uint32_t* array, const uint32_t size)
 {
     serialize_endian_uint32_t(mb, endianness, size);
     return serialize_array_byte_4(mb, endianness, array, size);
 }
 
-bool serialize_sequence_byte_8(MicroBuffer* mb, Endianness endianness, const uint64_t* array, const uint32_t size)
+bool serialize_sequence_byte_8(mcMicroBuffer* mb, Endianness endianness, const uint64_t* array, const uint32_t size)
 {
     serialize_endian_uint32_t(mb, endianness, size);
     return serialize_array_byte_8(mb, endianness, array, size);
 }
 
-bool deserialize_sequence_byte_1(MicroBuffer* mb, Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_byte_1(mcMicroBuffer* mb, Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     deserialize_sequence_header(mb, endianness, array_capacity, size);
     return deserialize_array_byte_1(mb, array, *size);
 }
 
-bool deserialize_sequence_byte_2(MicroBuffer* mb, Endianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_byte_2(mcMicroBuffer* mb, Endianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     deserialize_sequence_header(mb, endianness, array_capacity, size);
     return deserialize_array_byte_2(mb, endianness, array, *size);
 }
 
-bool deserialize_sequence_byte_4(MicroBuffer* mb, Endianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_byte_4(mcMicroBuffer* mb, Endianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     deserialize_sequence_header(mb, endianness, array_capacity, size);
     return deserialize_array_byte_4(mb, endianness, array, *size);
 }
 
-bool deserialize_sequence_byte_8(MicroBuffer* mb, Endianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_byte_8(mcMicroBuffer* mb, Endianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     deserialize_sequence_header(mb, endianness, array_capacity, size);
     return deserialize_array_byte_8(mb, endianness, array, *size);
@@ -89,242 +89,242 @@ bool deserialize_sequence_byte_8(MicroBuffer* mb, Endianness endianness, uint64_
 //              PUBLIC SERIALIZATION IMPLEMENTATIONS
 // -------------------------------------------------------------------
 
-bool serialize_sequence_char(MicroBuffer* mb, const char* array, const uint32_t size)
+bool serialize_sequence_char(mcMicroBuffer* mb, const char* array, const uint32_t size)
 {
     return serialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, size);
 }
 
-bool serialize_sequence_bool(MicroBuffer* mb, const bool* array, const uint32_t size)
+bool serialize_sequence_bool(mcMicroBuffer* mb, const bool* array, const uint32_t size)
 {
     return serialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, size);
 }
 
-bool serialize_sequence_uint8_t(MicroBuffer* mb, const uint8_t* array, const uint32_t size)
+bool serialize_sequence_uint8_t(mcMicroBuffer* mb, const uint8_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, size);
 }
 
-bool serialize_sequence_uint16_t(MicroBuffer* mb, const uint16_t* array, const uint32_t size)
+bool serialize_sequence_uint16_t(mcMicroBuffer* mb, const uint16_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_2(mb, mb->endianness, (uint16_t*)array, size);
 }
 
-bool serialize_sequence_uint32_t(MicroBuffer* mb, const uint32_t* array, const uint32_t size)
+bool serialize_sequence_uint32_t(mcMicroBuffer* mb, const uint32_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, size);
 }
 
-bool serialize_sequence_uint64_t(MicroBuffer* mb, const uint64_t* array, const uint32_t size)
+bool serialize_sequence_uint64_t(mcMicroBuffer* mb, const uint64_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
-bool serialize_sequence_int8_t(MicroBuffer* mb, const int8_t* array, const uint32_t size)
+bool serialize_sequence_int8_t(mcMicroBuffer* mb, const int8_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, size);
 }
 
-bool serialize_sequence_int16_t(MicroBuffer* mb, const int16_t* array, const uint32_t size)
+bool serialize_sequence_int16_t(mcMicroBuffer* mb, const int16_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_2(mb, mb->endianness, (uint16_t*)array, size);
 }
 
-bool serialize_sequence_int32_t(MicroBuffer* mb, const int32_t* array, const uint32_t size)
+bool serialize_sequence_int32_t(mcMicroBuffer* mb, const int32_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, size);
 }
 
-bool serialize_sequence_int64_t(MicroBuffer* mb, const int64_t* array, const uint32_t size)
+bool serialize_sequence_int64_t(mcMicroBuffer* mb, const int64_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
-bool serialize_sequence_float(MicroBuffer* mb, const float* array, const uint32_t size)
+bool serialize_sequence_float(mcMicroBuffer* mb, const float* array, const uint32_t size)
 {
     return serialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, size);
 }
 
-bool serialize_sequence_double(MicroBuffer* mb, const double* array, const uint32_t size)
+bool serialize_sequence_double(mcMicroBuffer* mb, const double* array, const uint32_t size)
 {
     return serialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, size);
 }
 
-bool deserialize_sequence_char(MicroBuffer* mb, char* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_char(mcMicroBuffer* mb, char* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool deserialize_sequence_bool(MicroBuffer* mb, bool* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_bool(mcMicroBuffer* mb, bool* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool deserialize_sequence_uint8_t(MicroBuffer* mb, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_uint8_t(mcMicroBuffer* mb, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool deserialize_sequence_uint16_t(MicroBuffer* mb, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_uint16_t(mcMicroBuffer* mb, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_2(mb, mb->endianness, (uint16_t*)array, array_capacity, size);
 }
 
-bool deserialize_sequence_uint32_t(MicroBuffer* mb, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_uint32_t(mcMicroBuffer* mb, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool deserialize_sequence_uint64_t(MicroBuffer* mb, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_uint64_t(mcMicroBuffer* mb, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, array_capacity, size);
 }
 
-bool deserialize_sequence_int8_t(MicroBuffer* mb, int8_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_int8_t(mcMicroBuffer* mb, int8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool deserialize_sequence_int16_t(MicroBuffer* mb, int16_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_int16_t(mcMicroBuffer* mb, int16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_2(mb, mb->endianness, (uint16_t*)array, array_capacity, size);
 }
 
-bool deserialize_sequence_int32_t(MicroBuffer* mb, int32_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_int32_t(mcMicroBuffer* mb, int32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool deserialize_sequence_int64_t(MicroBuffer* mb, int64_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_int64_t(mcMicroBuffer* mb, int64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, array_capacity, size);
 }
 
-bool deserialize_sequence_float(MicroBuffer* mb, float* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_float(mcMicroBuffer* mb, float* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool deserialize_sequence_double(MicroBuffer* mb, double* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_sequence_double(mcMicroBuffer* mb, double* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, array_capacity, size);
 }
 
-bool serialize_endian_sequence_char(MicroBuffer* mb, const Endianness endianness, const char* array, const uint32_t size)
+bool serialize_endian_sequence_char(mcMicroBuffer* mb, const Endianness endianness, const char* array, const uint32_t size)
 {
     return serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
 }
 
-bool serialize_endian_sequence_bool(MicroBuffer* mb, const Endianness endianness, const bool* array, const uint32_t size)
+bool serialize_endian_sequence_bool(mcMicroBuffer* mb, const Endianness endianness, const bool* array, const uint32_t size)
 {
     return serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
 }
 
-bool serialize_endian_sequence_uint8_t(MicroBuffer* mb, const Endianness endianness, const uint8_t* array, const uint32_t size)
+bool serialize_endian_sequence_uint8_t(mcMicroBuffer* mb, const Endianness endianness, const uint8_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
 }
 
-bool serialize_endian_sequence_uint16_t(MicroBuffer* mb, const Endianness endianness, const uint16_t* array, const uint32_t size)
+bool serialize_endian_sequence_uint16_t(mcMicroBuffer* mb, const Endianness endianness, const uint16_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_2(mb, endianness, (uint16_t*)array, size);
 }
 
-bool serialize_endian_sequence_uint32_t(MicroBuffer* mb, const Endianness endianness, const uint32_t* array, const uint32_t size)
+bool serialize_endian_sequence_uint32_t(mcMicroBuffer* mb, const Endianness endianness, const uint32_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool serialize_endian_sequence_uint64_t(MicroBuffer* mb, const Endianness endianness, const uint64_t* array, const uint32_t size)
+bool serialize_endian_sequence_uint64_t(mcMicroBuffer* mb, const Endianness endianness, const uint64_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool serialize_endian_sequence_int8_t(MicroBuffer* mb, const Endianness endianness, const int8_t* array, const uint32_t size)
+bool serialize_endian_sequence_int8_t(mcMicroBuffer* mb, const Endianness endianness, const int8_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
 }
 
-bool serialize_endian_sequence_int16_t(MicroBuffer* mb, const Endianness endianness, const int16_t* array, const uint32_t size)
+bool serialize_endian_sequence_int16_t(mcMicroBuffer* mb, const Endianness endianness, const int16_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_2(mb, endianness, (uint16_t*)array, size);
 }
 
-bool serialize_endian_sequence_int32_t(MicroBuffer* mb, const Endianness endianness, const int32_t* array, const uint32_t size)
+bool serialize_endian_sequence_int32_t(mcMicroBuffer* mb, const Endianness endianness, const int32_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool serialize_endian_sequence_int64_t(MicroBuffer* mb, const Endianness endianness, const int64_t* array, const uint32_t size)
+bool serialize_endian_sequence_int64_t(mcMicroBuffer* mb, const Endianness endianness, const int64_t* array, const uint32_t size)
 {
     return serialize_sequence_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool serialize_endian_sequence_float(MicroBuffer* mb, const Endianness endianness, const float* array, const uint32_t size)
+bool serialize_endian_sequence_float(mcMicroBuffer* mb, const Endianness endianness, const float* array, const uint32_t size)
 {
     return serialize_sequence_byte_4(mb, endianness, (uint32_t*)array, size);
 }
 
-bool serialize_endian_sequence_double(MicroBuffer* mb, const Endianness endianness, const double* array, const uint32_t size)
+bool serialize_endian_sequence_double(mcMicroBuffer* mb, const Endianness endianness, const double* array, const uint32_t size)
 {
     return serialize_sequence_byte_8(mb, endianness, (uint64_t*)array, size);
 }
 
-bool deserialize_endian_sequence_char(MicroBuffer* mb, const Endianness endianness, char* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_endian_sequence_char(mcMicroBuffer* mb, const Endianness endianness, char* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool deserialize_endian_sequence_bool(MicroBuffer* mb, const Endianness endianness, bool* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_endian_sequence_bool(mcMicroBuffer* mb, const Endianness endianness, bool* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool deserialize_endian_sequence_uint8_t(MicroBuffer* mb, const Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_endian_sequence_uint8_t(mcMicroBuffer* mb, const Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool deserialize_endian_sequence_uint16_t(MicroBuffer* mb, const Endianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_endian_sequence_uint16_t(mcMicroBuffer* mb, const Endianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_2(mb, endianness, (uint16_t*)array, array_capacity, size);
 }
 
-bool deserialize_endian_sequence_uint32_t(MicroBuffer* mb, const Endianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_endian_sequence_uint32_t(mcMicroBuffer* mb, const Endianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_4(mb, endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool deserialize_endian_sequence_uint64_t(MicroBuffer* mb, const Endianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_endian_sequence_uint64_t(mcMicroBuffer* mb, const Endianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_8(mb, endianness, (uint64_t*)array, array_capacity, size);
 }
 
-bool deserialize_endian_sequence_int8_t(MicroBuffer* mb, const Endianness endianness, int8_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_endian_sequence_int8_t(mcMicroBuffer* mb, const Endianness endianness, int8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool deserialize_endian_sequence_int16_t(MicroBuffer* mb, const Endianness endianness, int16_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_endian_sequence_int16_t(mcMicroBuffer* mb, const Endianness endianness, int16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_2(mb, endianness, (uint16_t*)array, array_capacity, size);
 }
 
-bool deserialize_endian_sequence_int32_t(MicroBuffer* mb, const Endianness endianness, int32_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_endian_sequence_int32_t(mcMicroBuffer* mb, const Endianness endianness, int32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_4(mb, endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool deserialize_endian_sequence_int64_t(MicroBuffer* mb, const Endianness endianness, int64_t* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_endian_sequence_int64_t(mcMicroBuffer* mb, const Endianness endianness, int64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_8(mb, endianness, (uint64_t*)array, array_capacity, size);
 }
 
-bool deserialize_endian_sequence_float(MicroBuffer* mb, const Endianness endianness, float* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_endian_sequence_float(mcMicroBuffer* mb, const Endianness endianness, float* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_4(mb, endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool deserialize_endian_sequence_double(MicroBuffer* mb, const Endianness endianness, double* array, const uint32_t array_capacity, uint32_t* size)
+bool deserialize_endian_sequence_double(mcMicroBuffer* mb, const Endianness endianness, double* array, const uint32_t array_capacity, uint32_t* size)
 {
     return deserialize_sequence_byte_8(mb, endianness, (uint64_t*)array, array_capacity, size);
 }

--- a/src/c/types/sequence_internals.h
+++ b/src/c/types/sequence_internals.h
@@ -31,10 +31,10 @@ bool serialize_sequence_byte_2(mcMicroBuffer* buffer, Endianness endianness, con
 bool serialize_sequence_byte_4(mcMicroBuffer* buffer, Endianness endianness, const uint32_t* array, const uint32_t size);
 bool serialize_sequence_byte_8(mcMicroBuffer* buffer, Endianness endianness, const uint64_t* array, const uint32_t size);
 
-bool deserialize_sequence_byte_1(mcMicroBuffer* buffer, Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
-bool deserialize_sequence_byte_2(mcMicroBuffer* buffer, Endianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
-bool deserialize_sequence_byte_4(mcMicroBuffer* buffer, Endianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
-bool deserialize_sequence_byte_8(mcMicroBuffer* buffer, Endianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
+bool mc_deserialize_sequence_byte_1(mcMicroBuffer* buffer, Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
+bool mc_deserialize_sequence_byte_2(mcMicroBuffer* buffer, Endianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
+bool mc_deserialize_sequence_byte_4(mcMicroBuffer* buffer, Endianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
+bool mc_deserialize_sequence_byte_8(mcMicroBuffer* buffer, Endianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
 
 #ifdef __cplusplus
 }

--- a/src/c/types/sequence_internals.h
+++ b/src/c/types/sequence_internals.h
@@ -26,10 +26,10 @@ extern "C" {
 // -------------------------------------------------------------------
 //                  INTERNAL SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
-bool serialize_sequence_byte_1(mcMicroBuffer* buffer, Endianness endianness, const uint8_t* array, const uint32_t size);
-bool serialize_sequence_byte_2(mcMicroBuffer* buffer, Endianness endianness, const uint16_t* array, const uint32_t size);
-bool serialize_sequence_byte_4(mcMicroBuffer* buffer, Endianness endianness, const uint32_t* array, const uint32_t size);
-bool serialize_sequence_byte_8(mcMicroBuffer* buffer, Endianness endianness, const uint64_t* array, const uint32_t size);
+bool mc_serialize_sequence_byte_1(mcMicroBuffer* buffer, Endianness endianness, const uint8_t* array, const uint32_t size);
+bool mc_serialize_sequence_byte_2(mcMicroBuffer* buffer, Endianness endianness, const uint16_t* array, const uint32_t size);
+bool mc_serialize_sequence_byte_4(mcMicroBuffer* buffer, Endianness endianness, const uint32_t* array, const uint32_t size);
+bool mc_serialize_sequence_byte_8(mcMicroBuffer* buffer, Endianness endianness, const uint64_t* array, const uint32_t size);
 
 bool mc_deserialize_sequence_byte_1(mcMicroBuffer* buffer, Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
 bool mc_deserialize_sequence_byte_2(mcMicroBuffer* buffer, Endianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size);

--- a/src/c/types/sequence_internals.h
+++ b/src/c/types/sequence_internals.h
@@ -26,15 +26,15 @@ extern "C" {
 // -------------------------------------------------------------------
 //                  INTERNAL SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
-bool mc_serialize_sequence_byte_1(mcMicroBuffer* buffer, Endianness endianness, const uint8_t* array, const uint32_t size);
-bool mc_serialize_sequence_byte_2(mcMicroBuffer* buffer, Endianness endianness, const uint16_t* array, const uint32_t size);
-bool mc_serialize_sequence_byte_4(mcMicroBuffer* buffer, Endianness endianness, const uint32_t* array, const uint32_t size);
-bool mc_serialize_sequence_byte_8(mcMicroBuffer* buffer, Endianness endianness, const uint64_t* array, const uint32_t size);
+bool serialize_sequence_byte_1(mcMicroBuffer* buffer, Endianness endianness, const uint8_t* array, const uint32_t size);
+bool serialize_sequence_byte_2(mcMicroBuffer* buffer, Endianness endianness, const uint16_t* array, const uint32_t size);
+bool serialize_sequence_byte_4(mcMicroBuffer* buffer, Endianness endianness, const uint32_t* array, const uint32_t size);
+bool serialize_sequence_byte_8(mcMicroBuffer* buffer, Endianness endianness, const uint64_t* array, const uint32_t size);
 
-bool mc_deserialize_sequence_byte_1(mcMicroBuffer* buffer, Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
-bool mc_deserialize_sequence_byte_2(mcMicroBuffer* buffer, Endianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
-bool mc_deserialize_sequence_byte_4(mcMicroBuffer* buffer, Endianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
-bool mc_deserialize_sequence_byte_8(mcMicroBuffer* buffer, Endianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
+bool deserialize_sequence_byte_1(mcMicroBuffer* buffer, Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
+bool deserialize_sequence_byte_2(mcMicroBuffer* buffer, Endianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
+bool deserialize_sequence_byte_4(mcMicroBuffer* buffer, Endianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
+bool deserialize_sequence_byte_8(mcMicroBuffer* buffer, Endianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
 
 #ifdef __cplusplus
 }

--- a/src/c/types/sequence_internals.h
+++ b/src/c/types/sequence_internals.h
@@ -26,15 +26,15 @@ extern "C" {
 // -------------------------------------------------------------------
 //                  INTERNAL SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
-bool serialize_sequence_byte_1(MicroBuffer* buffer, Endianness endianness, const uint8_t* array, const uint32_t size);
-bool serialize_sequence_byte_2(MicroBuffer* buffer, Endianness endianness, const uint16_t* array, const uint32_t size);
-bool serialize_sequence_byte_4(MicroBuffer* buffer, Endianness endianness, const uint32_t* array, const uint32_t size);
-bool serialize_sequence_byte_8(MicroBuffer* buffer, Endianness endianness, const uint64_t* array, const uint32_t size);
+bool serialize_sequence_byte_1(mcMicroBuffer* buffer, Endianness endianness, const uint8_t* array, const uint32_t size);
+bool serialize_sequence_byte_2(mcMicroBuffer* buffer, Endianness endianness, const uint16_t* array, const uint32_t size);
+bool serialize_sequence_byte_4(mcMicroBuffer* buffer, Endianness endianness, const uint32_t* array, const uint32_t size);
+bool serialize_sequence_byte_8(mcMicroBuffer* buffer, Endianness endianness, const uint64_t* array, const uint32_t size);
 
-bool deserialize_sequence_byte_1(MicroBuffer* buffer, Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
-bool deserialize_sequence_byte_2(MicroBuffer* buffer, Endianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
-bool deserialize_sequence_byte_4(MicroBuffer* buffer, Endianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
-bool deserialize_sequence_byte_8(MicroBuffer* buffer, Endianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
+bool deserialize_sequence_byte_1(mcMicroBuffer* buffer, Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
+bool deserialize_sequence_byte_2(mcMicroBuffer* buffer, Endianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
+bool deserialize_sequence_byte_4(mcMicroBuffer* buffer, Endianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
+bool deserialize_sequence_byte_8(mcMicroBuffer* buffer, Endianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
 
 #ifdef __cplusplus
 }

--- a/src/c/types/sequence_internals.h
+++ b/src/c/types/sequence_internals.h
@@ -26,15 +26,15 @@ extern "C" {
 // -------------------------------------------------------------------
 //                  INTERNAL SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
-bool serialize_sequence_byte_1(mcBuffer* buffer, mrEndianness endianness, const uint8_t* array, const uint32_t size);
-bool serialize_sequence_byte_2(mcBuffer* buffer, mrEndianness endianness, const uint16_t* array, const uint32_t size);
-bool serialize_sequence_byte_4(mcBuffer* buffer, mrEndianness endianness, const uint32_t* array, const uint32_t size);
-bool serialize_sequence_byte_8(mcBuffer* buffer, mrEndianness endianness, const uint64_t* array, const uint32_t size);
+bool serialize_sequence_byte_1(mcBuffer* buffer, mcEndianness endianness, const uint8_t* array, const uint32_t size);
+bool serialize_sequence_byte_2(mcBuffer* buffer, mcEndianness endianness, const uint16_t* array, const uint32_t size);
+bool serialize_sequence_byte_4(mcBuffer* buffer, mcEndianness endianness, const uint32_t* array, const uint32_t size);
+bool serialize_sequence_byte_8(mcBuffer* buffer, mcEndianness endianness, const uint64_t* array, const uint32_t size);
 
-bool deserialize_sequence_byte_1(mcBuffer* buffer, mrEndianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
-bool deserialize_sequence_byte_2(mcBuffer* buffer, mrEndianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
-bool deserialize_sequence_byte_4(mcBuffer* buffer, mrEndianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
-bool deserialize_sequence_byte_8(mcBuffer* buffer, mrEndianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
+bool deserialize_sequence_byte_1(mcBuffer* buffer, mcEndianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
+bool deserialize_sequence_byte_2(mcBuffer* buffer, mcEndianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
+bool deserialize_sequence_byte_4(mcBuffer* buffer, mcEndianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
+bool deserialize_sequence_byte_8(mcBuffer* buffer, mcEndianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
 
 #ifdef __cplusplus
 }

--- a/src/c/types/sequence_internals.h
+++ b/src/c/types/sequence_internals.h
@@ -26,15 +26,15 @@ extern "C" {
 // -------------------------------------------------------------------
 //                  INTERNAL SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
-bool serialize_sequence_byte_1(mcMicroBuffer* buffer, mrEndianness endianness, const uint8_t* array, const uint32_t size);
-bool serialize_sequence_byte_2(mcMicroBuffer* buffer, mrEndianness endianness, const uint16_t* array, const uint32_t size);
-bool serialize_sequence_byte_4(mcMicroBuffer* buffer, mrEndianness endianness, const uint32_t* array, const uint32_t size);
-bool serialize_sequence_byte_8(mcMicroBuffer* buffer, mrEndianness endianness, const uint64_t* array, const uint32_t size);
+bool serialize_sequence_byte_1(mcBuffer* buffer, mrEndianness endianness, const uint8_t* array, const uint32_t size);
+bool serialize_sequence_byte_2(mcBuffer* buffer, mrEndianness endianness, const uint16_t* array, const uint32_t size);
+bool serialize_sequence_byte_4(mcBuffer* buffer, mrEndianness endianness, const uint32_t* array, const uint32_t size);
+bool serialize_sequence_byte_8(mcBuffer* buffer, mrEndianness endianness, const uint64_t* array, const uint32_t size);
 
-bool deserialize_sequence_byte_1(mcMicroBuffer* buffer, mrEndianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
-bool deserialize_sequence_byte_2(mcMicroBuffer* buffer, mrEndianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
-bool deserialize_sequence_byte_4(mcMicroBuffer* buffer, mrEndianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
-bool deserialize_sequence_byte_8(mcMicroBuffer* buffer, mrEndianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
+bool deserialize_sequence_byte_1(mcBuffer* buffer, mrEndianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
+bool deserialize_sequence_byte_2(mcBuffer* buffer, mrEndianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
+bool deserialize_sequence_byte_4(mcBuffer* buffer, mrEndianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
+bool deserialize_sequence_byte_8(mcBuffer* buffer, mrEndianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
 
 #ifdef __cplusplus
 }

--- a/src/c/types/sequence_internals.h
+++ b/src/c/types/sequence_internals.h
@@ -26,15 +26,15 @@ extern "C" {
 // -------------------------------------------------------------------
 //                  INTERNAL SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
-bool serialize_sequence_byte_1(mcMicroBuffer* buffer, Endianness endianness, const uint8_t* array, const uint32_t size);
-bool serialize_sequence_byte_2(mcMicroBuffer* buffer, Endianness endianness, const uint16_t* array, const uint32_t size);
-bool serialize_sequence_byte_4(mcMicroBuffer* buffer, Endianness endianness, const uint32_t* array, const uint32_t size);
-bool serialize_sequence_byte_8(mcMicroBuffer* buffer, Endianness endianness, const uint64_t* array, const uint32_t size);
+bool serialize_sequence_byte_1(mcMicroBuffer* buffer, mrEndianness endianness, const uint8_t* array, const uint32_t size);
+bool serialize_sequence_byte_2(mcMicroBuffer* buffer, mrEndianness endianness, const uint16_t* array, const uint32_t size);
+bool serialize_sequence_byte_4(mcMicroBuffer* buffer, mrEndianness endianness, const uint32_t* array, const uint32_t size);
+bool serialize_sequence_byte_8(mcMicroBuffer* buffer, mrEndianness endianness, const uint64_t* array, const uint32_t size);
 
-bool deserialize_sequence_byte_1(mcMicroBuffer* buffer, Endianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
-bool deserialize_sequence_byte_2(mcMicroBuffer* buffer, Endianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
-bool deserialize_sequence_byte_4(mcMicroBuffer* buffer, Endianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
-bool deserialize_sequence_byte_8(mcMicroBuffer* buffer, Endianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
+bool deserialize_sequence_byte_1(mcMicroBuffer* buffer, mrEndianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
+bool deserialize_sequence_byte_2(mcMicroBuffer* buffer, mrEndianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
+bool deserialize_sequence_byte_4(mcMicroBuffer* buffer, mrEndianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
+bool deserialize_sequence_byte_8(mcMicroBuffer* buffer, mrEndianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
 
 #ifdef __cplusplus
 }

--- a/src/c/types/string.c
+++ b/src/c/types/string.c
@@ -22,23 +22,23 @@
 //              PUBLIC SERIALIZATION IMPLEMENTATIONS
 // -------------------------------------------------------------------
 
-bool serialize_string(MicroBuffer* mb, const char* string)
+bool serialize_string(mcMicroBuffer* mb, const char* string)
 {
     return serialize_sequence_char(mb, string, (uint32_t)strlen(string) + 1);
 }
 
-bool deserialize_string(MicroBuffer* mb, char* string, const uint32_t string_capacity)
+bool deserialize_string(mcMicroBuffer* mb, char* string, const uint32_t string_capacity)
 {
     uint32_t length;
     return deserialize_sequence_char(mb, string, string_capacity, &length);
 }
 
-bool serialize_endian_string(MicroBuffer* mb, Endianness endianness, const char* string)
+bool serialize_endian_string(mcMicroBuffer* mb, Endianness endianness, const char* string)
 {
     return serialize_endian_sequence_char(mb, endianness, string, (uint32_t)strlen(string) + 1);
 }
 
-bool deserialize_endian_string(MicroBuffer* mb, Endianness endianness, char* string, const uint32_t string_capacity)
+bool deserialize_endian_string(mcMicroBuffer* mb, Endianness endianness, char* string, const uint32_t string_capacity)
 {
     uint32_t length;
     return deserialize_endian_sequence_char(mb, endianness, string, string_capacity, &length);

--- a/src/c/types/string.c
+++ b/src/c/types/string.c
@@ -22,9 +22,9 @@
 //              PUBLIC SERIALIZATION IMPLEMENTATIONS
 // -------------------------------------------------------------------
 
-bool serialize_string(mcMicroBuffer* mb, const char* string)
+bool mc_serialize_string(mcMicroBuffer* mb, const char* string)
 {
-    return serialize_sequence_char(mb, string, (uint32_t)strlen(string) + 1);
+    return mc_serialize_sequence_char(mb, string, (uint32_t)strlen(string) + 1);
 }
 
 bool mc_deserialize_string(mcMicroBuffer* mb, char* string, const uint32_t string_capacity)
@@ -33,9 +33,9 @@ bool mc_deserialize_string(mcMicroBuffer* mb, char* string, const uint32_t strin
     return mc_deserialize_sequence_char(mb, string, string_capacity, &length);
 }
 
-bool serialize_endian_string(mcMicroBuffer* mb, Endianness endianness, const char* string)
+bool mc_serialize_endian_string(mcMicroBuffer* mb, Endianness endianness, const char* string)
 {
-    return serialize_endian_sequence_char(mb, endianness, string, (uint32_t)strlen(string) + 1);
+    return mc_serialize_endian_sequence_char(mb, endianness, string, (uint32_t)strlen(string) + 1);
 }
 
 bool mc_deserialize_endian_string(mcMicroBuffer* mb, Endianness endianness, char* string, const uint32_t string_capacity)

--- a/src/c/types/string.c
+++ b/src/c/types/string.c
@@ -33,12 +33,12 @@ bool mc_deserialize_string(mcMicroBuffer* mb, char* string, const uint32_t strin
     return mc_deserialize_sequence_char(mb, string, string_capacity, &length);
 }
 
-bool mc_serialize_endian_string(mcMicroBuffer* mb, Endianness endianness, const char* string)
+bool mc_serialize_endian_string(mcMicroBuffer* mb, mrEndianness endianness, const char* string)
 {
     return mc_serialize_endian_sequence_char(mb, endianness, string, (uint32_t)strlen(string) + 1);
 }
 
-bool mc_deserialize_endian_string(mcMicroBuffer* mb, Endianness endianness, char* string, const uint32_t string_capacity)
+bool mc_deserialize_endian_string(mcMicroBuffer* mb, mrEndianness endianness, char* string, const uint32_t string_capacity)
 {
     uint32_t length;
     return mc_deserialize_endian_sequence_char(mb, endianness, string, string_capacity, &length);

--- a/src/c/types/string.c
+++ b/src/c/types/string.c
@@ -27,10 +27,10 @@ bool serialize_string(mcMicroBuffer* mb, const char* string)
     return serialize_sequence_char(mb, string, (uint32_t)strlen(string) + 1);
 }
 
-bool deserialize_string(mcMicroBuffer* mb, char* string, const uint32_t string_capacity)
+bool mc_deserialize_string(mcMicroBuffer* mb, char* string, const uint32_t string_capacity)
 {
     uint32_t length;
-    return deserialize_sequence_char(mb, string, string_capacity, &length);
+    return mc_deserialize_sequence_char(mb, string, string_capacity, &length);
 }
 
 bool serialize_endian_string(mcMicroBuffer* mb, Endianness endianness, const char* string)
@@ -38,8 +38,8 @@ bool serialize_endian_string(mcMicroBuffer* mb, Endianness endianness, const cha
     return serialize_endian_sequence_char(mb, endianness, string, (uint32_t)strlen(string) + 1);
 }
 
-bool deserialize_endian_string(mcMicroBuffer* mb, Endianness endianness, char* string, const uint32_t string_capacity)
+bool mc_deserialize_endian_string(mcMicroBuffer* mb, Endianness endianness, char* string, const uint32_t string_capacity)
 {
     uint32_t length;
-    return deserialize_endian_sequence_char(mb, endianness, string, string_capacity, &length);
+    return mc_deserialize_endian_sequence_char(mb, endianness, string, string_capacity, &length);
 }

--- a/src/c/types/string.c
+++ b/src/c/types/string.c
@@ -22,23 +22,23 @@
 //              PUBLIC SERIALIZATION IMPLEMENTATIONS
 // -------------------------------------------------------------------
 
-bool mc_serialize_string(mcMicroBuffer* mb, const char* string)
+bool mc_serialize_string(mcBuffer* mb, const char* string)
 {
     return mc_serialize_sequence_char(mb, string, (uint32_t)strlen(string) + 1);
 }
 
-bool mc_deserialize_string(mcMicroBuffer* mb, char* string, const uint32_t string_capacity)
+bool mc_deserialize_string(mcBuffer* mb, char* string, const uint32_t string_capacity)
 {
     uint32_t length;
     return mc_deserialize_sequence_char(mb, string, string_capacity, &length);
 }
 
-bool mc_serialize_endian_string(mcMicroBuffer* mb, mrEndianness endianness, const char* string)
+bool mc_serialize_endian_string(mcBuffer* mb, mrEndianness endianness, const char* string)
 {
     return mc_serialize_endian_sequence_char(mb, endianness, string, (uint32_t)strlen(string) + 1);
 }
 
-bool mc_deserialize_endian_string(mcMicroBuffer* mb, mrEndianness endianness, char* string, const uint32_t string_capacity)
+bool mc_deserialize_endian_string(mcBuffer* mb, mrEndianness endianness, char* string, const uint32_t string_capacity)
 {
     uint32_t length;
     return mc_deserialize_endian_sequence_char(mb, endianness, string, string_capacity, &length);

--- a/src/c/types/string.c
+++ b/src/c/types/string.c
@@ -33,12 +33,12 @@ bool mc_deserialize_string(mcBuffer* mb, char* string, const uint32_t string_cap
     return mc_deserialize_sequence_char(mb, string, string_capacity, &length);
 }
 
-bool mc_serialize_endian_string(mcBuffer* mb, mrEndianness endianness, const char* string)
+bool mc_serialize_endian_string(mcBuffer* mb, mcEndianness endianness, const char* string)
 {
     return mc_serialize_endian_sequence_char(mb, endianness, string, (uint32_t)strlen(string) + 1);
 }
 
-bool mc_deserialize_endian_string(mcBuffer* mb, mrEndianness endianness, char* string, const uint32_t string_capacity)
+bool mc_deserialize_endian_string(mcBuffer* mb, mcEndianness endianness, char* string, const uint32_t string_capacity)
 {
     uint32_t length;
     return mc_deserialize_endian_sequence_char(mb, endianness, string, string_capacity, &length);

--- a/test/Alignment.cpp
+++ b/test/Alignment.cpp
@@ -29,8 +29,8 @@ public:
 
     void check_alignment(int alignment)
     {
-        EXPECT_EQ(static_cast<int>(mc_micro_buffer_length(&writer)) % alignment, 0);
-        EXPECT_EQ(static_cast<int>(mc_micro_buffer_length(&reader)) % alignment, 0);
+        EXPECT_EQ(static_cast<int>(mc_buffer_length(&writer)) % alignment, 0);
+        EXPECT_EQ(static_cast<int>(mc_buffer_length(&reader)) % alignment, 0);
     }
 
     virtual ~Alignment()

--- a/test/Alignment.cpp
+++ b/test/Alignment.cpp
@@ -29,8 +29,8 @@ public:
 
     void check_alignment(int alignment)
     {
-        EXPECT_EQ(static_cast<int>(micro_buffer_length(&writer)) % alignment, 0);
-        EXPECT_EQ(static_cast<int>(micro_buffer_length(&reader)) % alignment, 0);
+        EXPECT_EQ(static_cast<int>(mc_micro_buffer_length(&writer)) % alignment, 0);
+        EXPECT_EQ(static_cast<int>(mc_micro_buffer_length(&reader)) % alignment, 0);
     }
 
     virtual ~Alignment()

--- a/test/FullBuffer.cpp
+++ b/test/FullBuffer.cpp
@@ -38,7 +38,7 @@ public:
         uint8_t output = 0;
 
         EXPECT_FALSE(serialize_uint8_t(&writer, input));
-        EXPECT_FALSE(deserialize_uint8_t(&reader, &output));
+        EXPECT_FALSE(mc_deserialize_uint8_t(&reader, &output));
     }
 
     void try_block_2()
@@ -47,7 +47,7 @@ public:
         uint16_t output = 0;
 
         EXPECT_FALSE(serialize_uint16_t(&writer, input));
-        EXPECT_FALSE(deserialize_uint16_t(&reader, &output));
+        EXPECT_FALSE(mc_deserialize_uint16_t(&reader, &output));
     }
 
     void try_block_4()
@@ -56,7 +56,7 @@ public:
         uint32_t output = 0;
 
         EXPECT_FALSE(serialize_uint32_t(&writer, input));
-        EXPECT_FALSE(deserialize_uint32_t(&reader, &output));
+        EXPECT_FALSE(mc_deserialize_uint32_t(&reader, &output));
     }
 
     void try_block_8()
@@ -65,7 +65,7 @@ public:
         uint64_t output = 0;
 
         EXPECT_FALSE(serialize_uint64_t(&writer, input));
-        EXPECT_FALSE(deserialize_uint64_t(&reader, &output));
+        EXPECT_FALSE(mc_deserialize_uint64_t(&reader, &output));
     }
 
     ~FullBuffer()

--- a/test/FullBuffer.cpp
+++ b/test/FullBuffer.cpp
@@ -37,7 +37,7 @@ public:
         uint8_t input = 0xAA;
         uint8_t output = 0;
 
-        EXPECT_FALSE(serialize_uint8_t(&writer, input));
+        EXPECT_FALSE(mc_serialize_uint8_t(&writer, input));
         EXPECT_FALSE(mc_deserialize_uint8_t(&reader, &output));
     }
 
@@ -46,7 +46,7 @@ public:
         uint16_t input = 0xAABB;
         uint16_t output = 0;
 
-        EXPECT_FALSE(serialize_uint16_t(&writer, input));
+        EXPECT_FALSE(mc_serialize_uint16_t(&writer, input));
         EXPECT_FALSE(mc_deserialize_uint16_t(&reader, &output));
     }
 
@@ -55,7 +55,7 @@ public:
         uint32_t input = 0xAABBCCDD;
         uint32_t output = 0;
 
-        EXPECT_FALSE(serialize_uint32_t(&writer, input));
+        EXPECT_FALSE(mc_serialize_uint32_t(&writer, input));
         EXPECT_FALSE(mc_deserialize_uint32_t(&reader, &output));
     }
 
@@ -64,7 +64,7 @@ public:
         uint64_t input = 0x0123456789ABCDEF;
         uint64_t output = 0;
 
-        EXPECT_FALSE(serialize_uint64_t(&writer, input));
+        EXPECT_FALSE(mc_serialize_uint64_t(&writer, input));
         EXPECT_FALSE(mc_deserialize_uint64_t(&reader, &output));
     }
 

--- a/test/SequenceOverflow.cpp
+++ b/test/SequenceOverflow.cpp
@@ -27,7 +27,7 @@ public:
     ~SequenceOverflow()
     {
         //4 because of the sequence header (no necessary padding)
-        EXPECT_EQ(mc_buffer_length(&reader), static_cast<size_t>(4));
+        EXPECT_EQ(mc_buffer_length(&reader), 4u);
         EXPECT_TRUE(reader.error);
 
         // To satisfy the base destructor

--- a/test/SequenceOverflow.cpp
+++ b/test/SequenceOverflow.cpp
@@ -27,7 +27,7 @@ public:
     ~SequenceOverflow()
     {
         //4 because of the sequence header (no necessary padding)
-        EXPECT_EQ(mc_micro_buffer_length(&reader), 4);
+        EXPECT_EQ(mc_buffer_length(&reader), 4);
         EXPECT_TRUE(reader.error);
 
         // To satisfy the base destructor

--- a/test/SequenceOverflow.cpp
+++ b/test/SequenceOverflow.cpp
@@ -27,7 +27,7 @@ public:
     ~SequenceOverflow()
     {
         //4 because of the sequence header (no necessary padding)
-        EXPECT_EQ(mc_buffer_length(&reader), 4);
+        EXPECT_EQ(mc_buffer_length(&reader), static_cast<size_t>(4));
         EXPECT_TRUE(reader.error);
 
         // To satisfy the base destructor

--- a/test/SequenceOverflow.cpp
+++ b/test/SequenceOverflow.cpp
@@ -44,7 +44,7 @@ TEST_F(SequenceOverflow, Block1)
     uint8_t output[ARRAY_CAPACITY];
 
     EXPECT_TRUE(serialize_sequence_uint8_t(&writer, input, SEQUENCE_SIZE_OVERFLOW));
-    EXPECT_FALSE(deserialize_sequence_uint8_t(&reader, output, ARRAY_CAPACITY, &output_size));
+    EXPECT_FALSE(mc_deserialize_sequence_uint8_t(&reader, output, ARRAY_CAPACITY, &output_size));
 }
 
 TEST_F(SequenceOverflow, Block2)
@@ -53,7 +53,7 @@ TEST_F(SequenceOverflow, Block2)
     uint16_t output[ARRAY_CAPACITY];
 
     EXPECT_TRUE(serialize_sequence_uint16_t(&writer, input, SEQUENCE_SIZE_OVERFLOW));
-    EXPECT_FALSE(deserialize_sequence_uint16_t(&reader, output, ARRAY_CAPACITY, &output_size));
+    EXPECT_FALSE(mc_deserialize_sequence_uint16_t(&reader, output, ARRAY_CAPACITY, &output_size));
 }
 
 TEST_F(SequenceOverflow, Block4)
@@ -62,7 +62,7 @@ TEST_F(SequenceOverflow, Block4)
     uint32_t output[ARRAY_CAPACITY];
 
     EXPECT_TRUE(serialize_sequence_uint32_t(&writer, input, SEQUENCE_SIZE_OVERFLOW));
-    EXPECT_FALSE(deserialize_sequence_uint32_t(&reader, output, ARRAY_CAPACITY, &output_size));
+    EXPECT_FALSE(mc_deserialize_sequence_uint32_t(&reader, output, ARRAY_CAPACITY, &output_size));
 }
 
 TEST_F(SequenceOverflow, Block8)
@@ -71,6 +71,6 @@ TEST_F(SequenceOverflow, Block8)
     uint64_t output[ARRAY_CAPACITY];
 
     EXPECT_TRUE(serialize_sequence_uint64_t(&writer, input, SEQUENCE_SIZE_OVERFLOW));
-    EXPECT_FALSE(deserialize_sequence_uint64_t(&reader, output, ARRAY_CAPACITY, &output_size));
+    EXPECT_FALSE(mc_deserialize_sequence_uint64_t(&reader, output, ARRAY_CAPACITY, &output_size));
 }
 

--- a/test/SequenceOverflow.cpp
+++ b/test/SequenceOverflow.cpp
@@ -43,7 +43,7 @@ TEST_F(SequenceOverflow, Block1)
     uint8_t input[SEQUENCE_SIZE_OVERFLOW];
     uint8_t output[ARRAY_CAPACITY];
 
-    EXPECT_TRUE(serialize_sequence_uint8_t(&writer, input, SEQUENCE_SIZE_OVERFLOW));
+    EXPECT_TRUE(mc_serialize_sequence_uint8_t(&writer, input, SEQUENCE_SIZE_OVERFLOW));
     EXPECT_FALSE(mc_deserialize_sequence_uint8_t(&reader, output, ARRAY_CAPACITY, &output_size));
 }
 
@@ -52,7 +52,7 @@ TEST_F(SequenceOverflow, Block2)
     uint16_t input[SEQUENCE_SIZE_OVERFLOW];
     uint16_t output[ARRAY_CAPACITY];
 
-    EXPECT_TRUE(serialize_sequence_uint16_t(&writer, input, SEQUENCE_SIZE_OVERFLOW));
+    EXPECT_TRUE(mc_serialize_sequence_uint16_t(&writer, input, SEQUENCE_SIZE_OVERFLOW));
     EXPECT_FALSE(mc_deserialize_sequence_uint16_t(&reader, output, ARRAY_CAPACITY, &output_size));
 }
 
@@ -61,7 +61,7 @@ TEST_F(SequenceOverflow, Block4)
     uint32_t input[SEQUENCE_SIZE_OVERFLOW];
     uint32_t output[ARRAY_CAPACITY];
 
-    EXPECT_TRUE(serialize_sequence_uint32_t(&writer, input, SEQUENCE_SIZE_OVERFLOW));
+    EXPECT_TRUE(mc_serialize_sequence_uint32_t(&writer, input, SEQUENCE_SIZE_OVERFLOW));
     EXPECT_FALSE(mc_deserialize_sequence_uint32_t(&reader, output, ARRAY_CAPACITY, &output_size));
 }
 
@@ -70,7 +70,7 @@ TEST_F(SequenceOverflow, Block8)
     uint64_t input[SEQUENCE_SIZE_OVERFLOW];
     uint64_t output[ARRAY_CAPACITY];
 
-    EXPECT_TRUE(serialize_sequence_uint64_t(&writer, input, SEQUENCE_SIZE_OVERFLOW));
+    EXPECT_TRUE(mc_serialize_sequence_uint64_t(&writer, input, SEQUENCE_SIZE_OVERFLOW));
     EXPECT_FALSE(mc_deserialize_sequence_uint64_t(&reader, output, ARRAY_CAPACITY, &output_size));
 }
 

--- a/test/SequenceOverflow.cpp
+++ b/test/SequenceOverflow.cpp
@@ -27,7 +27,7 @@ public:
     ~SequenceOverflow()
     {
         //4 because of the sequence header (no necessary padding)
-        EXPECT_EQ(micro_buffer_length(&reader), 4);
+        EXPECT_EQ(mc_micro_buffer_length(&reader), 4);
         EXPECT_TRUE(reader.error);
 
         // To satisfy the base destructor

--- a/test/endianness/ArrayEndianness.cpp
+++ b/test/endianness/ArrayEndianness.cpp
@@ -38,7 +38,7 @@ TEST_P(ArrayEndianness, Int16)
     int16_t output[ARRAY_SIZE];
 
     EXPECT_TRUE(serialize_endian_array_int16_t(&writer, endianness, input, ARRAY_SIZE));
-    EXPECT_TRUE(deserialize_endian_array_int16_t(&reader, endianness, output, ARRAY_SIZE));
+    EXPECT_TRUE(mc_deserialize_endian_array_int16_t(&reader, endianness, output, ARRAY_SIZE));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
 }
@@ -50,7 +50,7 @@ TEST_P(ArrayEndianness, Uint16)
     uint16_t output[ARRAY_SIZE];
 
     EXPECT_TRUE(serialize_endian_array_uint16_t(&writer, endianness, input, ARRAY_SIZE));
-    EXPECT_TRUE(deserialize_endian_array_uint16_t(&reader, endianness, output, ARRAY_SIZE));
+    EXPECT_TRUE(mc_deserialize_endian_array_uint16_t(&reader, endianness, output, ARRAY_SIZE));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
 }
@@ -62,7 +62,7 @@ TEST_P(ArrayEndianness, Int32)
     int32_t output[ARRAY_SIZE];
 
     EXPECT_TRUE(serialize_endian_array_int32_t(&writer, endianness, input, ARRAY_SIZE));
-    EXPECT_TRUE(deserialize_endian_array_int32_t(&reader, endianness, output, ARRAY_SIZE));
+    EXPECT_TRUE(mc_deserialize_endian_array_int32_t(&reader, endianness, output, ARRAY_SIZE));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
 }
@@ -74,7 +74,7 @@ TEST_P(ArrayEndianness, Uint32)
     uint32_t output[ARRAY_SIZE];
 
     EXPECT_TRUE(serialize_endian_array_uint32_t(&writer, endianness, input, ARRAY_SIZE));
-    EXPECT_TRUE(deserialize_endian_array_uint32_t(&reader, endianness, output, ARRAY_SIZE));
+    EXPECT_TRUE(mc_deserialize_endian_array_uint32_t(&reader, endianness, output, ARRAY_SIZE));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
 }
@@ -86,7 +86,7 @@ TEST_P(ArrayEndianness, Int64)
     int64_t output[ARRAY_SIZE];
 
     EXPECT_TRUE(serialize_endian_array_int64_t(&writer, endianness, input, ARRAY_SIZE));
-    EXPECT_TRUE(deserialize_endian_array_int64_t(&reader, endianness, output, ARRAY_SIZE));
+    EXPECT_TRUE(mc_deserialize_endian_array_int64_t(&reader, endianness, output, ARRAY_SIZE));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
 }
@@ -98,7 +98,7 @@ TEST_P(ArrayEndianness, Uint64)
     uint64_t output[ARRAY_SIZE];
 
     EXPECT_TRUE(serialize_endian_array_uint64_t(&writer, endianness, input, ARRAY_SIZE));
-    EXPECT_TRUE(deserialize_endian_array_uint64_t(&reader, endianness, output, ARRAY_SIZE));
+    EXPECT_TRUE(mc_deserialize_endian_array_uint64_t(&reader, endianness, output, ARRAY_SIZE));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
 }
@@ -110,7 +110,7 @@ TEST_P(ArrayEndianness, Float)
     float output[ARRAY_SIZE];
 
     EXPECT_TRUE(serialize_endian_array_float(&writer, endianness, input, ARRAY_SIZE));
-    EXPECT_TRUE(deserialize_endian_array_float(&reader, endianness, output, ARRAY_SIZE));
+    EXPECT_TRUE(mc_deserialize_endian_array_float(&reader, endianness, output, ARRAY_SIZE));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
 }
@@ -122,7 +122,7 @@ TEST_P(ArrayEndianness, Double)
     double output[ARRAY_SIZE];
 
     EXPECT_TRUE(serialize_endian_array_double(&writer, endianness, input, ARRAY_SIZE));
-    EXPECT_TRUE(deserialize_endian_array_double(&reader, endianness, output, ARRAY_SIZE));
+    EXPECT_TRUE(mc_deserialize_endian_array_double(&reader, endianness, output, ARRAY_SIZE));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
 }

--- a/test/endianness/ArrayEndianness.cpp
+++ b/test/endianness/ArrayEndianness.cpp
@@ -37,7 +37,7 @@ TEST_P(ArrayEndianness, Int16)
     std::fill_n(input, ARRAY_SIZE, 0x0A0B);
     int16_t output[ARRAY_SIZE];
 
-    EXPECT_TRUE(serialize_endian_array_int16_t(&writer, endianness, input, ARRAY_SIZE));
+    EXPECT_TRUE(mc_serialize_endian_array_int16_t(&writer, endianness, input, ARRAY_SIZE));
     EXPECT_TRUE(mc_deserialize_endian_array_int16_t(&reader, endianness, output, ARRAY_SIZE));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
@@ -49,7 +49,7 @@ TEST_P(ArrayEndianness, Uint16)
     std::fill_n(input, ARRAY_SIZE, 0x0A0B);
     uint16_t output[ARRAY_SIZE];
 
-    EXPECT_TRUE(serialize_endian_array_uint16_t(&writer, endianness, input, ARRAY_SIZE));
+    EXPECT_TRUE(mc_serialize_endian_array_uint16_t(&writer, endianness, input, ARRAY_SIZE));
     EXPECT_TRUE(mc_deserialize_endian_array_uint16_t(&reader, endianness, output, ARRAY_SIZE));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
@@ -61,7 +61,7 @@ TEST_P(ArrayEndianness, Int32)
     std::fill_n(input, ARRAY_SIZE, 0x0C0D0E0F);
     int32_t output[ARRAY_SIZE];
 
-    EXPECT_TRUE(serialize_endian_array_int32_t(&writer, endianness, input, ARRAY_SIZE));
+    EXPECT_TRUE(mc_serialize_endian_array_int32_t(&writer, endianness, input, ARRAY_SIZE));
     EXPECT_TRUE(mc_deserialize_endian_array_int32_t(&reader, endianness, output, ARRAY_SIZE));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
@@ -73,7 +73,7 @@ TEST_P(ArrayEndianness, Uint32)
     std::fill_n(input, ARRAY_SIZE, 0x0C0D0E0F);
     uint32_t output[ARRAY_SIZE];
 
-    EXPECT_TRUE(serialize_endian_array_uint32_t(&writer, endianness, input, ARRAY_SIZE));
+    EXPECT_TRUE(mc_serialize_endian_array_uint32_t(&writer, endianness, input, ARRAY_SIZE));
     EXPECT_TRUE(mc_deserialize_endian_array_uint32_t(&reader, endianness, output, ARRAY_SIZE));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
@@ -85,7 +85,7 @@ TEST_P(ArrayEndianness, Int64)
     std::fill_n(input, ARRAY_SIZE, 0x0102030405060708L);
     int64_t output[ARRAY_SIZE];
 
-    EXPECT_TRUE(serialize_endian_array_int64_t(&writer, endianness, input, ARRAY_SIZE));
+    EXPECT_TRUE(mc_serialize_endian_array_int64_t(&writer, endianness, input, ARRAY_SIZE));
     EXPECT_TRUE(mc_deserialize_endian_array_int64_t(&reader, endianness, output, ARRAY_SIZE));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
@@ -97,7 +97,7 @@ TEST_P(ArrayEndianness, Uint64)
     std::fill_n(input, ARRAY_SIZE, 0x0102030405060708L);
     uint64_t output[ARRAY_SIZE];
 
-    EXPECT_TRUE(serialize_endian_array_uint64_t(&writer, endianness, input, ARRAY_SIZE));
+    EXPECT_TRUE(mc_serialize_endian_array_uint64_t(&writer, endianness, input, ARRAY_SIZE));
     EXPECT_TRUE(mc_deserialize_endian_array_uint64_t(&reader, endianness, output, ARRAY_SIZE));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
@@ -109,7 +109,7 @@ TEST_P(ArrayEndianness, Float)
     std::fill_n(input, ARRAY_SIZE, 3.141592653589793238462f);
     float output[ARRAY_SIZE];
 
-    EXPECT_TRUE(serialize_endian_array_float(&writer, endianness, input, ARRAY_SIZE));
+    EXPECT_TRUE(mc_serialize_endian_array_float(&writer, endianness, input, ARRAY_SIZE));
     EXPECT_TRUE(mc_deserialize_endian_array_float(&reader, endianness, output, ARRAY_SIZE));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
@@ -121,7 +121,7 @@ TEST_P(ArrayEndianness, Double)
     std::fill_n(input, ARRAY_SIZE, 3.141592653589793238462);
     double output[ARRAY_SIZE];
 
-    EXPECT_TRUE(serialize_endian_array_double(&writer, endianness, input, ARRAY_SIZE));
+    EXPECT_TRUE(mc_serialize_endian_array_double(&writer, endianness, input, ARRAY_SIZE));
     EXPECT_TRUE(mc_deserialize_endian_array_double(&reader, endianness, output, ARRAY_SIZE));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));

--- a/test/endianness/ArrayEndianness.cpp
+++ b/test/endianness/ArrayEndianness.cpp
@@ -14,7 +14,7 @@
 
 #include "../serialization/ArraySerialization.hpp"
 
-class ArrayEndianness : public ArraySerialization, public ::testing::WithParamInterface<Endianness>
+class ArrayEndianness : public ArraySerialization, public ::testing::WithParamInterface<mrEndianness>
 {
 public:
 
@@ -28,7 +28,7 @@ public:
     }
 
 protected:
-    Endianness endianness;
+    mrEndianness endianness;
 };
 
 TEST_P(ArrayEndianness, Int16)
@@ -127,4 +127,4 @@ TEST_P(ArrayEndianness, Double)
     EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
 }
 
-INSTANTIATE_TEST_CASE_P(Endianness, ArrayEndianness, ::testing::Values(LITTLE_ENDIANNESS, BIG_ENDIANNESS));
+INSTANTIATE_TEST_CASE_P(mrEndianness, ArrayEndianness, ::testing::Values(MC_LITTLE_ENDIANNESS, MC_BIG_ENDIANNESS));

--- a/test/endianness/ArrayEndianness.cpp
+++ b/test/endianness/ArrayEndianness.cpp
@@ -34,7 +34,7 @@ protected:
 TEST_P(ArrayEndianness, Int16)
 {
     int16_t input[ARRAY_SIZE];
-    std::fill_n(input, ARRAY_SIZE, 0x0A0B);
+    std::fill_n(input, ARRAY_SIZE, static_cast<int16_t>(0x0A0B));
     int16_t output[ARRAY_SIZE];
 
     EXPECT_TRUE(mc_serialize_endian_array_int16_t(&writer, endianness, input, ARRAY_SIZE));
@@ -46,7 +46,7 @@ TEST_P(ArrayEndianness, Int16)
 TEST_P(ArrayEndianness, Uint16)
 {
     uint16_t input[ARRAY_SIZE];
-    std::fill_n(input, ARRAY_SIZE, 0x0A0B);
+    std::fill_n(input, ARRAY_SIZE, static_cast<uint16_t>(0x0A0B));
     uint16_t output[ARRAY_SIZE];
 
     EXPECT_TRUE(mc_serialize_endian_array_uint16_t(&writer, endianness, input, ARRAY_SIZE));

--- a/test/endianness/ArrayEndianness.cpp
+++ b/test/endianness/ArrayEndianness.cpp
@@ -34,7 +34,7 @@ protected:
 TEST_P(ArrayEndianness, Int16)
 {
     int16_t input[ARRAY_SIZE];
-    std::fill_n(input, ARRAY_SIZE, static_cast<int16_t>(0x0A0B));
+    std::fill_n(input, ARRAY_SIZE, int16_t(0x0A0B));
     int16_t output[ARRAY_SIZE];
 
     EXPECT_TRUE(mc_serialize_endian_array_int16_t(&writer, endianness, input, ARRAY_SIZE));
@@ -46,7 +46,7 @@ TEST_P(ArrayEndianness, Int16)
 TEST_P(ArrayEndianness, Uint16)
 {
     uint16_t input[ARRAY_SIZE];
-    std::fill_n(input, ARRAY_SIZE, static_cast<uint16_t>(0x0A0B));
+    std::fill_n(input, ARRAY_SIZE, uint16_t(0x0A0Bu));
     uint16_t output[ARRAY_SIZE];
 
     EXPECT_TRUE(mc_serialize_endian_array_uint16_t(&writer, endianness, input, ARRAY_SIZE));

--- a/test/endianness/ArrayEndianness.cpp
+++ b/test/endianness/ArrayEndianness.cpp
@@ -14,7 +14,7 @@
 
 #include "../serialization/ArraySerialization.hpp"
 
-class ArrayEndianness : public ArraySerialization, public ::testing::WithParamInterface<mrEndianness>
+class ArrayEndianness : public ArraySerialization, public ::testing::WithParamInterface<mcEndianness>
 {
 public:
 
@@ -28,7 +28,7 @@ public:
     }
 
 protected:
-    mrEndianness endianness;
+    mcEndianness endianness;
 };
 
 TEST_P(ArrayEndianness, Int16)
@@ -127,4 +127,4 @@ TEST_P(ArrayEndianness, Double)
     EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
 }
 
-INSTANTIATE_TEST_CASE_P(mrEndianness, ArrayEndianness, ::testing::Values(MC_LITTLE_ENDIANNESS, MC_BIG_ENDIANNESS));
+INSTANTIATE_TEST_CASE_P(mcEndianness, ArrayEndianness, ::testing::Values(MC_LITTLE_ENDIANNESS, MC_BIG_ENDIANNESS));

--- a/test/endianness/BasicEndianness.cpp
+++ b/test/endianness/BasicEndianness.cpp
@@ -36,7 +36,7 @@ TEST_P(BasicEndianness, Int16)
     int16_t input = 0x0A0B;
     int16_t output = 0;
 
-    EXPECT_TRUE(serialize_endian_int16_t(&writer, endianness, input));
+    EXPECT_TRUE(mc_serialize_endian_int16_t(&writer, endianness, input));
     EXPECT_TRUE(mc_deserialize_endian_int16_t(&reader, endianness, &output));
 
     EXPECT_EQ(input, output);
@@ -47,7 +47,7 @@ TEST_P(BasicEndianness, Uint16)
     uint16_t input = 0x0A0B;
     uint16_t output = 0;
 
-    EXPECT_TRUE(serialize_endian_uint16_t(&writer, endianness, input));
+    EXPECT_TRUE(mc_serialize_endian_uint16_t(&writer, endianness, input));
     EXPECT_TRUE(mc_deserialize_endian_uint16_t(&reader, endianness, &output));
 
     EXPECT_EQ(input, output);
@@ -58,7 +58,7 @@ TEST_P(BasicEndianness, Int32)
     int32_t input = 0x0C0D0E0F;
     int32_t output = 0;
 
-    EXPECT_TRUE(serialize_endian_int32_t(&writer, endianness, input));
+    EXPECT_TRUE(mc_serialize_endian_int32_t(&writer, endianness, input));
     EXPECT_TRUE(mc_deserialize_endian_int32_t(&reader, endianness, &output));
 
     EXPECT_EQ(input, output);
@@ -69,7 +69,7 @@ TEST_P(BasicEndianness, Uint32)
     uint32_t input = 0x0C0D0E0F;
     uint32_t output = 0;
 
-    EXPECT_TRUE(serialize_endian_uint32_t(&writer, endianness, input));
+    EXPECT_TRUE(mc_serialize_endian_uint32_t(&writer, endianness, input));
     EXPECT_TRUE(mc_deserialize_endian_uint32_t(&reader, endianness, &output));
 
     EXPECT_EQ(input, output);
@@ -80,7 +80,7 @@ TEST_P(BasicEndianness, Int64)
     int64_t input = 0x0102030405060708L;
     int64_t output = 0;
 
-    EXPECT_TRUE(serialize_endian_int64_t(&writer, endianness, input));
+    EXPECT_TRUE(mc_serialize_endian_int64_t(&writer, endianness, input));
     EXPECT_TRUE(mc_deserialize_endian_int64_t(&reader, endianness, &output));
 
     EXPECT_EQ(input, output);
@@ -91,7 +91,7 @@ TEST_P(BasicEndianness, Uint64)
     uint64_t input = 0x0102030405060708L;
     uint64_t output = 0;
 
-    EXPECT_TRUE(serialize_endian_uint64_t(&writer, endianness, input));
+    EXPECT_TRUE(mc_serialize_endian_uint64_t(&writer, endianness, input));
     EXPECT_TRUE(mc_deserialize_endian_uint64_t(&reader, endianness, &output));
 
     EXPECT_EQ(input, output);
@@ -102,7 +102,7 @@ TEST_P(BasicEndianness, Float)
     float input  = 3.141592653589793238462f;
     float output = 0;
 
-    EXPECT_TRUE(serialize_endian_float(&writer, endianness, input));
+    EXPECT_TRUE(mc_serialize_endian_float(&writer, endianness, input));
     EXPECT_TRUE(mc_deserialize_endian_float(&reader, endianness, &output));
 
     EXPECT_EQ(input, output);
@@ -113,7 +113,7 @@ TEST_P(BasicEndianness, Double)
     double input  = 3.141592653589793238462;
     double output = 0;
 
-    EXPECT_TRUE(serialize_endian_double(&writer, endianness, input));
+    EXPECT_TRUE(mc_serialize_endian_double(&writer, endianness, input));
     EXPECT_TRUE(mc_deserialize_endian_double(&reader, endianness, &output));
 
     EXPECT_EQ(input, output);

--- a/test/endianness/BasicEndianness.cpp
+++ b/test/endianness/BasicEndianness.cpp
@@ -37,7 +37,7 @@ TEST_P(BasicEndianness, Int16)
     int16_t output = 0;
 
     EXPECT_TRUE(serialize_endian_int16_t(&writer, endianness, input));
-    EXPECT_TRUE(deserialize_endian_int16_t(&reader, endianness, &output));
+    EXPECT_TRUE(mc_deserialize_endian_int16_t(&reader, endianness, &output));
 
     EXPECT_EQ(input, output);
 }
@@ -48,7 +48,7 @@ TEST_P(BasicEndianness, Uint16)
     uint16_t output = 0;
 
     EXPECT_TRUE(serialize_endian_uint16_t(&writer, endianness, input));
-    EXPECT_TRUE(deserialize_endian_uint16_t(&reader, endianness, &output));
+    EXPECT_TRUE(mc_deserialize_endian_uint16_t(&reader, endianness, &output));
 
     EXPECT_EQ(input, output);
 }
@@ -59,7 +59,7 @@ TEST_P(BasicEndianness, Int32)
     int32_t output = 0;
 
     EXPECT_TRUE(serialize_endian_int32_t(&writer, endianness, input));
-    EXPECT_TRUE(deserialize_endian_int32_t(&reader, endianness, &output));
+    EXPECT_TRUE(mc_deserialize_endian_int32_t(&reader, endianness, &output));
 
     EXPECT_EQ(input, output);
 }
@@ -70,7 +70,7 @@ TEST_P(BasicEndianness, Uint32)
     uint32_t output = 0;
 
     EXPECT_TRUE(serialize_endian_uint32_t(&writer, endianness, input));
-    EXPECT_TRUE(deserialize_endian_uint32_t(&reader, endianness, &output));
+    EXPECT_TRUE(mc_deserialize_endian_uint32_t(&reader, endianness, &output));
 
     EXPECT_EQ(input, output);
 }
@@ -81,7 +81,7 @@ TEST_P(BasicEndianness, Int64)
     int64_t output = 0;
 
     EXPECT_TRUE(serialize_endian_int64_t(&writer, endianness, input));
-    EXPECT_TRUE(deserialize_endian_int64_t(&reader, endianness, &output));
+    EXPECT_TRUE(mc_deserialize_endian_int64_t(&reader, endianness, &output));
 
     EXPECT_EQ(input, output);
 }
@@ -92,7 +92,7 @@ TEST_P(BasicEndianness, Uint64)
     uint64_t output = 0;
 
     EXPECT_TRUE(serialize_endian_uint64_t(&writer, endianness, input));
-    EXPECT_TRUE(deserialize_endian_uint64_t(&reader, endianness, &output));
+    EXPECT_TRUE(mc_deserialize_endian_uint64_t(&reader, endianness, &output));
 
     EXPECT_EQ(input, output);
 }
@@ -103,7 +103,7 @@ TEST_P(BasicEndianness, Float)
     float output = 0;
 
     EXPECT_TRUE(serialize_endian_float(&writer, endianness, input));
-    EXPECT_TRUE(deserialize_endian_float(&reader, endianness, &output));
+    EXPECT_TRUE(mc_deserialize_endian_float(&reader, endianness, &output));
 
     EXPECT_EQ(input, output);
 }
@@ -114,7 +114,7 @@ TEST_P(BasicEndianness, Double)
     double output = 0;
 
     EXPECT_TRUE(serialize_endian_double(&writer, endianness, input));
-    EXPECT_TRUE(deserialize_endian_double(&reader, endianness, &output));
+    EXPECT_TRUE(mc_deserialize_endian_double(&reader, endianness, &output));
 
     EXPECT_EQ(input, output);
 }

--- a/test/endianness/BasicEndianness.cpp
+++ b/test/endianness/BasicEndianness.cpp
@@ -14,7 +14,7 @@
 
 #include "../serialization/BasicSerialization.hpp"
 
-class BasicEndianness : public BasicSerialization, public ::testing::WithParamInterface<mrEndianness>
+class BasicEndianness : public BasicSerialization, public ::testing::WithParamInterface<mcEndianness>
 {
 public:
 
@@ -28,7 +28,7 @@ public:
     }
 
 protected:
-    mrEndianness endianness;
+    mcEndianness endianness;
 };
 
 TEST_P(BasicEndianness, Int16)
@@ -119,4 +119,4 @@ TEST_P(BasicEndianness, Double)
     EXPECT_EQ(input, output);
 }
 
-INSTANTIATE_TEST_CASE_P(mrEndianness, BasicEndianness, ::testing::Values(MC_LITTLE_ENDIANNESS, MC_BIG_ENDIANNESS));
+INSTANTIATE_TEST_CASE_P(mcEndianness, BasicEndianness, ::testing::Values(MC_LITTLE_ENDIANNESS, MC_BIG_ENDIANNESS));

--- a/test/endianness/BasicEndianness.cpp
+++ b/test/endianness/BasicEndianness.cpp
@@ -14,7 +14,7 @@
 
 #include "../serialization/BasicSerialization.hpp"
 
-class BasicEndianness : public BasicSerialization, public ::testing::WithParamInterface<Endianness>
+class BasicEndianness : public BasicSerialization, public ::testing::WithParamInterface<mrEndianness>
 {
 public:
 
@@ -28,7 +28,7 @@ public:
     }
 
 protected:
-    Endianness endianness;
+    mrEndianness endianness;
 };
 
 TEST_P(BasicEndianness, Int16)
@@ -119,4 +119,4 @@ TEST_P(BasicEndianness, Double)
     EXPECT_EQ(input, output);
 }
 
-INSTANTIATE_TEST_CASE_P(Endianness, BasicEndianness, ::testing::Values(LITTLE_ENDIANNESS, BIG_ENDIANNESS));
+INSTANTIATE_TEST_CASE_P(mrEndianness, BasicEndianness, ::testing::Values(MC_LITTLE_ENDIANNESS, MC_BIG_ENDIANNESS));

--- a/test/endianness/SequenceEndianness.cpp
+++ b/test/endianness/SequenceEndianness.cpp
@@ -14,7 +14,7 @@
 
 #include "../serialization/SequenceSerialization.hpp"
 
-class SequenceEndianness : public SequenceSerialization, public ::testing::WithParamInterface<Endianness>
+class SequenceEndianness : public SequenceSerialization, public ::testing::WithParamInterface<mrEndianness>
 {
 public:
 
@@ -29,7 +29,7 @@ public:
 
 
 protected:
-    Endianness endianness;
+    mrEndianness endianness;
 };
 
 TEST_P(SequenceEndianness, Bool)
@@ -176,4 +176,4 @@ TEST_P(SequenceEndianness, Double)
     EXPECT_TRUE(0 == std::memcmp(input, output, SEQUENCE_SIZE));
 }
 
-INSTANTIATE_TEST_CASE_P(Endianness, SequenceEndianness, ::testing::Values(LITTLE_ENDIANNESS, BIG_ENDIANNESS));
+INSTANTIATE_TEST_CASE_P(mrEndianness, SequenceEndianness, ::testing::Values(MC_LITTLE_ENDIANNESS, MC_BIG_ENDIANNESS));

--- a/test/endianness/SequenceEndianness.cpp
+++ b/test/endianness/SequenceEndianness.cpp
@@ -14,7 +14,7 @@
 
 #include "../serialization/SequenceSerialization.hpp"
 
-class SequenceEndianness : public SequenceSerialization, public ::testing::WithParamInterface<mrEndianness>
+class SequenceEndianness : public SequenceSerialization, public ::testing::WithParamInterface<mcEndianness>
 {
 public:
 
@@ -29,7 +29,7 @@ public:
 
 
 protected:
-    mrEndianness endianness;
+    mcEndianness endianness;
 };
 
 TEST_P(SequenceEndianness, Bool)
@@ -176,4 +176,4 @@ TEST_P(SequenceEndianness, Double)
     EXPECT_TRUE(0 == std::memcmp(input, output, SEQUENCE_SIZE));
 }
 
-INSTANTIATE_TEST_CASE_P(mrEndianness, SequenceEndianness, ::testing::Values(MC_LITTLE_ENDIANNESS, MC_BIG_ENDIANNESS));
+INSTANTIATE_TEST_CASE_P(mcEndianness, SequenceEndianness, ::testing::Values(MC_LITTLE_ENDIANNESS, MC_BIG_ENDIANNESS));

--- a/test/endianness/SequenceEndianness.cpp
+++ b/test/endianness/SequenceEndianness.cpp
@@ -59,7 +59,7 @@ TEST_P(SequenceEndianness, Char)
 TEST_P(SequenceEndianness, Int8)
 {
     int8_t input[ARRAY_CAPACITY];
-    std::fill_n(input, SEQUENCE_SIZE, static_cast<int8_t>(0x09));
+    std::fill_n(input, SEQUENCE_SIZE, int8_t(0x09));
     int8_t output[ARRAY_CAPACITY];
 
     EXPECT_TRUE(mc_serialize_endian_sequence_int8_t(&writer, endianness, input, SEQUENCE_SIZE));
@@ -71,7 +71,7 @@ TEST_P(SequenceEndianness, Int8)
 TEST_P(SequenceEndianness, Uint8)
 {
     uint8_t input[ARRAY_CAPACITY];
-    std::fill_n(input, SEQUENCE_SIZE, static_cast<uint8_t>(0x09));
+    std::fill_n(input, SEQUENCE_SIZE, uint8_t(0x09));
     uint8_t output[ARRAY_CAPACITY];
 
     EXPECT_TRUE(mc_serialize_endian_sequence_uint8_t(&writer, endianness, input, SEQUENCE_SIZE));
@@ -83,7 +83,7 @@ TEST_P(SequenceEndianness, Uint8)
 TEST_P(SequenceEndianness, Int16)
 {
     int16_t input[ARRAY_CAPACITY];
-    std::fill_n(input, SEQUENCE_SIZE, static_cast<int16_t>(0x0A0B));
+    std::fill_n(input, SEQUENCE_SIZE, int16_t(0x0A0B));
     int16_t output[ARRAY_CAPACITY];
 
     EXPECT_TRUE(mc_serialize_endian_sequence_int16_t(&writer, endianness, input, SEQUENCE_SIZE));
@@ -95,7 +95,7 @@ TEST_P(SequenceEndianness, Int16)
 TEST_P(SequenceEndianness, Uint16)
 {
     uint16_t input[ARRAY_CAPACITY];
-    std::fill_n(input, SEQUENCE_SIZE, static_cast<uint8_t>(0x0A0B));
+    std::fill_n(input, SEQUENCE_SIZE, uint16_t(0x0A0B));
     uint16_t output[ARRAY_CAPACITY];
 
     EXPECT_TRUE(mc_serialize_endian_sequence_uint16_t(&writer, endianness, input, SEQUENCE_SIZE));

--- a/test/endianness/SequenceEndianness.cpp
+++ b/test/endianness/SequenceEndianness.cpp
@@ -38,7 +38,7 @@ TEST_P(SequenceEndianness, Bool)
     std::fill_n(input, SEQUENCE_SIZE, true);
     bool output[ARRAY_CAPACITY];
 
-    EXPECT_TRUE(serialize_endian_sequence_bool(&writer, endianness, input, SEQUENCE_SIZE));
+    EXPECT_TRUE(mc_serialize_endian_sequence_bool(&writer, endianness, input, SEQUENCE_SIZE));
     EXPECT_TRUE(mc_deserialize_endian_sequence_bool(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, SEQUENCE_SIZE));
@@ -50,7 +50,7 @@ TEST_P(SequenceEndianness, Char)
     std::fill_n(input, SEQUENCE_SIZE, 'A');
     char output[ARRAY_CAPACITY];
 
-    EXPECT_TRUE(serialize_endian_sequence_char(&writer, endianness, input, SEQUENCE_SIZE));
+    EXPECT_TRUE(mc_serialize_endian_sequence_char(&writer, endianness, input, SEQUENCE_SIZE));
     EXPECT_TRUE(mc_deserialize_endian_sequence_char(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, SEQUENCE_SIZE));
@@ -62,7 +62,7 @@ TEST_P(SequenceEndianness, Int8)
     std::fill_n(input, SEQUENCE_SIZE, 0x09);
     int8_t output[ARRAY_CAPACITY];
 
-    EXPECT_TRUE(serialize_endian_sequence_int8_t(&writer, endianness, input, SEQUENCE_SIZE));
+    EXPECT_TRUE(mc_serialize_endian_sequence_int8_t(&writer, endianness, input, SEQUENCE_SIZE));
     EXPECT_TRUE(mc_deserialize_endian_sequence_int8_t(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, SEQUENCE_SIZE));
@@ -74,7 +74,7 @@ TEST_P(SequenceEndianness, Uint8)
     std::fill_n(input, SEQUENCE_SIZE, 0x09);
     uint8_t output[ARRAY_CAPACITY];
 
-    EXPECT_TRUE(serialize_endian_sequence_uint8_t(&writer, endianness, input, SEQUENCE_SIZE));
+    EXPECT_TRUE(mc_serialize_endian_sequence_uint8_t(&writer, endianness, input, SEQUENCE_SIZE));
     EXPECT_TRUE(mc_deserialize_endian_sequence_uint8_t(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, SEQUENCE_SIZE));
@@ -86,7 +86,7 @@ TEST_P(SequenceEndianness, Int16)
     std::fill_n(input, SEQUENCE_SIZE, 0x0A0B);
     int16_t output[ARRAY_CAPACITY];
 
-    EXPECT_TRUE(serialize_endian_sequence_int16_t(&writer, endianness, input, SEQUENCE_SIZE));
+    EXPECT_TRUE(mc_serialize_endian_sequence_int16_t(&writer, endianness, input, SEQUENCE_SIZE));
     EXPECT_TRUE(mc_deserialize_endian_sequence_int16_t(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, SEQUENCE_SIZE));
@@ -98,7 +98,7 @@ TEST_P(SequenceEndianness, Uint16)
     std::fill_n(input, SEQUENCE_SIZE, 0x0A0B);
     uint16_t output[ARRAY_CAPACITY];
 
-    EXPECT_TRUE(serialize_endian_sequence_uint16_t(&writer, endianness, input, SEQUENCE_SIZE));
+    EXPECT_TRUE(mc_serialize_endian_sequence_uint16_t(&writer, endianness, input, SEQUENCE_SIZE));
     EXPECT_TRUE(mc_deserialize_endian_sequence_uint16_t(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, SEQUENCE_SIZE));
@@ -110,7 +110,7 @@ TEST_P(SequenceEndianness, Int32)
     std::fill_n(input, SEQUENCE_SIZE, 0x0A0B0C0D);
     int32_t output[ARRAY_CAPACITY];
 
-    EXPECT_TRUE(serialize_endian_sequence_int32_t(&writer, endianness, input, SEQUENCE_SIZE));
+    EXPECT_TRUE(mc_serialize_endian_sequence_int32_t(&writer, endianness, input, SEQUENCE_SIZE));
     EXPECT_TRUE(mc_deserialize_endian_sequence_int32_t(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, SEQUENCE_SIZE));
@@ -122,7 +122,7 @@ TEST_P(SequenceEndianness, Uint32)
     std::fill_n(input, SEQUENCE_SIZE, 0x0A0B0C0D);
     uint32_t output[ARRAY_CAPACITY];
 
-    EXPECT_TRUE(serialize_endian_sequence_uint32_t(&writer, endianness, input, SEQUENCE_SIZE));
+    EXPECT_TRUE(mc_serialize_endian_sequence_uint32_t(&writer, endianness, input, SEQUENCE_SIZE));
     EXPECT_TRUE(mc_deserialize_endian_sequence_uint32_t(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, SEQUENCE_SIZE));
@@ -134,7 +134,7 @@ TEST_P(SequenceEndianness, Int64)
     std::fill_n(input, SEQUENCE_SIZE, 0x0102030405060708L);
     int64_t output[ARRAY_CAPACITY];
 
-    EXPECT_TRUE(serialize_endian_sequence_int64_t(&writer, endianness, input, SEQUENCE_SIZE));
+    EXPECT_TRUE(mc_serialize_endian_sequence_int64_t(&writer, endianness, input, SEQUENCE_SIZE));
     EXPECT_TRUE(mc_deserialize_endian_sequence_int64_t(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, SEQUENCE_SIZE));
@@ -146,7 +146,7 @@ TEST_P(SequenceEndianness, Uint64)
     std::fill_n(input, SEQUENCE_SIZE, 0x0102030405060708L);
     uint64_t output[ARRAY_CAPACITY];
 
-    EXPECT_TRUE(serialize_endian_sequence_uint64_t(&writer, endianness, input, SEQUENCE_SIZE));
+    EXPECT_TRUE(mc_serialize_endian_sequence_uint64_t(&writer, endianness, input, SEQUENCE_SIZE));
     EXPECT_TRUE(mc_deserialize_endian_sequence_uint64_t(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, SEQUENCE_SIZE));
@@ -158,7 +158,7 @@ TEST_P(SequenceEndianness, Float)
     std::fill_n(input, SEQUENCE_SIZE, 3.141592653589793238462f);
     float output[ARRAY_CAPACITY];
 
-    EXPECT_TRUE(serialize_endian_sequence_float(&writer, endianness, input, SEQUENCE_SIZE));
+    EXPECT_TRUE(mc_serialize_endian_sequence_float(&writer, endianness, input, SEQUENCE_SIZE));
     EXPECT_TRUE(mc_deserialize_endian_sequence_float(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, SEQUENCE_SIZE));
@@ -170,7 +170,7 @@ TEST_P(SequenceEndianness, Double)
     std::fill_n(input, SEQUENCE_SIZE, 3.141592653589793238462);
     double output[ARRAY_CAPACITY];
 
-    EXPECT_TRUE(serialize_endian_sequence_double(&writer, endianness, input, SEQUENCE_SIZE));
+    EXPECT_TRUE(mc_serialize_endian_sequence_double(&writer, endianness, input, SEQUENCE_SIZE));
     EXPECT_TRUE(mc_deserialize_endian_sequence_double(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, SEQUENCE_SIZE));

--- a/test/endianness/SequenceEndianness.cpp
+++ b/test/endianness/SequenceEndianness.cpp
@@ -39,7 +39,7 @@ TEST_P(SequenceEndianness, Bool)
     bool output[ARRAY_CAPACITY];
 
     EXPECT_TRUE(serialize_endian_sequence_bool(&writer, endianness, input, SEQUENCE_SIZE));
-    EXPECT_TRUE(deserialize_endian_sequence_bool(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
+    EXPECT_TRUE(mc_deserialize_endian_sequence_bool(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, SEQUENCE_SIZE));
 }
@@ -51,7 +51,7 @@ TEST_P(SequenceEndianness, Char)
     char output[ARRAY_CAPACITY];
 
     EXPECT_TRUE(serialize_endian_sequence_char(&writer, endianness, input, SEQUENCE_SIZE));
-    EXPECT_TRUE(deserialize_endian_sequence_char(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
+    EXPECT_TRUE(mc_deserialize_endian_sequence_char(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, SEQUENCE_SIZE));
 }
@@ -63,7 +63,7 @@ TEST_P(SequenceEndianness, Int8)
     int8_t output[ARRAY_CAPACITY];
 
     EXPECT_TRUE(serialize_endian_sequence_int8_t(&writer, endianness, input, SEQUENCE_SIZE));
-    EXPECT_TRUE(deserialize_endian_sequence_int8_t(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
+    EXPECT_TRUE(mc_deserialize_endian_sequence_int8_t(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, SEQUENCE_SIZE));
 }
@@ -75,7 +75,7 @@ TEST_P(SequenceEndianness, Uint8)
     uint8_t output[ARRAY_CAPACITY];
 
     EXPECT_TRUE(serialize_endian_sequence_uint8_t(&writer, endianness, input, SEQUENCE_SIZE));
-    EXPECT_TRUE(deserialize_endian_sequence_uint8_t(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
+    EXPECT_TRUE(mc_deserialize_endian_sequence_uint8_t(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, SEQUENCE_SIZE));
 }
@@ -87,7 +87,7 @@ TEST_P(SequenceEndianness, Int16)
     int16_t output[ARRAY_CAPACITY];
 
     EXPECT_TRUE(serialize_endian_sequence_int16_t(&writer, endianness, input, SEQUENCE_SIZE));
-    EXPECT_TRUE(deserialize_endian_sequence_int16_t(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
+    EXPECT_TRUE(mc_deserialize_endian_sequence_int16_t(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, SEQUENCE_SIZE));
 }
@@ -99,7 +99,7 @@ TEST_P(SequenceEndianness, Uint16)
     uint16_t output[ARRAY_CAPACITY];
 
     EXPECT_TRUE(serialize_endian_sequence_uint16_t(&writer, endianness, input, SEQUENCE_SIZE));
-    EXPECT_TRUE(deserialize_endian_sequence_uint16_t(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
+    EXPECT_TRUE(mc_deserialize_endian_sequence_uint16_t(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, SEQUENCE_SIZE));
 }
@@ -111,7 +111,7 @@ TEST_P(SequenceEndianness, Int32)
     int32_t output[ARRAY_CAPACITY];
 
     EXPECT_TRUE(serialize_endian_sequence_int32_t(&writer, endianness, input, SEQUENCE_SIZE));
-    EXPECT_TRUE(deserialize_endian_sequence_int32_t(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
+    EXPECT_TRUE(mc_deserialize_endian_sequence_int32_t(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, SEQUENCE_SIZE));
 }
@@ -123,7 +123,7 @@ TEST_P(SequenceEndianness, Uint32)
     uint32_t output[ARRAY_CAPACITY];
 
     EXPECT_TRUE(serialize_endian_sequence_uint32_t(&writer, endianness, input, SEQUENCE_SIZE));
-    EXPECT_TRUE(deserialize_endian_sequence_uint32_t(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
+    EXPECT_TRUE(mc_deserialize_endian_sequence_uint32_t(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, SEQUENCE_SIZE));
 }
@@ -135,7 +135,7 @@ TEST_P(SequenceEndianness, Int64)
     int64_t output[ARRAY_CAPACITY];
 
     EXPECT_TRUE(serialize_endian_sequence_int64_t(&writer, endianness, input, SEQUENCE_SIZE));
-    EXPECT_TRUE(deserialize_endian_sequence_int64_t(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
+    EXPECT_TRUE(mc_deserialize_endian_sequence_int64_t(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, SEQUENCE_SIZE));
 }
@@ -147,7 +147,7 @@ TEST_P(SequenceEndianness, Uint64)
     uint64_t output[ARRAY_CAPACITY];
 
     EXPECT_TRUE(serialize_endian_sequence_uint64_t(&writer, endianness, input, SEQUENCE_SIZE));
-    EXPECT_TRUE(deserialize_endian_sequence_uint64_t(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
+    EXPECT_TRUE(mc_deserialize_endian_sequence_uint64_t(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, SEQUENCE_SIZE));
 }
@@ -159,7 +159,7 @@ TEST_P(SequenceEndianness, Float)
     float output[ARRAY_CAPACITY];
 
     EXPECT_TRUE(serialize_endian_sequence_float(&writer, endianness, input, SEQUENCE_SIZE));
-    EXPECT_TRUE(deserialize_endian_sequence_float(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
+    EXPECT_TRUE(mc_deserialize_endian_sequence_float(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, SEQUENCE_SIZE));
 }
@@ -171,7 +171,7 @@ TEST_P(SequenceEndianness, Double)
     double output[ARRAY_CAPACITY];
 
     EXPECT_TRUE(serialize_endian_sequence_double(&writer, endianness, input, SEQUENCE_SIZE));
-    EXPECT_TRUE(deserialize_endian_sequence_double(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
+    EXPECT_TRUE(mc_deserialize_endian_sequence_double(&reader, endianness, output, ARRAY_CAPACITY, &output_size));
 
     EXPECT_TRUE(0 == std::memcmp(input, output, SEQUENCE_SIZE));
 }

--- a/test/endianness/SequenceEndianness.cpp
+++ b/test/endianness/SequenceEndianness.cpp
@@ -59,7 +59,7 @@ TEST_P(SequenceEndianness, Char)
 TEST_P(SequenceEndianness, Int8)
 {
     int8_t input[ARRAY_CAPACITY];
-    std::fill_n(input, SEQUENCE_SIZE, 0x09);
+    std::fill_n(input, SEQUENCE_SIZE, static_cast<int8_t>(0x09));
     int8_t output[ARRAY_CAPACITY];
 
     EXPECT_TRUE(mc_serialize_endian_sequence_int8_t(&writer, endianness, input, SEQUENCE_SIZE));
@@ -71,7 +71,7 @@ TEST_P(SequenceEndianness, Int8)
 TEST_P(SequenceEndianness, Uint8)
 {
     uint8_t input[ARRAY_CAPACITY];
-    std::fill_n(input, SEQUENCE_SIZE, 0x09);
+    std::fill_n(input, SEQUENCE_SIZE, static_cast<uint8_t>(0x09));
     uint8_t output[ARRAY_CAPACITY];
 
     EXPECT_TRUE(mc_serialize_endian_sequence_uint8_t(&writer, endianness, input, SEQUENCE_SIZE));
@@ -83,7 +83,7 @@ TEST_P(SequenceEndianness, Uint8)
 TEST_P(SequenceEndianness, Int16)
 {
     int16_t input[ARRAY_CAPACITY];
-    std::fill_n(input, SEQUENCE_SIZE, 0x0A0B);
+    std::fill_n(input, SEQUENCE_SIZE, static_cast<int16_t>(0x0A0B));
     int16_t output[ARRAY_CAPACITY];
 
     EXPECT_TRUE(mc_serialize_endian_sequence_int16_t(&writer, endianness, input, SEQUENCE_SIZE));
@@ -95,7 +95,7 @@ TEST_P(SequenceEndianness, Int16)
 TEST_P(SequenceEndianness, Uint16)
 {
     uint16_t input[ARRAY_CAPACITY];
-    std::fill_n(input, SEQUENCE_SIZE, 0x0A0B);
+    std::fill_n(input, SEQUENCE_SIZE, static_cast<uint8_t>(0x0A0B));
     uint16_t output[ARRAY_CAPACITY];
 
     EXPECT_TRUE(mc_serialize_endian_sequence_uint16_t(&writer, endianness, input, SEQUENCE_SIZE));

--- a/test/serialization/ArraySerialization.hpp
+++ b/test/serialization/ArraySerialization.hpp
@@ -58,7 +58,7 @@ public:
     void int8_t_array_serialization()
     {
         int8_t input[ARRAY_SIZE];
-        std::fill_n(input, ARRAY_SIZE, static_cast<int8_t>(0x09));
+        std::fill_n(input, ARRAY_SIZE, int8_t(0x09));
         int8_t output[ARRAY_SIZE];
 
         EXPECT_TRUE(mc_serialize_array_int8_t(&writer, input, ARRAY_SIZE));
@@ -70,7 +70,7 @@ public:
     void uint8_t_array_serialization()
     {
         uint8_t input[ARRAY_SIZE];
-        std::fill_n(input, ARRAY_SIZE, static_cast<uint8_t>(0x09));
+        std::fill_n(input, ARRAY_SIZE, uint8_t(0x09));
         uint8_t output[ARRAY_SIZE];
 
         EXPECT_TRUE(mc_serialize_array_uint8_t(&writer, input, ARRAY_SIZE));
@@ -82,7 +82,7 @@ public:
     void int16_t_array_serialization()
     {
         int16_t input[ARRAY_SIZE];
-        std::fill_n(input, ARRAY_SIZE, static_cast<int16_t>(0x0A0B));
+        std::fill_n(input, ARRAY_SIZE, int16_t(0x0A0B));
         int16_t output[ARRAY_SIZE];
 
         EXPECT_TRUE(mc_serialize_array_int16_t(&writer, input, ARRAY_SIZE));
@@ -94,7 +94,7 @@ public:
     void uint16_t_array_serialization()
     {
         uint16_t input[ARRAY_SIZE];
-        std::fill_n(input, ARRAY_SIZE, static_cast<uint16_t>(0x0A0B));
+        std::fill_n(input, ARRAY_SIZE, uint16_t(0x0A0B));
         uint16_t output[ARRAY_SIZE];
 
         EXPECT_TRUE(mc_serialize_array_uint16_t(&writer, input, ARRAY_SIZE));

--- a/test/serialization/ArraySerialization.hpp
+++ b/test/serialization/ArraySerialization.hpp
@@ -58,7 +58,7 @@ public:
     void int8_t_array_serialization()
     {
         int8_t input[ARRAY_SIZE];
-        std::fill_n(input, ARRAY_SIZE, 0x09);
+        std::fill_n(input, ARRAY_SIZE, (int8_t)0x09);
         int8_t output[ARRAY_SIZE];
 
         EXPECT_TRUE(mc_serialize_array_int8_t(&writer, input, ARRAY_SIZE));
@@ -70,7 +70,7 @@ public:
     void uint8_t_array_serialization()
     {
         uint8_t input[ARRAY_SIZE];
-        std::fill_n(input, ARRAY_SIZE, 0x09);
+        std::fill_n(input, ARRAY_SIZE, (uint8_t)0x09);
         uint8_t output[ARRAY_SIZE];
 
         EXPECT_TRUE(mc_serialize_array_uint8_t(&writer, input, ARRAY_SIZE));
@@ -82,7 +82,7 @@ public:
     void int16_t_array_serialization()
     {
         int16_t input[ARRAY_SIZE];
-        std::fill_n(input, ARRAY_SIZE, 0x0A0B);
+        std::fill_n(input, ARRAY_SIZE, (int16_t)0x0A0B);
         int16_t output[ARRAY_SIZE];
 
         EXPECT_TRUE(mc_serialize_array_int16_t(&writer, input, ARRAY_SIZE));
@@ -94,7 +94,7 @@ public:
     void uint16_t_array_serialization()
     {
         uint16_t input[ARRAY_SIZE];
-        std::fill_n(input, ARRAY_SIZE, 0x0A0B);
+        std::fill_n(input, ARRAY_SIZE, (uint16_t)0x0A0B);
         uint16_t output[ARRAY_SIZE];
 
         EXPECT_TRUE(mc_serialize_array_uint16_t(&writer, input, ARRAY_SIZE));

--- a/test/serialization/ArraySerialization.hpp
+++ b/test/serialization/ArraySerialization.hpp
@@ -38,7 +38,7 @@ public:
         bool output[ARRAY_SIZE];
 
         EXPECT_TRUE(serialize_array_bool(&writer, input, ARRAY_SIZE));
-        EXPECT_TRUE(deserialize_array_bool(&reader, output, ARRAY_SIZE));
+        EXPECT_TRUE(mc_deserialize_array_bool(&reader, output, ARRAY_SIZE));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
     }
@@ -50,7 +50,7 @@ public:
         char output[ARRAY_SIZE];
 
         EXPECT_TRUE(serialize_array_char(&writer, input, ARRAY_SIZE));
-        EXPECT_TRUE(deserialize_array_char(&reader, output, ARRAY_SIZE));
+        EXPECT_TRUE(mc_deserialize_array_char(&reader, output, ARRAY_SIZE));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
     }
@@ -62,7 +62,7 @@ public:
         int8_t output[ARRAY_SIZE];
 
         EXPECT_TRUE(serialize_array_int8_t(&writer, input, ARRAY_SIZE));
-        EXPECT_TRUE(deserialize_array_int8_t(&reader, output, ARRAY_SIZE));
+        EXPECT_TRUE(mc_deserialize_array_int8_t(&reader, output, ARRAY_SIZE));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
     }
@@ -74,7 +74,7 @@ public:
         uint8_t output[ARRAY_SIZE];
 
         EXPECT_TRUE(serialize_array_uint8_t(&writer, input, ARRAY_SIZE));
-        EXPECT_TRUE(deserialize_array_uint8_t(&reader, output, ARRAY_SIZE));
+        EXPECT_TRUE(mc_deserialize_array_uint8_t(&reader, output, ARRAY_SIZE));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
     }
@@ -86,7 +86,7 @@ public:
         int16_t output[ARRAY_SIZE];
 
         EXPECT_TRUE(serialize_array_int16_t(&writer, input, ARRAY_SIZE));
-        EXPECT_TRUE(deserialize_array_int16_t(&reader, output, ARRAY_SIZE));
+        EXPECT_TRUE(mc_deserialize_array_int16_t(&reader, output, ARRAY_SIZE));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
     }
@@ -98,7 +98,7 @@ public:
         uint16_t output[ARRAY_SIZE];
 
         EXPECT_TRUE(serialize_array_uint16_t(&writer, input, ARRAY_SIZE));
-        EXPECT_TRUE(deserialize_array_uint16_t(&reader, output, ARRAY_SIZE));
+        EXPECT_TRUE(mc_deserialize_array_uint16_t(&reader, output, ARRAY_SIZE));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
     }
@@ -110,7 +110,7 @@ public:
         int32_t output[ARRAY_SIZE];
 
         EXPECT_TRUE(serialize_array_int32_t(&writer, input, ARRAY_SIZE));
-        EXPECT_TRUE(deserialize_array_int32_t(&reader, output, ARRAY_SIZE));
+        EXPECT_TRUE(mc_deserialize_array_int32_t(&reader, output, ARRAY_SIZE));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
     }
@@ -122,7 +122,7 @@ public:
         uint32_t output[ARRAY_SIZE];
 
         EXPECT_TRUE(serialize_array_uint32_t(&writer, input, ARRAY_SIZE));
-        EXPECT_TRUE(deserialize_array_uint32_t(&reader, output, ARRAY_SIZE));
+        EXPECT_TRUE(mc_deserialize_array_uint32_t(&reader, output, ARRAY_SIZE));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
     }
@@ -134,7 +134,7 @@ public:
         int64_t output[ARRAY_SIZE];
 
         EXPECT_TRUE(serialize_array_int64_t(&writer, input, ARRAY_SIZE));
-        EXPECT_TRUE(deserialize_array_int64_t(&reader, output, ARRAY_SIZE));
+        EXPECT_TRUE(mc_deserialize_array_int64_t(&reader, output, ARRAY_SIZE));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
     }
@@ -146,7 +146,7 @@ public:
         uint64_t output[ARRAY_SIZE];
 
         EXPECT_TRUE(serialize_array_uint64_t(&writer, input, ARRAY_SIZE));
-        EXPECT_TRUE(deserialize_array_uint64_t(&reader, output, ARRAY_SIZE));
+        EXPECT_TRUE(mc_deserialize_array_uint64_t(&reader, output, ARRAY_SIZE));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
     }
@@ -158,7 +158,7 @@ public:
         float output[ARRAY_SIZE];
 
         EXPECT_TRUE(serialize_array_float(&writer, input, ARRAY_SIZE));
-        EXPECT_TRUE(deserialize_array_float(&reader, output, ARRAY_SIZE));
+        EXPECT_TRUE(mc_deserialize_array_float(&reader, output, ARRAY_SIZE));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
     }
@@ -170,7 +170,7 @@ public:
         double output[ARRAY_SIZE];
 
         EXPECT_TRUE(serialize_array_double(&writer, input, ARRAY_SIZE));
-        EXPECT_TRUE(deserialize_array_double(&reader, output, ARRAY_SIZE));
+        EXPECT_TRUE(mc_deserialize_array_double(&reader, output, ARRAY_SIZE));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
     }

--- a/test/serialization/ArraySerialization.hpp
+++ b/test/serialization/ArraySerialization.hpp
@@ -58,7 +58,7 @@ public:
     void int8_t_array_serialization()
     {
         int8_t input[ARRAY_SIZE];
-        std::fill_n(input, ARRAY_SIZE, (int8_t)0x09);
+        std::fill_n(input, ARRAY_SIZE, static_cast<int8_t>(0x09));
         int8_t output[ARRAY_SIZE];
 
         EXPECT_TRUE(mc_serialize_array_int8_t(&writer, input, ARRAY_SIZE));
@@ -70,7 +70,7 @@ public:
     void uint8_t_array_serialization()
     {
         uint8_t input[ARRAY_SIZE];
-        std::fill_n(input, ARRAY_SIZE, (uint8_t)0x09);
+        std::fill_n(input, ARRAY_SIZE, static_cast<uint8_t>(0x09));
         uint8_t output[ARRAY_SIZE];
 
         EXPECT_TRUE(mc_serialize_array_uint8_t(&writer, input, ARRAY_SIZE));
@@ -82,7 +82,7 @@ public:
     void int16_t_array_serialization()
     {
         int16_t input[ARRAY_SIZE];
-        std::fill_n(input, ARRAY_SIZE, (int16_t)0x0A0B);
+        std::fill_n(input, ARRAY_SIZE, static_cast<int16_t>(0x0A0B));
         int16_t output[ARRAY_SIZE];
 
         EXPECT_TRUE(mc_serialize_array_int16_t(&writer, input, ARRAY_SIZE));
@@ -94,7 +94,7 @@ public:
     void uint16_t_array_serialization()
     {
         uint16_t input[ARRAY_SIZE];
-        std::fill_n(input, ARRAY_SIZE, (uint16_t)0x0A0B);
+        std::fill_n(input, ARRAY_SIZE, static_cast<uint16_t>(0x0A0B));
         uint16_t output[ARRAY_SIZE];
 
         EXPECT_TRUE(mc_serialize_array_uint16_t(&writer, input, ARRAY_SIZE));

--- a/test/serialization/ArraySerialization.hpp
+++ b/test/serialization/ArraySerialization.hpp
@@ -37,7 +37,7 @@ public:
         std::fill_n(input, ARRAY_SIZE, true);
         bool output[ARRAY_SIZE];
 
-        EXPECT_TRUE(serialize_array_bool(&writer, input, ARRAY_SIZE));
+        EXPECT_TRUE(mc_serialize_array_bool(&writer, input, ARRAY_SIZE));
         EXPECT_TRUE(mc_deserialize_array_bool(&reader, output, ARRAY_SIZE));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
@@ -49,7 +49,7 @@ public:
         std::fill_n(input, ARRAY_SIZE, 'A');
         char output[ARRAY_SIZE];
 
-        EXPECT_TRUE(serialize_array_char(&writer, input, ARRAY_SIZE));
+        EXPECT_TRUE(mc_serialize_array_char(&writer, input, ARRAY_SIZE));
         EXPECT_TRUE(mc_deserialize_array_char(&reader, output, ARRAY_SIZE));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
@@ -61,7 +61,7 @@ public:
         std::fill_n(input, ARRAY_SIZE, 0x09);
         int8_t output[ARRAY_SIZE];
 
-        EXPECT_TRUE(serialize_array_int8_t(&writer, input, ARRAY_SIZE));
+        EXPECT_TRUE(mc_serialize_array_int8_t(&writer, input, ARRAY_SIZE));
         EXPECT_TRUE(mc_deserialize_array_int8_t(&reader, output, ARRAY_SIZE));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
@@ -73,7 +73,7 @@ public:
         std::fill_n(input, ARRAY_SIZE, 0x09);
         uint8_t output[ARRAY_SIZE];
 
-        EXPECT_TRUE(serialize_array_uint8_t(&writer, input, ARRAY_SIZE));
+        EXPECT_TRUE(mc_serialize_array_uint8_t(&writer, input, ARRAY_SIZE));
         EXPECT_TRUE(mc_deserialize_array_uint8_t(&reader, output, ARRAY_SIZE));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
@@ -85,7 +85,7 @@ public:
         std::fill_n(input, ARRAY_SIZE, 0x0A0B);
         int16_t output[ARRAY_SIZE];
 
-        EXPECT_TRUE(serialize_array_int16_t(&writer, input, ARRAY_SIZE));
+        EXPECT_TRUE(mc_serialize_array_int16_t(&writer, input, ARRAY_SIZE));
         EXPECT_TRUE(mc_deserialize_array_int16_t(&reader, output, ARRAY_SIZE));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
@@ -97,7 +97,7 @@ public:
         std::fill_n(input, ARRAY_SIZE, 0x0A0B);
         uint16_t output[ARRAY_SIZE];
 
-        EXPECT_TRUE(serialize_array_uint16_t(&writer, input, ARRAY_SIZE));
+        EXPECT_TRUE(mc_serialize_array_uint16_t(&writer, input, ARRAY_SIZE));
         EXPECT_TRUE(mc_deserialize_array_uint16_t(&reader, output, ARRAY_SIZE));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
@@ -109,7 +109,7 @@ public:
         std::fill_n(input, ARRAY_SIZE, 0x0C0D0E0F);
         int32_t output[ARRAY_SIZE];
 
-        EXPECT_TRUE(serialize_array_int32_t(&writer, input, ARRAY_SIZE));
+        EXPECT_TRUE(mc_serialize_array_int32_t(&writer, input, ARRAY_SIZE));
         EXPECT_TRUE(mc_deserialize_array_int32_t(&reader, output, ARRAY_SIZE));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
@@ -121,7 +121,7 @@ public:
         std::fill_n(input, ARRAY_SIZE, 0x0C0D0E0F);
         uint32_t output[ARRAY_SIZE];
 
-        EXPECT_TRUE(serialize_array_uint32_t(&writer, input, ARRAY_SIZE));
+        EXPECT_TRUE(mc_serialize_array_uint32_t(&writer, input, ARRAY_SIZE));
         EXPECT_TRUE(mc_deserialize_array_uint32_t(&reader, output, ARRAY_SIZE));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
@@ -133,7 +133,7 @@ public:
         std::fill_n(input, ARRAY_SIZE, 0x0102030405060708L);
         int64_t output[ARRAY_SIZE];
 
-        EXPECT_TRUE(serialize_array_int64_t(&writer, input, ARRAY_SIZE));
+        EXPECT_TRUE(mc_serialize_array_int64_t(&writer, input, ARRAY_SIZE));
         EXPECT_TRUE(mc_deserialize_array_int64_t(&reader, output, ARRAY_SIZE));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
@@ -145,7 +145,7 @@ public:
         std::fill_n(input, ARRAY_SIZE, 0x0102030405060708L);
         uint64_t output[ARRAY_SIZE];
 
-        EXPECT_TRUE(serialize_array_uint64_t(&writer, input, ARRAY_SIZE));
+        EXPECT_TRUE(mc_serialize_array_uint64_t(&writer, input, ARRAY_SIZE));
         EXPECT_TRUE(mc_deserialize_array_uint64_t(&reader, output, ARRAY_SIZE));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
@@ -157,7 +157,7 @@ public:
         std::fill_n(input, ARRAY_SIZE, 3.141592653589793238462f);
         float output[ARRAY_SIZE];
 
-        EXPECT_TRUE(serialize_array_float(&writer, input, ARRAY_SIZE));
+        EXPECT_TRUE(mc_serialize_array_float(&writer, input, ARRAY_SIZE));
         EXPECT_TRUE(mc_deserialize_array_float(&reader, output, ARRAY_SIZE));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));
@@ -169,7 +169,7 @@ public:
         std::fill_n(input, ARRAY_SIZE, 3.141592653589793238462);
         double output[ARRAY_SIZE];
 
-        EXPECT_TRUE(serialize_array_double(&writer, input, ARRAY_SIZE));
+        EXPECT_TRUE(mc_serialize_array_double(&writer, input, ARRAY_SIZE));
         EXPECT_TRUE(mc_deserialize_array_double(&reader, output, ARRAY_SIZE));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, ARRAY_SIZE));

--- a/test/serialization/BasicSerialization.hpp
+++ b/test/serialization/BasicSerialization.hpp
@@ -29,8 +29,8 @@ public:
     BasicSerialization()
     {
         std::memset(buffer, 0, BUFFER_LENGTH);
-        init_micro_buffer(&writer, buffer, BUFFER_LENGTH);
-        init_micro_buffer(&reader, buffer, BUFFER_LENGTH);
+        mc_init_micro_buffer(&writer, buffer, BUFFER_LENGTH);
+        mc_init_micro_buffer(&reader, buffer, BUFFER_LENGTH);
     }
 
     void check_data_size(uint32_t data_size)

--- a/test/serialization/BasicSerialization.hpp
+++ b/test/serialization/BasicSerialization.hpp
@@ -192,8 +192,8 @@ public:
     }
 
 protected:
-    mcMicroBuffer writer;
-    mcMicroBuffer reader;
+    mcBuffer writer;
+    mcBuffer reader;
     uint8_t buffer[BUFFER_LENGTH];
 };
 

--- a/test/serialization/BasicSerialization.hpp
+++ b/test/serialization/BasicSerialization.hpp
@@ -29,8 +29,8 @@ public:
     BasicSerialization()
     {
         std::memset(buffer, 0, BUFFER_LENGTH);
-        mc_init_micro_buffer(&writer, buffer, BUFFER_LENGTH);
-        mc_init_micro_buffer(&reader, buffer, BUFFER_LENGTH);
+        mc_init_buffer(&writer, buffer, BUFFER_LENGTH);
+        mc_init_buffer(&reader, buffer, BUFFER_LENGTH);
     }
 
     void check_data_size(uint32_t data_size)

--- a/test/serialization/BasicSerialization.hpp
+++ b/test/serialization/BasicSerialization.hpp
@@ -192,8 +192,8 @@ public:
     }
 
 protected:
-    MicroBuffer writer;
-    MicroBuffer reader;
+    mcMicroBuffer writer;
+    mcMicroBuffer reader;
     uint8_t buffer[BUFFER_LENGTH];
 };
 

--- a/test/serialization/BasicSerialization.hpp
+++ b/test/serialization/BasicSerialization.hpp
@@ -51,7 +51,7 @@ public:
         bool input = true;
         bool output = 0;
 
-        EXPECT_TRUE(serialize_bool(&writer, input));
+        EXPECT_TRUE(mc_serialize_bool(&writer, input));
         EXPECT_TRUE(mc_deserialize_bool(&reader, &output));
 
         EXPECT_EQ(input, output);
@@ -64,7 +64,7 @@ public:
         char input = 'A';
         char output = 0;
 
-        EXPECT_TRUE(serialize_char(&writer, input));
+        EXPECT_TRUE(mc_serialize_char(&writer, input));
         EXPECT_TRUE(mc_deserialize_char(&reader, &output));
 
         EXPECT_EQ(input, output);
@@ -76,7 +76,7 @@ public:
         int8_t input = 0x09;
         int8_t output = 0;
 
-        EXPECT_TRUE(serialize_int8_t(&writer, input));
+        EXPECT_TRUE(mc_serialize_int8_t(&writer, input));
         EXPECT_TRUE(mc_deserialize_int8_t(&reader, &output));
 
         EXPECT_EQ(input, output);
@@ -88,7 +88,7 @@ public:
         uint8_t input = 0x09;
         uint8_t output = 0;
 
-        EXPECT_TRUE(serialize_uint8_t(&writer, input));
+        EXPECT_TRUE(mc_serialize_uint8_t(&writer, input));
         EXPECT_TRUE(mc_deserialize_uint8_t(&reader, &output));
 
         EXPECT_EQ(input, output);
@@ -100,7 +100,7 @@ public:
         int16_t input = 0x0A0B;
         int16_t output = 0;
 
-        EXPECT_TRUE(serialize_int16_t(&writer, input));
+        EXPECT_TRUE(mc_serialize_int16_t(&writer, input));
         EXPECT_TRUE(mc_deserialize_int16_t(&reader, &output));
 
         EXPECT_EQ(input, output);
@@ -112,7 +112,7 @@ public:
         uint16_t input = 0x0A0B;
         uint16_t output = 0;
 
-        EXPECT_TRUE(serialize_uint16_t(&writer, input));
+        EXPECT_TRUE(mc_serialize_uint16_t(&writer, input));
         EXPECT_TRUE(mc_deserialize_uint16_t(&reader, &output));
 
         EXPECT_EQ(input, output);
@@ -124,7 +124,7 @@ public:
         int32_t input = 0x0C0D0E0F;
         int32_t output = 0;
 
-        EXPECT_TRUE(serialize_int32_t(&writer, input));
+        EXPECT_TRUE(mc_serialize_int32_t(&writer, input));
         EXPECT_TRUE(mc_deserialize_int32_t(&reader, &output));
 
         EXPECT_EQ(input, output);
@@ -136,7 +136,7 @@ public:
         uint32_t input = 0x0C0D0E0F;
         uint32_t output = 0;
 
-        EXPECT_TRUE(serialize_uint32_t(&writer, input));
+        EXPECT_TRUE(mc_serialize_uint32_t(&writer, input));
         EXPECT_TRUE(mc_deserialize_uint32_t(&reader, &output));
 
         EXPECT_EQ(input, output);
@@ -148,7 +148,7 @@ public:
         int64_t input = 0x0102030405060708L;
         int64_t output = 0;
 
-        EXPECT_TRUE(serialize_int64_t(&writer, input));
+        EXPECT_TRUE(mc_serialize_int64_t(&writer, input));
         EXPECT_TRUE(mc_deserialize_int64_t(&reader, &output));
 
         EXPECT_EQ(input, output);
@@ -160,7 +160,7 @@ public:
         uint64_t input = 0x0102030405060708L;
         uint64_t output = 0;
 
-        EXPECT_TRUE(serialize_uint64_t(&writer, input));
+        EXPECT_TRUE(mc_serialize_uint64_t(&writer, input));
         EXPECT_TRUE(mc_deserialize_uint64_t(&reader, &output));
 
         EXPECT_EQ(input, output);
@@ -172,7 +172,7 @@ public:
         float input  = 3.141592653589793238462f;
         float output = 0;
 
-        EXPECT_TRUE(serialize_float(&writer, input));
+        EXPECT_TRUE(mc_serialize_float(&writer, input));
         EXPECT_TRUE(mc_deserialize_float(&reader, &output));
 
         EXPECT_EQ(input, output);
@@ -184,7 +184,7 @@ public:
         double input  = 3.141592653589793238462;
         double output = 0;
 
-        EXPECT_TRUE(serialize_double(&writer, input));
+        EXPECT_TRUE(mc_serialize_double(&writer, input));
         EXPECT_TRUE(mc_deserialize_double(&reader, &output));
 
         EXPECT_EQ(input, output);

--- a/test/serialization/BasicSerialization.hpp
+++ b/test/serialization/BasicSerialization.hpp
@@ -52,7 +52,7 @@ public:
         bool output = 0;
 
         EXPECT_TRUE(serialize_bool(&writer, input));
-        EXPECT_TRUE(deserialize_bool(&reader, &output));
+        EXPECT_TRUE(mc_deserialize_bool(&reader, &output));
 
         EXPECT_EQ(input, output);
 
@@ -65,7 +65,7 @@ public:
         char output = 0;
 
         EXPECT_TRUE(serialize_char(&writer, input));
-        EXPECT_TRUE(deserialize_char(&reader, &output));
+        EXPECT_TRUE(mc_deserialize_char(&reader, &output));
 
         EXPECT_EQ(input, output);
         check_data_size(1);
@@ -77,7 +77,7 @@ public:
         int8_t output = 0;
 
         EXPECT_TRUE(serialize_int8_t(&writer, input));
-        EXPECT_TRUE(deserialize_int8_t(&reader, &output));
+        EXPECT_TRUE(mc_deserialize_int8_t(&reader, &output));
 
         EXPECT_EQ(input, output);
         check_data_size(1);
@@ -89,7 +89,7 @@ public:
         uint8_t output = 0;
 
         EXPECT_TRUE(serialize_uint8_t(&writer, input));
-        EXPECT_TRUE(deserialize_uint8_t(&reader, &output));
+        EXPECT_TRUE(mc_deserialize_uint8_t(&reader, &output));
 
         EXPECT_EQ(input, output);
         check_data_size(1);
@@ -101,7 +101,7 @@ public:
         int16_t output = 0;
 
         EXPECT_TRUE(serialize_int16_t(&writer, input));
-        EXPECT_TRUE(deserialize_int16_t(&reader, &output));
+        EXPECT_TRUE(mc_deserialize_int16_t(&reader, &output));
 
         EXPECT_EQ(input, output);
         check_data_size(2);
@@ -113,7 +113,7 @@ public:
         uint16_t output = 0;
 
         EXPECT_TRUE(serialize_uint16_t(&writer, input));
-        EXPECT_TRUE(deserialize_uint16_t(&reader, &output));
+        EXPECT_TRUE(mc_deserialize_uint16_t(&reader, &output));
 
         EXPECT_EQ(input, output);
         check_data_size(2);
@@ -125,7 +125,7 @@ public:
         int32_t output = 0;
 
         EXPECT_TRUE(serialize_int32_t(&writer, input));
-        EXPECT_TRUE(deserialize_int32_t(&reader, &output));
+        EXPECT_TRUE(mc_deserialize_int32_t(&reader, &output));
 
         EXPECT_EQ(input, output);
         check_data_size(4);
@@ -137,7 +137,7 @@ public:
         uint32_t output = 0;
 
         EXPECT_TRUE(serialize_uint32_t(&writer, input));
-        EXPECT_TRUE(deserialize_uint32_t(&reader, &output));
+        EXPECT_TRUE(mc_deserialize_uint32_t(&reader, &output));
 
         EXPECT_EQ(input, output);
         check_data_size(4);
@@ -149,7 +149,7 @@ public:
         int64_t output = 0;
 
         EXPECT_TRUE(serialize_int64_t(&writer, input));
-        EXPECT_TRUE(deserialize_int64_t(&reader, &output));
+        EXPECT_TRUE(mc_deserialize_int64_t(&reader, &output));
 
         EXPECT_EQ(input, output);
         check_data_size(8);
@@ -161,7 +161,7 @@ public:
         uint64_t output = 0;
 
         EXPECT_TRUE(serialize_uint64_t(&writer, input));
-        EXPECT_TRUE(deserialize_uint64_t(&reader, &output));
+        EXPECT_TRUE(mc_deserialize_uint64_t(&reader, &output));
 
         EXPECT_EQ(input, output);
         check_data_size(8);
@@ -173,7 +173,7 @@ public:
         float output = 0;
 
         EXPECT_TRUE(serialize_float(&writer, input));
-        EXPECT_TRUE(deserialize_float(&reader, &output));
+        EXPECT_TRUE(mc_deserialize_float(&reader, &output));
 
         EXPECT_EQ(input, output);
         check_data_size(4);
@@ -185,7 +185,7 @@ public:
         double output = 0;
 
         EXPECT_TRUE(serialize_double(&writer, input));
-        EXPECT_TRUE(deserialize_double(&reader, &output));
+        EXPECT_TRUE(mc_deserialize_double(&reader, &output));
 
         EXPECT_EQ(input, output);
         check_data_size(8);

--- a/test/serialization/SequenceSerialization.hpp
+++ b/test/serialization/SequenceSerialization.hpp
@@ -45,7 +45,7 @@ public:
         bool output[ARRAY_CAPACITY];
 
         EXPECT_TRUE(serialize_sequence_bool(&writer, input, sequence_size));
-        EXPECT_TRUE(deserialize_sequence_bool(&reader, output, ARRAY_CAPACITY, &output_size));
+        EXPECT_TRUE(mc_deserialize_sequence_bool(&reader, output, ARRAY_CAPACITY, &output_size));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, sequence_size));
     }
@@ -57,7 +57,7 @@ public:
         char output[ARRAY_CAPACITY];
 
         EXPECT_TRUE(serialize_sequence_char(&writer, input, sequence_size));
-        EXPECT_TRUE(deserialize_sequence_char(&reader, output, ARRAY_CAPACITY, &output_size));
+        EXPECT_TRUE(mc_deserialize_sequence_char(&reader, output, ARRAY_CAPACITY, &output_size));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, sequence_size));
     }
@@ -69,7 +69,7 @@ public:
         int8_t output[ARRAY_CAPACITY];
 
         EXPECT_TRUE(serialize_sequence_int8_t(&writer, input, sequence_size));
-        EXPECT_TRUE(deserialize_sequence_int8_t(&reader, output, ARRAY_CAPACITY, &output_size));
+        EXPECT_TRUE(mc_deserialize_sequence_int8_t(&reader, output, ARRAY_CAPACITY, &output_size));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, sequence_size));
     }
@@ -81,7 +81,7 @@ public:
         uint8_t output[ARRAY_CAPACITY];
 
         EXPECT_TRUE(serialize_sequence_uint8_t(&writer, input, sequence_size));
-        EXPECT_TRUE(deserialize_sequence_uint8_t(&reader, output, ARRAY_CAPACITY, &output_size));
+        EXPECT_TRUE(mc_deserialize_sequence_uint8_t(&reader, output, ARRAY_CAPACITY, &output_size));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, sequence_size));
     }
@@ -93,7 +93,7 @@ public:
         int16_t output[ARRAY_CAPACITY];
 
         EXPECT_TRUE(serialize_sequence_int16_t(&writer, input, sequence_size));
-        EXPECT_TRUE(deserialize_sequence_int16_t(&reader, output, ARRAY_CAPACITY, &output_size));
+        EXPECT_TRUE(mc_deserialize_sequence_int16_t(&reader, output, ARRAY_CAPACITY, &output_size));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, sequence_size));
     }
@@ -105,7 +105,7 @@ public:
         uint16_t output[ARRAY_CAPACITY];
 
         EXPECT_TRUE(serialize_sequence_uint16_t(&writer, input, sequence_size));
-        EXPECT_TRUE(deserialize_sequence_uint16_t(&reader, output, ARRAY_CAPACITY, &output_size));
+        EXPECT_TRUE(mc_deserialize_sequence_uint16_t(&reader, output, ARRAY_CAPACITY, &output_size));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, sequence_size));
     }
@@ -117,7 +117,7 @@ public:
         int32_t output[ARRAY_CAPACITY];
 
         EXPECT_TRUE(serialize_sequence_int32_t(&writer, input, sequence_size));
-        EXPECT_TRUE(deserialize_sequence_int32_t(&reader, output, ARRAY_CAPACITY, &output_size));
+        EXPECT_TRUE(mc_deserialize_sequence_int32_t(&reader, output, ARRAY_CAPACITY, &output_size));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, sequence_size));
     }
@@ -129,7 +129,7 @@ public:
         uint32_t output[ARRAY_CAPACITY];
 
         EXPECT_TRUE(serialize_sequence_uint32_t(&writer, input, sequence_size));
-        EXPECT_TRUE(deserialize_sequence_uint32_t(&reader, output, ARRAY_CAPACITY, &output_size));
+        EXPECT_TRUE(mc_deserialize_sequence_uint32_t(&reader, output, ARRAY_CAPACITY, &output_size));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, sequence_size));
     }
@@ -141,7 +141,7 @@ public:
         int64_t output[ARRAY_CAPACITY];
 
         EXPECT_TRUE(serialize_sequence_int64_t(&writer, input, sequence_size));
-        EXPECT_TRUE(deserialize_sequence_int64_t(&reader, output, ARRAY_CAPACITY, &output_size));
+        EXPECT_TRUE(mc_deserialize_sequence_int64_t(&reader, output, ARRAY_CAPACITY, &output_size));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, sequence_size));
     }
@@ -153,7 +153,7 @@ public:
         uint64_t output[ARRAY_CAPACITY];
 
         EXPECT_TRUE(serialize_sequence_uint64_t(&writer, input, sequence_size));
-        EXPECT_TRUE(deserialize_sequence_uint64_t(&reader, output, ARRAY_CAPACITY, &output_size));
+        EXPECT_TRUE(mc_deserialize_sequence_uint64_t(&reader, output, ARRAY_CAPACITY, &output_size));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, sequence_size));
     }
@@ -165,7 +165,7 @@ public:
         float output[ARRAY_CAPACITY];
 
         EXPECT_TRUE(serialize_sequence_float(&writer, input, sequence_size));
-        EXPECT_TRUE(deserialize_sequence_float(&reader, output, ARRAY_CAPACITY, &output_size));
+        EXPECT_TRUE(mc_deserialize_sequence_float(&reader, output, ARRAY_CAPACITY, &output_size));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, sequence_size));
     }
@@ -177,7 +177,7 @@ public:
         double output[ARRAY_CAPACITY];
 
         EXPECT_TRUE(serialize_sequence_double(&writer, input, sequence_size));
-        EXPECT_TRUE(deserialize_sequence_double(&reader, output, ARRAY_CAPACITY, &output_size));
+        EXPECT_TRUE(mc_deserialize_sequence_double(&reader, output, ARRAY_CAPACITY, &output_size));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, sequence_size));
     }

--- a/test/serialization/SequenceSerialization.hpp
+++ b/test/serialization/SequenceSerialization.hpp
@@ -65,7 +65,7 @@ public:
     void int8_t_sequence_serialization()
     {
         int8_t input[ARRAY_CAPACITY];
-        std::fill_n(input, sequence_size, static_cast<int8_t>(0x09));
+        std::fill_n(input, sequence_size, int8_t(0x09));
         int8_t output[ARRAY_CAPACITY];
 
         EXPECT_TRUE(mc_serialize_sequence_int8_t(&writer, input, sequence_size));
@@ -77,7 +77,7 @@ public:
     void uint8_t_sequence_serialization()
     {
         uint8_t input[ARRAY_CAPACITY];
-        std::fill_n(input, sequence_size, static_cast<uint8_t>(0x09));
+        std::fill_n(input, sequence_size, uint8_t(0x09));
         uint8_t output[ARRAY_CAPACITY];
 
         EXPECT_TRUE(mc_serialize_sequence_uint8_t(&writer, input, sequence_size));
@@ -89,7 +89,7 @@ public:
     void int16_t_sequence_serialization()
     {
         int16_t input[ARRAY_CAPACITY];
-        std::fill_n(input, sequence_size, static_cast<int16_t>(0x0A0B));
+        std::fill_n(input, sequence_size, int16_t(0x0A0B));
         int16_t output[ARRAY_CAPACITY];
 
         EXPECT_TRUE(mc_serialize_sequence_int16_t(&writer, input, sequence_size));
@@ -101,7 +101,7 @@ public:
     void uint16_t_sequence_serialization()
     {
         uint16_t input[ARRAY_CAPACITY];
-        std::fill_n(input, sequence_size, static_cast<uint16_t>(0x0A0B));
+        std::fill_n(input, sequence_size, uint16_t(0x0A0B));
         uint16_t output[ARRAY_CAPACITY];
 
         EXPECT_TRUE(mc_serialize_sequence_uint16_t(&writer, input, sequence_size));

--- a/test/serialization/SequenceSerialization.hpp
+++ b/test/serialization/SequenceSerialization.hpp
@@ -44,7 +44,7 @@ public:
         std::fill_n(input, sequence_size, true);
         bool output[ARRAY_CAPACITY];
 
-        EXPECT_TRUE(serialize_sequence_bool(&writer, input, sequence_size));
+        EXPECT_TRUE(mc_serialize_sequence_bool(&writer, input, sequence_size));
         EXPECT_TRUE(mc_deserialize_sequence_bool(&reader, output, ARRAY_CAPACITY, &output_size));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, sequence_size));
@@ -56,7 +56,7 @@ public:
         std::fill_n(input, sequence_size, 'A');
         char output[ARRAY_CAPACITY];
 
-        EXPECT_TRUE(serialize_sequence_char(&writer, input, sequence_size));
+        EXPECT_TRUE(mc_serialize_sequence_char(&writer, input, sequence_size));
         EXPECT_TRUE(mc_deserialize_sequence_char(&reader, output, ARRAY_CAPACITY, &output_size));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, sequence_size));
@@ -68,7 +68,7 @@ public:
         std::fill_n(input, sequence_size, 0x09);
         int8_t output[ARRAY_CAPACITY];
 
-        EXPECT_TRUE(serialize_sequence_int8_t(&writer, input, sequence_size));
+        EXPECT_TRUE(mc_serialize_sequence_int8_t(&writer, input, sequence_size));
         EXPECT_TRUE(mc_deserialize_sequence_int8_t(&reader, output, ARRAY_CAPACITY, &output_size));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, sequence_size));
@@ -80,7 +80,7 @@ public:
         std::fill_n(input, sequence_size, 0x09);
         uint8_t output[ARRAY_CAPACITY];
 
-        EXPECT_TRUE(serialize_sequence_uint8_t(&writer, input, sequence_size));
+        EXPECT_TRUE(mc_serialize_sequence_uint8_t(&writer, input, sequence_size));
         EXPECT_TRUE(mc_deserialize_sequence_uint8_t(&reader, output, ARRAY_CAPACITY, &output_size));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, sequence_size));
@@ -92,7 +92,7 @@ public:
         std::fill_n(input, sequence_size, 0x0A0B);
         int16_t output[ARRAY_CAPACITY];
 
-        EXPECT_TRUE(serialize_sequence_int16_t(&writer, input, sequence_size));
+        EXPECT_TRUE(mc_serialize_sequence_int16_t(&writer, input, sequence_size));
         EXPECT_TRUE(mc_deserialize_sequence_int16_t(&reader, output, ARRAY_CAPACITY, &output_size));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, sequence_size));
@@ -104,7 +104,7 @@ public:
         std::fill_n(input, sequence_size, 0x0A0B);
         uint16_t output[ARRAY_CAPACITY];
 
-        EXPECT_TRUE(serialize_sequence_uint16_t(&writer, input, sequence_size));
+        EXPECT_TRUE(mc_serialize_sequence_uint16_t(&writer, input, sequence_size));
         EXPECT_TRUE(mc_deserialize_sequence_uint16_t(&reader, output, ARRAY_CAPACITY, &output_size));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, sequence_size));
@@ -116,7 +116,7 @@ public:
         std::fill_n(input, sequence_size, 0x0A0B0C0D);
         int32_t output[ARRAY_CAPACITY];
 
-        EXPECT_TRUE(serialize_sequence_int32_t(&writer, input, sequence_size));
+        EXPECT_TRUE(mc_serialize_sequence_int32_t(&writer, input, sequence_size));
         EXPECT_TRUE(mc_deserialize_sequence_int32_t(&reader, output, ARRAY_CAPACITY, &output_size));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, sequence_size));
@@ -128,7 +128,7 @@ public:
         std::fill_n(input, sequence_size, 0x0A0B0C0D);
         uint32_t output[ARRAY_CAPACITY];
 
-        EXPECT_TRUE(serialize_sequence_uint32_t(&writer, input, sequence_size));
+        EXPECT_TRUE(mc_serialize_sequence_uint32_t(&writer, input, sequence_size));
         EXPECT_TRUE(mc_deserialize_sequence_uint32_t(&reader, output, ARRAY_CAPACITY, &output_size));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, sequence_size));
@@ -140,7 +140,7 @@ public:
         std::fill_n(input, sequence_size, 0x0102030405060708L);
         int64_t output[ARRAY_CAPACITY];
 
-        EXPECT_TRUE(serialize_sequence_int64_t(&writer, input, sequence_size));
+        EXPECT_TRUE(mc_serialize_sequence_int64_t(&writer, input, sequence_size));
         EXPECT_TRUE(mc_deserialize_sequence_int64_t(&reader, output, ARRAY_CAPACITY, &output_size));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, sequence_size));
@@ -152,7 +152,7 @@ public:
         std::fill_n(input, sequence_size, 0x0102030405060708L);
         uint64_t output[ARRAY_CAPACITY];
 
-        EXPECT_TRUE(serialize_sequence_uint64_t(&writer, input, sequence_size));
+        EXPECT_TRUE(mc_serialize_sequence_uint64_t(&writer, input, sequence_size));
         EXPECT_TRUE(mc_deserialize_sequence_uint64_t(&reader, output, ARRAY_CAPACITY, &output_size));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, sequence_size));
@@ -164,7 +164,7 @@ public:
         std::fill_n(input, sequence_size, 3.141592653589793238462f);
         float output[ARRAY_CAPACITY];
 
-        EXPECT_TRUE(serialize_sequence_float(&writer, input, sequence_size));
+        EXPECT_TRUE(mc_serialize_sequence_float(&writer, input, sequence_size));
         EXPECT_TRUE(mc_deserialize_sequence_float(&reader, output, ARRAY_CAPACITY, &output_size));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, sequence_size));
@@ -176,7 +176,7 @@ public:
         std::fill_n(input, sequence_size, 3.141592653589793238462);
         double output[ARRAY_CAPACITY];
 
-        EXPECT_TRUE(serialize_sequence_double(&writer, input, sequence_size));
+        EXPECT_TRUE(mc_serialize_sequence_double(&writer, input, sequence_size));
         EXPECT_TRUE(mc_deserialize_sequence_double(&reader, output, ARRAY_CAPACITY, &output_size));
 
         EXPECT_TRUE(0 == std::memcmp(input, output, sequence_size));

--- a/test/serialization/SequenceSerialization.hpp
+++ b/test/serialization/SequenceSerialization.hpp
@@ -65,7 +65,7 @@ public:
     void int8_t_sequence_serialization()
     {
         int8_t input[ARRAY_CAPACITY];
-        std::fill_n(input, sequence_size, 0x09);
+        std::fill_n(input, sequence_size, static_cast<int8_t>(0x09));
         int8_t output[ARRAY_CAPACITY];
 
         EXPECT_TRUE(mc_serialize_sequence_int8_t(&writer, input, sequence_size));
@@ -77,7 +77,7 @@ public:
     void uint8_t_sequence_serialization()
     {
         uint8_t input[ARRAY_CAPACITY];
-        std::fill_n(input, sequence_size, 0x09);
+        std::fill_n(input, sequence_size, static_cast<uint8_t>(0x09));
         uint8_t output[ARRAY_CAPACITY];
 
         EXPECT_TRUE(mc_serialize_sequence_uint8_t(&writer, input, sequence_size));
@@ -89,7 +89,7 @@ public:
     void int16_t_sequence_serialization()
     {
         int16_t input[ARRAY_CAPACITY];
-        std::fill_n(input, sequence_size, 0x0A0B);
+        std::fill_n(input, sequence_size, static_cast<int16_t>(0x0A0B));
         int16_t output[ARRAY_CAPACITY];
 
         EXPECT_TRUE(mc_serialize_sequence_int16_t(&writer, input, sequence_size));
@@ -101,7 +101,7 @@ public:
     void uint16_t_sequence_serialization()
     {
         uint16_t input[ARRAY_CAPACITY];
-        std::fill_n(input, sequence_size, 0x0A0B);
+        std::fill_n(input, sequence_size, static_cast<uint16_t>(0x0A0B));
         uint16_t output[ARRAY_CAPACITY];
 
         EXPECT_TRUE(mc_serialize_sequence_uint16_t(&writer, input, sequence_size));

--- a/test/serialization/StringSerialization.hpp
+++ b/test/serialization/StringSerialization.hpp
@@ -35,7 +35,7 @@ public:
         char input[MAX_STRING_LENGTH] = "This is a message test";
         char output[MAX_STRING_LENGTH] = {0};
 
-        EXPECT_TRUE(serialize_string(&writer, input));
+        EXPECT_TRUE(mc_serialize_string(&writer, input));
         EXPECT_TRUE(mc_deserialize_string(&reader, output, MAX_STRING_LENGTH));
 
         EXPECT_STREQ(input, output);

--- a/test/serialization/StringSerialization.hpp
+++ b/test/serialization/StringSerialization.hpp
@@ -36,7 +36,7 @@ public:
         char output[MAX_STRING_LENGTH] = {0};
 
         EXPECT_TRUE(serialize_string(&writer, input));
-        EXPECT_TRUE(deserialize_string(&reader, output, MAX_STRING_LENGTH));
+        EXPECT_TRUE(mc_deserialize_string(&reader, output, MAX_STRING_LENGTH));
 
         EXPECT_STREQ(input, output);
     }


### PR DESCRIPTION
- `MC_` to public constants
- `mc` to public types
- `mc_` to public functions
- `MicroBuffer` to `mcBuffer`
- some function names changed

DO NOT MERGE until:
- [x] Support by MicroRTPSGen: https://github.com/eProsima/micro-RTPS-gen/pull/11
- [x] MicroRTPS Client updated: https://github.com/eProsima/micro-RTPS-client/pull/20
- [x] MicroRTPS documentation updated: https://github.com/eProsima/micro-RTPS-docs/pull/5
