### PR TITLE
Refs #3623. Modified mb to ub variable names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ As *MicroCDR* uses a static buffer, that means the user has to provide a defined
 ## API functions
 
 ```c
-void ucdr_init_buffer        (ucdrBuffer* mb, uint8_t* data, const uint32_t size);
-void ucdr_init_buffer_offset (ucdrBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset);
+void ucdr_init_buffer        (ucdrBuffer* ub, uint8_t* data, const uint32_t size);
+void ucdr_init_buffer_offset (ucdrBuffer* ub, uint8_t* data, const uint32_t size, uint32_t offset);
 ```
 Initialize a `ucdrBuffer` structure, the main struct of *MicroCDR*.
-- `mb`: the `ucdrBuffer` struct
+- `ub`: the `ucdrBuffer` struct
 - `data`: the buffer that the `ucdrBuffer` will use.
 - `size`: the size of the buffer that the `ucdrBuffer` will use.
 - `offset`: where the serialization/deserialization will start.
@@ -61,32 +61,32 @@ Initially, the serialization/deserialization starts at the beginning of the buff
 ---
 
 ```c
-void ucdr_copy_buffer (ucdrBuffer* mb_dest, const ucdrBuffer* mb_source);
+void ucdr_copy_buffer (ucdrBuffer* ub_dest, const ucdrBuffer* ub_source);
 ```
 Copy a `ucdrBuffer` structure data to another `ucdrBuffer` structure.
-- `mb_dest`: the destination `ucdrBuffer` struct.
-- `mb_source`: the origin initialized `ucdrBuffer` struct.
+- `ub_dest`: the destination `ucdrBuffer` struct.
+- `ub_source`: the origin initialized `ucdrBuffer` struct.
 
 ---
 
 ```c
-void ucdr_reset_buffer       (ucdrBuffer* mb);
-void ucdr_reset_buffer_offset(ucdrBuffer* mb, const uint32_t offset);
+void ucdr_reset_buffer       (ucdrBuffer* ub);
+void ucdr_reset_buffer_offset(ucdrBuffer* ub, const uint32_t offset);
 ```
 Reset the `ucdrBuffer` as the same state that it was created.
-- `mb`: the `ucdrBuffer` struct.
+- `ub`: the `ucdrBuffer` struct.
 - `offset`: where the serialization/deserialization will start.
 Initially, the serialization/deserialization starts at the beginning of the buffer.
 
 ---
 
 ```c
-void ucdr_align_to (ucdrBuffer* mb, const uint32_t alignment);
+void ucdr_align_to (ucdrBuffer* ub, const uint32_t alignment);
 ```
 Align the ucdrBuffer to an `alignment` position.
 After call this function, the serialization pointer will be moved only if the current `ucdrBuffer` was not aligment to the passed value.
 
-- `mb`: the `ucdrBuffer` struct
+- `ub`: the `ucdrBuffer` struct
 - `alignment`: the alignment value used.
 
 ---
@@ -96,57 +96,57 @@ uint32_t ucdr_aligment(uint32_t buffer_position, const uint32_t data_size);
 ```
 Returns the aligment necessary to serialize/deserialize a type with `data_size` size.
 
-- `buffer_position`: the current serialization/deserialization position of the `ucdrBuffer`. (Typically  `mb->iterator - mb->init`).
+- `buffer_position`: the current serialization/deserialization position of the `ucdrBuffer`. (Typically  `ub->iterator - ub->init`).
 - `data_size`: the bytes of the data that you are asking for.
 
 ---
 
 ```c
-uint32_t ucdr_buffer_alignment(const ucdrBuffer* mb, const uint32_t data_size);
+uint32_t ucdr_buffer_alignment(const ucdrBuffer* ub, const uint32_t data_size);
 ```
 Returns the aligment necessary to serialize/deserialize a type with `data_size` size into the `ucdrBuffer` given.
 
-- `mb`: the `ucdrBuffer` struct to ask the alignment.
+- `ub`: the `ucdrBuffer` struct to ask the alignment.
 - `data_size`: the bytes of the data that you are asking for.
 ---
 
 ```c
-size_t ucdr_buffer_size(const ucdrBuffer* mb);
+size_t ucdr_buffer_size(const ucdrBuffer* ub);
 ```
 Returns the memory size of the buffer.
-- `mb`: the `ucdrBuffer` struct
+- `ub`: the `ucdrBuffer` struct
 
 ---
 
 ```c
-size_t ucdr_buffer_length(const ucdrBuffer* mb);
+size_t ucdr_buffer_length(const ucdrBuffer* ub);
 ```
 Returns the size of the serialized/deserialized data.
-- `mb`: the `ucdrBuffer` struct
+- `ub`: the `ucdrBuffer` struct
 
 ---
 
 ```c
-size_t ucdr_buffer_remaining(const ucdrBuffer* mb);
+size_t ucdr_buffer_remaining(const ucdrBuffer* ub);
 ```
 Returns the remaining size for the serializing/deserializing.
-- `mb`: the `ucdrBuffer` struct
+- `ub`: the `ucdrBuffer` struct
 
 ---
 
 ```c
-ucdrEndianness ucdr_buffer_endianness(const ucdrBuffer* mb);
+ucdrEndianness ucdr_buffer_endianness(const ucdrBuffer* ub);
 ```
 Returns the serialization/deserialization endianness.
-- `mb`: the `ucdrBuffer` struct
+- `ub`: the `ucdrBuffer` struct
 
 ---
 
 ```c
-bool ucdr_buffer_error(const ucdrBuffer* mb);
+bool ucdr_buffer_error(const ucdrBuffer* ub);
 ```
 Returns the status error of the `ucdrBuffer`.
-- `mb`: the `ucdrBuffer` struct
+- `ub`: the `ucdrBuffer` struct
 
 
 ### Serialization/deserialization functions

--- a/include/ucdr/common.h
+++ b/include/ucdr/common.h
@@ -50,23 +50,23 @@ UCDRDLLAPI extern const ucdrEndianness UCDR_MACHINE_ENDIANNESS;
 // ------------------------------------------------
 //              Main library functions
 // ------------------------------------------------
-UCDRDLLAPI void ucdr_init_buffer               (ucdrBuffer* mb, uint8_t* data, const uint32_t size);
-UCDRDLLAPI void ucdr_init_buffer_offset        (ucdrBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset);
-UCDRDLLAPI void ucdr_init_buffer_offset_endian (ucdrBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, ucdrEndianness endianness);
-UCDRDLLAPI void ucdr_copy_buffer               (ucdrBuffer* mb_dest, const ucdrBuffer* mb_source);
+UCDRDLLAPI void ucdr_init_buffer               (ucdrBuffer* ub, uint8_t* data, const uint32_t size);
+UCDRDLLAPI void ucdr_init_buffer_offset        (ucdrBuffer* ub, uint8_t* data, const uint32_t size, uint32_t offset);
+UCDRDLLAPI void ucdr_init_buffer_offset_endian (ucdrBuffer* ub, uint8_t* data, const uint32_t size, uint32_t offset, ucdrEndianness endianness);
+UCDRDLLAPI void ucdr_copy_buffer               (ucdrBuffer* ub_dest, const ucdrBuffer* ub_source);
 
-UCDRDLLAPI void ucdr_reset_buffer        (ucdrBuffer* mb);
-UCDRDLLAPI void ucdr_reset_buffer_offset (ucdrBuffer* mb, const uint32_t offset);
+UCDRDLLAPI void ucdr_reset_buffer        (ucdrBuffer* ub);
+UCDRDLLAPI void ucdr_reset_buffer_offset (ucdrBuffer* ub, const uint32_t offset);
 
-UCDRDLLAPI void     ucdr_align_to              (ucdrBuffer* mb, const uint32_t alignment);
+UCDRDLLAPI void     ucdr_align_to              (ucdrBuffer* ub, const uint32_t alignment);
 UCDRDLLAPI uint32_t ucdr_alignment             (uint32_t buffer_position, const uint32_t data_size);
-UCDRDLLAPI uint32_t ucdr_buffer_alignment(const ucdrBuffer* mb, const uint32_t data_size);
+UCDRDLLAPI uint32_t ucdr_buffer_alignment(const ucdrBuffer* ub, const uint32_t data_size);
 
-UCDRDLLAPI size_t     ucdr_buffer_size      (const ucdrBuffer* mb);
-UCDRDLLAPI size_t     ucdr_buffer_length    (const ucdrBuffer* mb);
-UCDRDLLAPI size_t     ucdr_buffer_remaining (const ucdrBuffer* mb);
-UCDRDLLAPI ucdrEndianness ucdr_buffer_endianness(const ucdrBuffer* mb);
-UCDRDLLAPI bool       ucdr_buffer_has_error (const ucdrBuffer* mb);
+UCDRDLLAPI size_t     ucdr_buffer_size      (const ucdrBuffer* ub);
+UCDRDLLAPI size_t     ucdr_buffer_length    (const ucdrBuffer* ub);
+UCDRDLLAPI size_t     ucdr_buffer_remaining (const ucdrBuffer* ub);
+UCDRDLLAPI ucdrEndianness ucdr_buffer_endianness(const ucdrBuffer* ub);
+UCDRDLLAPI bool       ucdr_buffer_has_error (const ucdrBuffer* ub);
 
 #ifdef __cplusplus
 }

--- a/include/ucdr/types/array.h
+++ b/include/ucdr/types/array.h
@@ -25,49 +25,49 @@ extern "C" {
 //                   PUBLIC SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
 
-UCDRDLLAPI bool ucdr_serialize_array_char(ucdrBuffer* mb, const char* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_array_bool(ucdrBuffer* mb, const bool* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_array_uint8_t(ucdrBuffer* mb, const uint8_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_array_uint16_t(ucdrBuffer* mb, const uint16_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_array_uint32_t(ucdrBuffer* mb, const uint32_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_array_uint64_t(ucdrBuffer* mb, const uint64_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_array_int8_t(ucdrBuffer* mb, const int8_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_array_int16_t(ucdrBuffer* mb, const int16_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_array_int32_t(ucdrBuffer* mb, const int32_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_array_int64_t(ucdrBuffer* mb, const int64_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_array_float(ucdrBuffer* mb, const float* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_array_double(ucdrBuffer* mb, const double* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_array_char(ucdrBuffer* ub, const char* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_array_bool(ucdrBuffer* ub, const bool* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_array_uint8_t(ucdrBuffer* ub, const uint8_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_array_uint16_t(ucdrBuffer* ub, const uint16_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_array_uint32_t(ucdrBuffer* ub, const uint32_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_array_uint64_t(ucdrBuffer* ub, const uint64_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_array_int8_t(ucdrBuffer* ub, const int8_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_array_int16_t(ucdrBuffer* ub, const int16_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_array_int32_t(ucdrBuffer* ub, const int32_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_array_int64_t(ucdrBuffer* ub, const int64_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_array_float(ucdrBuffer* ub, const float* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_array_double(ucdrBuffer* ub, const double* array, const uint32_t size);
 
-UCDRDLLAPI bool ucdr_deserialize_array_char(ucdrBuffer* mb, char* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_deserialize_array_bool(ucdrBuffer* mb, bool* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_deserialize_array_uint8_t(ucdrBuffer* mb, uint8_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_deserialize_array_uint16_t(ucdrBuffer* mb, uint16_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_deserialize_array_uint32_t(ucdrBuffer* mb, uint32_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_deserialize_array_uint64_t(ucdrBuffer* mb, uint64_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_deserialize_array_int8_t(ucdrBuffer* mb, int8_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_deserialize_array_int16_t(ucdrBuffer* mb, int16_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_deserialize_array_int32_t(ucdrBuffer* mb, int32_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_deserialize_array_int64_t(ucdrBuffer* mb, int64_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_deserialize_array_float(ucdrBuffer* mb, float* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_deserialize_array_double(ucdrBuffer* mb, double* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_deserialize_array_char(ucdrBuffer* ub, char* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_deserialize_array_bool(ucdrBuffer* ub, bool* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_deserialize_array_uint8_t(ucdrBuffer* ub, uint8_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_deserialize_array_uint16_t(ucdrBuffer* ub, uint16_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_deserialize_array_uint32_t(ucdrBuffer* ub, uint32_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_deserialize_array_uint64_t(ucdrBuffer* ub, uint64_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_deserialize_array_int8_t(ucdrBuffer* ub, int8_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_deserialize_array_int16_t(ucdrBuffer* ub, int16_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_deserialize_array_int32_t(ucdrBuffer* ub, int32_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_deserialize_array_int64_t(ucdrBuffer* ub, int64_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_deserialize_array_float(ucdrBuffer* ub, float* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_deserialize_array_double(ucdrBuffer* ub, double* array, const uint32_t size);
 
-UCDRDLLAPI bool ucdr_serialize_endian_array_uint16_t(ucdrBuffer* mb, ucdrEndianness endianness, const uint16_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_endian_array_uint32_t(ucdrBuffer* mb, ucdrEndianness endianness, const uint32_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_endian_array_uint64_t(ucdrBuffer* mb, ucdrEndianness endianness, const uint64_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_endian_array_int16_t(ucdrBuffer* mb, ucdrEndianness endianness, const int16_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_endian_array_int32_t(ucdrBuffer* mb, ucdrEndianness endianness, const int32_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_endian_array_int64_t(ucdrBuffer* mb, ucdrEndianness endianness, const int64_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_endian_array_float(ucdrBuffer* mb, ucdrEndianness endianness, const float* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_endian_array_double(ucdrBuffer* mb, ucdrEndianness endianness, const double* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_endian_array_uint16_t(ucdrBuffer* ub, ucdrEndianness endianness, const uint16_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_endian_array_uint32_t(ucdrBuffer* ub, ucdrEndianness endianness, const uint32_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_endian_array_uint64_t(ucdrBuffer* ub, ucdrEndianness endianness, const uint64_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_endian_array_int16_t(ucdrBuffer* ub, ucdrEndianness endianness, const int16_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_endian_array_int32_t(ucdrBuffer* ub, ucdrEndianness endianness, const int32_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_endian_array_int64_t(ucdrBuffer* ub, ucdrEndianness endianness, const int64_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_endian_array_float(ucdrBuffer* ub, ucdrEndianness endianness, const float* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_endian_array_double(ucdrBuffer* ub, ucdrEndianness endianness, const double* array, const uint32_t size);
 
-UCDRDLLAPI bool ucdr_deserialize_endian_array_uint16_t(ucdrBuffer* mb, ucdrEndianness endianness, uint16_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_deserialize_endian_array_uint32_t(ucdrBuffer* mb, ucdrEndianness endianness, uint32_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_deserialize_endian_array_uint64_t(ucdrBuffer* mb, ucdrEndianness endianness, uint64_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_deserialize_endian_array_int16_t(ucdrBuffer* mb, ucdrEndianness endianness, int16_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_deserialize_endian_array_int32_t(ucdrBuffer* mb, ucdrEndianness endianness, int32_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_deserialize_endian_array_int64_t(ucdrBuffer* mb, ucdrEndianness endianness, int64_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_deserialize_endian_array_float(ucdrBuffer* mb, ucdrEndianness endianness, float* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_deserialize_endian_array_double(ucdrBuffer* mb, ucdrEndianness endianness, double* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_deserialize_endian_array_uint16_t(ucdrBuffer* ub, ucdrEndianness endianness, uint16_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_deserialize_endian_array_uint32_t(ucdrBuffer* ub, ucdrEndianness endianness, uint32_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_deserialize_endian_array_uint64_t(ucdrBuffer* ub, ucdrEndianness endianness, uint64_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_deserialize_endian_array_int16_t(ucdrBuffer* ub, ucdrEndianness endianness, int16_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_deserialize_endian_array_int32_t(ucdrBuffer* ub, ucdrEndianness endianness, int32_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_deserialize_endian_array_int64_t(ucdrBuffer* ub, ucdrEndianness endianness, int64_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_deserialize_endian_array_float(ucdrBuffer* ub, ucdrEndianness endianness, float* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_deserialize_endian_array_double(ucdrBuffer* ub, ucdrEndianness endianness, double* array, const uint32_t size);
 
 #ifdef __cplusplus
 }

--- a/include/ucdr/types/basic.h
+++ b/include/ucdr/types/basic.h
@@ -25,49 +25,49 @@ extern "C" {
 //                   PUBLIC SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
 
-UCDRDLLAPI bool ucdr_serialize_char(ucdrBuffer* mb, const char value);
-UCDRDLLAPI bool ucdr_serialize_bool(ucdrBuffer* mb, const bool value);
-UCDRDLLAPI bool ucdr_serialize_uint8_t(ucdrBuffer* mb, const uint8_t value);
-UCDRDLLAPI bool ucdr_serialize_uint16_t(ucdrBuffer* mb, const uint16_t value);
-UCDRDLLAPI bool ucdr_serialize_uint32_t(ucdrBuffer* mb, const uint32_t value);
-UCDRDLLAPI bool ucdr_serialize_uint64_t(ucdrBuffer* mb, const uint64_t value);
-UCDRDLLAPI bool ucdr_serialize_int8_t(ucdrBuffer* mb, const int8_t value);
-UCDRDLLAPI bool ucdr_serialize_int16_t(ucdrBuffer* mb, const int16_t value);
-UCDRDLLAPI bool ucdr_serialize_int32_t(ucdrBuffer* mb, const int32_t value);
-UCDRDLLAPI bool ucdr_serialize_int64_t(ucdrBuffer* mb, const int64_t value);
-UCDRDLLAPI bool ucdr_serialize_float(ucdrBuffer* mb, const float value);
-UCDRDLLAPI bool ucdr_serialize_double(ucdrBuffer* mb, const double value);
+UCDRDLLAPI bool ucdr_serialize_char(ucdrBuffer* ub, const char value);
+UCDRDLLAPI bool ucdr_serialize_bool(ucdrBuffer* ub, const bool value);
+UCDRDLLAPI bool ucdr_serialize_uint8_t(ucdrBuffer* ub, const uint8_t value);
+UCDRDLLAPI bool ucdr_serialize_uint16_t(ucdrBuffer* ub, const uint16_t value);
+UCDRDLLAPI bool ucdr_serialize_uint32_t(ucdrBuffer* ub, const uint32_t value);
+UCDRDLLAPI bool ucdr_serialize_uint64_t(ucdrBuffer* ub, const uint64_t value);
+UCDRDLLAPI bool ucdr_serialize_int8_t(ucdrBuffer* ub, const int8_t value);
+UCDRDLLAPI bool ucdr_serialize_int16_t(ucdrBuffer* ub, const int16_t value);
+UCDRDLLAPI bool ucdr_serialize_int32_t(ucdrBuffer* ub, const int32_t value);
+UCDRDLLAPI bool ucdr_serialize_int64_t(ucdrBuffer* ub, const int64_t value);
+UCDRDLLAPI bool ucdr_serialize_float(ucdrBuffer* ub, const float value);
+UCDRDLLAPI bool ucdr_serialize_double(ucdrBuffer* ub, const double value);
 
-UCDRDLLAPI bool ucdr_deserialize_char(ucdrBuffer* mb, char* value);
-UCDRDLLAPI bool ucdr_deserialize_bool(ucdrBuffer* mb, bool* value);
-UCDRDLLAPI bool ucdr_deserialize_uint8_t(ucdrBuffer* mb, uint8_t* value);
-UCDRDLLAPI bool ucdr_deserialize_uint16_t(ucdrBuffer* mb, uint16_t* value);
-UCDRDLLAPI bool ucdr_deserialize_uint32_t(ucdrBuffer* mb, uint32_t* value);
-UCDRDLLAPI bool ucdr_deserialize_uint64_t(ucdrBuffer* mb, uint64_t* value);
-UCDRDLLAPI bool ucdr_deserialize_int8_t(ucdrBuffer* mb, int8_t* value);
-UCDRDLLAPI bool ucdr_deserialize_int16_t(ucdrBuffer* mb, int16_t* value);
-UCDRDLLAPI bool ucdr_deserialize_int32_t(ucdrBuffer* mb, int32_t* value);
-UCDRDLLAPI bool ucdr_deserialize_int64_t(ucdrBuffer* mb, int64_t* value);
-UCDRDLLAPI bool ucdr_deserialize_float(ucdrBuffer* mb, float* value);
-UCDRDLLAPI bool ucdr_deserialize_double(ucdrBuffer* mb, double* value);
+UCDRDLLAPI bool ucdr_deserialize_char(ucdrBuffer* ub, char* value);
+UCDRDLLAPI bool ucdr_deserialize_bool(ucdrBuffer* ub, bool* value);
+UCDRDLLAPI bool ucdr_deserialize_uint8_t(ucdrBuffer* ub, uint8_t* value);
+UCDRDLLAPI bool ucdr_deserialize_uint16_t(ucdrBuffer* ub, uint16_t* value);
+UCDRDLLAPI bool ucdr_deserialize_uint32_t(ucdrBuffer* ub, uint32_t* value);
+UCDRDLLAPI bool ucdr_deserialize_uint64_t(ucdrBuffer* ub, uint64_t* value);
+UCDRDLLAPI bool ucdr_deserialize_int8_t(ucdrBuffer* ub, int8_t* value);
+UCDRDLLAPI bool ucdr_deserialize_int16_t(ucdrBuffer* ub, int16_t* value);
+UCDRDLLAPI bool ucdr_deserialize_int32_t(ucdrBuffer* ub, int32_t* value);
+UCDRDLLAPI bool ucdr_deserialize_int64_t(ucdrBuffer* ub, int64_t* value);
+UCDRDLLAPI bool ucdr_deserialize_float(ucdrBuffer* ub, float* value);
+UCDRDLLAPI bool ucdr_deserialize_double(ucdrBuffer* ub, double* value);
 
-UCDRDLLAPI bool ucdr_serialize_endian_uint16_t(ucdrBuffer* mb, ucdrEndianness endianness, const uint16_t value);
-UCDRDLLAPI bool ucdr_serialize_endian_uint32_t(ucdrBuffer* mb, ucdrEndianness endianness, const uint32_t value);
-UCDRDLLAPI bool ucdr_serialize_endian_uint64_t(ucdrBuffer* mb, ucdrEndianness endianness, const uint64_t value);
-UCDRDLLAPI bool ucdr_serialize_endian_int16_t(ucdrBuffer* mb, ucdrEndianness endianness, const int16_t value);
-UCDRDLLAPI bool ucdr_serialize_endian_int32_t(ucdrBuffer* mb, ucdrEndianness endianness, const int32_t value);
-UCDRDLLAPI bool ucdr_serialize_endian_int64_t(ucdrBuffer* mb, ucdrEndianness endianness, const int64_t value);
-UCDRDLLAPI bool ucdr_serialize_endian_float(ucdrBuffer* mb, ucdrEndianness endianness, const float value);
-UCDRDLLAPI bool ucdr_serialize_endian_double(ucdrBuffer* mb, ucdrEndianness endianness, const double value);
+UCDRDLLAPI bool ucdr_serialize_endian_uint16_t(ucdrBuffer* ub, ucdrEndianness endianness, const uint16_t value);
+UCDRDLLAPI bool ucdr_serialize_endian_uint32_t(ucdrBuffer* ub, ucdrEndianness endianness, const uint32_t value);
+UCDRDLLAPI bool ucdr_serialize_endian_uint64_t(ucdrBuffer* ub, ucdrEndianness endianness, const uint64_t value);
+UCDRDLLAPI bool ucdr_serialize_endian_int16_t(ucdrBuffer* ub, ucdrEndianness endianness, const int16_t value);
+UCDRDLLAPI bool ucdr_serialize_endian_int32_t(ucdrBuffer* ub, ucdrEndianness endianness, const int32_t value);
+UCDRDLLAPI bool ucdr_serialize_endian_int64_t(ucdrBuffer* ub, ucdrEndianness endianness, const int64_t value);
+UCDRDLLAPI bool ucdr_serialize_endian_float(ucdrBuffer* ub, ucdrEndianness endianness, const float value);
+UCDRDLLAPI bool ucdr_serialize_endian_double(ucdrBuffer* ub, ucdrEndianness endianness, const double value);
 
-UCDRDLLAPI bool ucdr_deserialize_endian_uint16_t(ucdrBuffer* mb, ucdrEndianness endianness, uint16_t* value);
-UCDRDLLAPI bool ucdr_deserialize_endian_uint32_t(ucdrBuffer* mb, ucdrEndianness endianness, uint32_t *value);
-UCDRDLLAPI bool ucdr_deserialize_endian_uint64_t(ucdrBuffer* mb, ucdrEndianness endianness, uint64_t* value);
-UCDRDLLAPI bool ucdr_deserialize_endian_int16_t(ucdrBuffer* mb, ucdrEndianness endianness, int16_t* value);
-UCDRDLLAPI bool ucdr_deserialize_endian_int32_t(ucdrBuffer* mb, ucdrEndianness endianness, int32_t* value);
-UCDRDLLAPI bool ucdr_deserialize_endian_int64_t(ucdrBuffer* mb, ucdrEndianness endianness, int64_t* value);
-UCDRDLLAPI bool ucdr_deserialize_endian_float(ucdrBuffer* mb, ucdrEndianness endianness, float* value);
-UCDRDLLAPI bool ucdr_deserialize_endian_double(ucdrBuffer* mb, ucdrEndianness endianness, double* value);
+UCDRDLLAPI bool ucdr_deserialize_endian_uint16_t(ucdrBuffer* ub, ucdrEndianness endianness, uint16_t* value);
+UCDRDLLAPI bool ucdr_deserialize_endian_uint32_t(ucdrBuffer* ub, ucdrEndianness endianness, uint32_t *value);
+UCDRDLLAPI bool ucdr_deserialize_endian_uint64_t(ucdrBuffer* ub, ucdrEndianness endianness, uint64_t* value);
+UCDRDLLAPI bool ucdr_deserialize_endian_int16_t(ucdrBuffer* ub, ucdrEndianness endianness, int16_t* value);
+UCDRDLLAPI bool ucdr_deserialize_endian_int32_t(ucdrBuffer* ub, ucdrEndianness endianness, int32_t* value);
+UCDRDLLAPI bool ucdr_deserialize_endian_int64_t(ucdrBuffer* ub, ucdrEndianness endianness, int64_t* value);
+UCDRDLLAPI bool ucdr_deserialize_endian_float(ucdrBuffer* ub, ucdrEndianness endianness, float* value);
+UCDRDLLAPI bool ucdr_deserialize_endian_double(ucdrBuffer* ub, ucdrEndianness endianness, double* value);
 
 #ifdef __cplusplus
 }

--- a/include/ucdr/types/sequence.h
+++ b/include/ucdr/types/sequence.h
@@ -25,57 +25,57 @@ extern "C" {
 //                   PUBLIC SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
 
-UCDRDLLAPI bool ucdr_serialize_sequence_char(ucdrBuffer* mb, const char* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_sequence_bool(ucdrBuffer* mb, const bool* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_sequence_uint8_t(ucdrBuffer* mb, const uint8_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_sequence_uint16_t(ucdrBuffer* mb, const uint16_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_sequence_uint32_t(ucdrBuffer* mb, const uint32_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_sequence_uint64_t(ucdrBuffer* mb, const uint64_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_sequence_int8_t(ucdrBuffer* mb, const int8_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_sequence_int16_t(ucdrBuffer* mb, const int16_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_sequence_int32_t(ucdrBuffer* mb, const int32_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_sequence_int64_t(ucdrBuffer* mb, const int64_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_sequence_float(ucdrBuffer* mb, const float* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_sequence_double(ucdrBuffer* mb, const double* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_sequence_char(ucdrBuffer* ub, const char* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_sequence_bool(ucdrBuffer* ub, const bool* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_sequence_uint8_t(ucdrBuffer* ub, const uint8_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_sequence_uint16_t(ucdrBuffer* ub, const uint16_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_sequence_uint32_t(ucdrBuffer* ub, const uint32_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_sequence_uint64_t(ucdrBuffer* ub, const uint64_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_sequence_int8_t(ucdrBuffer* ub, const int8_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_sequence_int16_t(ucdrBuffer* ub, const int16_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_sequence_int32_t(ucdrBuffer* ub, const int32_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_sequence_int64_t(ucdrBuffer* ub, const int64_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_sequence_float(ucdrBuffer* ub, const float* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_sequence_double(ucdrBuffer* ub, const double* array, const uint32_t size);
 
-UCDRDLLAPI bool ucdr_deserialize_sequence_char(ucdrBuffer* mb, char* array, const uint32_t array_capacity, uint32_t* size);
-UCDRDLLAPI bool ucdr_deserialize_sequence_bool(ucdrBuffer* mb, bool* array, const uint32_t array_capacity, uint32_t* size);
-UCDRDLLAPI bool ucdr_deserialize_sequence_uint8_t(ucdrBuffer* mb, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
-UCDRDLLAPI bool ucdr_deserialize_sequence_uint16_t(ucdrBuffer* mb, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
-UCDRDLLAPI bool ucdr_deserialize_sequence_uint32_t(ucdrBuffer* mb, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
-UCDRDLLAPI bool ucdr_deserialize_sequence_uint64_t(ucdrBuffer* mb, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
-UCDRDLLAPI bool ucdr_deserialize_sequence_int8_t(ucdrBuffer* mb, int8_t* array, const uint32_t array_capacity, uint32_t* size);
-UCDRDLLAPI bool ucdr_deserialize_sequence_int16_t(ucdrBuffer* mb, int16_t* array, const uint32_t array_capacity, uint32_t* size);
-UCDRDLLAPI bool ucdr_deserialize_sequence_int32_t(ucdrBuffer* mb, int32_t* array, const uint32_t array_capacity, uint32_t* size);
-UCDRDLLAPI bool ucdr_deserialize_sequence_int64_t(ucdrBuffer* mb, int64_t* array, const uint32_t array_capacity, uint32_t* size);
-UCDRDLLAPI bool ucdr_deserialize_sequence_float(ucdrBuffer* mb, float* array, const uint32_t array_capacity, uint32_t* size);
-UCDRDLLAPI bool ucdr_deserialize_sequence_double(ucdrBuffer* mb, double* array, const uint32_t array_capacity, uint32_t* size);
+UCDRDLLAPI bool ucdr_deserialize_sequence_char(ucdrBuffer* ub, char* array, const uint32_t array_capacity, uint32_t* size);
+UCDRDLLAPI bool ucdr_deserialize_sequence_bool(ucdrBuffer* ub, bool* array, const uint32_t array_capacity, uint32_t* size);
+UCDRDLLAPI bool ucdr_deserialize_sequence_uint8_t(ucdrBuffer* ub, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
+UCDRDLLAPI bool ucdr_deserialize_sequence_uint16_t(ucdrBuffer* ub, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
+UCDRDLLAPI bool ucdr_deserialize_sequence_uint32_t(ucdrBuffer* ub, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
+UCDRDLLAPI bool ucdr_deserialize_sequence_uint64_t(ucdrBuffer* ub, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
+UCDRDLLAPI bool ucdr_deserialize_sequence_int8_t(ucdrBuffer* ub, int8_t* array, const uint32_t array_capacity, uint32_t* size);
+UCDRDLLAPI bool ucdr_deserialize_sequence_int16_t(ucdrBuffer* ub, int16_t* array, const uint32_t array_capacity, uint32_t* size);
+UCDRDLLAPI bool ucdr_deserialize_sequence_int32_t(ucdrBuffer* ub, int32_t* array, const uint32_t array_capacity, uint32_t* size);
+UCDRDLLAPI bool ucdr_deserialize_sequence_int64_t(ucdrBuffer* ub, int64_t* array, const uint32_t array_capacity, uint32_t* size);
+UCDRDLLAPI bool ucdr_deserialize_sequence_float(ucdrBuffer* ub, float* array, const uint32_t array_capacity, uint32_t* size);
+UCDRDLLAPI bool ucdr_deserialize_sequence_double(ucdrBuffer* ub, double* array, const uint32_t array_capacity, uint32_t* size);
 
-UCDRDLLAPI bool ucdr_serialize_endian_sequence_char(ucdrBuffer* mb, ucdrEndianness endianness, const char* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_endian_sequence_bool(ucdrBuffer* mb, ucdrEndianness endianness, const bool* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_endian_sequence_uint8_t(ucdrBuffer* mb, ucdrEndianness endianness, const uint8_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_endian_sequence_uint16_t(ucdrBuffer* mb, ucdrEndianness endianness, const uint16_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_endian_sequence_uint32_t(ucdrBuffer* mb, ucdrEndianness endianness, const uint32_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_endian_sequence_uint64_t(ucdrBuffer* mb, ucdrEndianness endianness, const uint64_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_endian_sequence_int8_t(ucdrBuffer* mb, ucdrEndianness endianness, const int8_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_endian_sequence_int16_t(ucdrBuffer* mb, ucdrEndianness endianness, const int16_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_endian_sequence_int32_t(ucdrBuffer* mb, ucdrEndianness endianness, const int32_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_endian_sequence_int64_t(ucdrBuffer* mb, ucdrEndianness endianness, const int64_t* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_endian_sequence_float(ucdrBuffer* mb, ucdrEndianness endianness, const float* array, const uint32_t size);
-UCDRDLLAPI bool ucdr_serialize_endian_sequence_double(ucdrBuffer* mb, ucdrEndianness endianness, const double* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_endian_sequence_char(ucdrBuffer* ub, ucdrEndianness endianness, const char* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_endian_sequence_bool(ucdrBuffer* ub, ucdrEndianness endianness, const bool* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_endian_sequence_uint8_t(ucdrBuffer* ub, ucdrEndianness endianness, const uint8_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_endian_sequence_uint16_t(ucdrBuffer* ub, ucdrEndianness endianness, const uint16_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_endian_sequence_uint32_t(ucdrBuffer* ub, ucdrEndianness endianness, const uint32_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_endian_sequence_uint64_t(ucdrBuffer* ub, ucdrEndianness endianness, const uint64_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_endian_sequence_int8_t(ucdrBuffer* ub, ucdrEndianness endianness, const int8_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_endian_sequence_int16_t(ucdrBuffer* ub, ucdrEndianness endianness, const int16_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_endian_sequence_int32_t(ucdrBuffer* ub, ucdrEndianness endianness, const int32_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_endian_sequence_int64_t(ucdrBuffer* ub, ucdrEndianness endianness, const int64_t* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_endian_sequence_float(ucdrBuffer* ub, ucdrEndianness endianness, const float* array, const uint32_t size);
+UCDRDLLAPI bool ucdr_serialize_endian_sequence_double(ucdrBuffer* ub, ucdrEndianness endianness, const double* array, const uint32_t size);
 
-UCDRDLLAPI bool ucdr_deserialize_endian_sequence_char(ucdrBuffer* mb, ucdrEndianness endianness, char* array, const uint32_t array_capacity, uint32_t* size);
-UCDRDLLAPI bool ucdr_deserialize_endian_sequence_bool(ucdrBuffer* mb, ucdrEndianness endianness, bool* array, const uint32_t array_capacity, uint32_t* size);
-UCDRDLLAPI bool ucdr_deserialize_endian_sequence_uint8_t(ucdrBuffer* mb, ucdrEndianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
-UCDRDLLAPI bool ucdr_deserialize_endian_sequence_uint16_t(ucdrBuffer* mb, ucdrEndianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
-UCDRDLLAPI bool ucdr_deserialize_endian_sequence_uint32_t(ucdrBuffer* mb, ucdrEndianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
-UCDRDLLAPI bool ucdr_deserialize_endian_sequence_uint64_t(ucdrBuffer* mb, ucdrEndianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
-UCDRDLLAPI bool ucdr_deserialize_endian_sequence_int8_t(ucdrBuffer* mb, ucdrEndianness endianness, int8_t* array, const uint32_t array_capacity, uint32_t* size);
-UCDRDLLAPI bool ucdr_deserialize_endian_sequence_int16_t(ucdrBuffer* mb, ucdrEndianness endianness, int16_t* array, const uint32_t array_capacity, uint32_t* size);
-UCDRDLLAPI bool ucdr_deserialize_endian_sequence_int32_t(ucdrBuffer* mb, ucdrEndianness endianness, int32_t* array, const uint32_t array_capacity, uint32_t* size);
-UCDRDLLAPI bool ucdr_deserialize_endian_sequence_int64_t(ucdrBuffer* mb, ucdrEndianness endianness, int64_t* array, const uint32_t array_capacity, uint32_t* size);
-UCDRDLLAPI bool ucdr_deserialize_endian_sequence_float(ucdrBuffer* mb, ucdrEndianness endianness, float* array, const uint32_t array_capacity, uint32_t* size);
-UCDRDLLAPI bool ucdr_deserialize_endian_sequence_double(ucdrBuffer* mb, ucdrEndianness endianness, double* array, const uint32_t array_capacity, uint32_t* size);
+UCDRDLLAPI bool ucdr_deserialize_endian_sequence_char(ucdrBuffer* ub, ucdrEndianness endianness, char* array, const uint32_t array_capacity, uint32_t* size);
+UCDRDLLAPI bool ucdr_deserialize_endian_sequence_bool(ucdrBuffer* ub, ucdrEndianness endianness, bool* array, const uint32_t array_capacity, uint32_t* size);
+UCDRDLLAPI bool ucdr_deserialize_endian_sequence_uint8_t(ucdrBuffer* ub, ucdrEndianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size);
+UCDRDLLAPI bool ucdr_deserialize_endian_sequence_uint16_t(ucdrBuffer* ub, ucdrEndianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size);
+UCDRDLLAPI bool ucdr_deserialize_endian_sequence_uint32_t(ucdrBuffer* ub, ucdrEndianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size);
+UCDRDLLAPI bool ucdr_deserialize_endian_sequence_uint64_t(ucdrBuffer* ub, ucdrEndianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size);
+UCDRDLLAPI bool ucdr_deserialize_endian_sequence_int8_t(ucdrBuffer* ub, ucdrEndianness endianness, int8_t* array, const uint32_t array_capacity, uint32_t* size);
+UCDRDLLAPI bool ucdr_deserialize_endian_sequence_int16_t(ucdrBuffer* ub, ucdrEndianness endianness, int16_t* array, const uint32_t array_capacity, uint32_t* size);
+UCDRDLLAPI bool ucdr_deserialize_endian_sequence_int32_t(ucdrBuffer* ub, ucdrEndianness endianness, int32_t* array, const uint32_t array_capacity, uint32_t* size);
+UCDRDLLAPI bool ucdr_deserialize_endian_sequence_int64_t(ucdrBuffer* ub, ucdrEndianness endianness, int64_t* array, const uint32_t array_capacity, uint32_t* size);
+UCDRDLLAPI bool ucdr_deserialize_endian_sequence_float(ucdrBuffer* ub, ucdrEndianness endianness, float* array, const uint32_t array_capacity, uint32_t* size);
+UCDRDLLAPI bool ucdr_deserialize_endian_sequence_double(ucdrBuffer* ub, ucdrEndianness endianness, double* array, const uint32_t array_capacity, uint32_t* size);
 
 #ifdef __cplusplus
 }

--- a/include/ucdr/types/string.h
+++ b/include/ucdr/types/string.h
@@ -28,11 +28,11 @@ extern "C" {
 //                   PUBLIC SERIALIZATION FUNCTIONS
 // -------------------------------------------------------------------
 
-UCDRDLLAPI bool ucdr_serialize_string(ucdrBuffer* mb, const char* string);
-UCDRDLLAPI bool ucdr_deserialize_string(ucdrBuffer* mb, char* string, const uint32_t string_capacity);
+UCDRDLLAPI bool ucdr_serialize_string(ucdrBuffer* ub, const char* string);
+UCDRDLLAPI bool ucdr_deserialize_string(ucdrBuffer* ub, char* string, const uint32_t string_capacity);
 
-UCDRDLLAPI bool ucdr_serialize_endian_string(ucdrBuffer* mb, ucdrEndianness endianness, const char* string);
-UCDRDLLAPI bool ucdr_deserialize_endian_string(ucdrBuffer* mb, ucdrEndianness endianness, char* string, const uint32_t string_capacity);
+UCDRDLLAPI bool ucdr_serialize_endian_string(ucdrBuffer* ub, ucdrEndianness endianness, const char* string);
+UCDRDLLAPI bool ucdr_deserialize_endian_string(ucdrBuffer* ub, ucdrEndianness endianness, char* string, const uint32_t string_capacity);
 
 #ifdef __cplusplus
 }

--- a/src/c/common.c
+++ b/src/c/common.c
@@ -25,71 +25,71 @@
 // -------------------------------------------------------------------
 //                   INTERNAL UTIL IMPLEMENTATIONS
 // -------------------------------------------------------------------
-bool ucdr_check_buffer(ucdrBuffer* mb, const uint32_t bytes)
+bool ucdr_check_buffer(ucdrBuffer* ub, const uint32_t bytes)
 {
-    if(!mb->error)
+    if(!ub->error)
     {
-        bool fit = mb->iterator + bytes <= mb->final;
+        bool fit = ub->iterator + bytes <= ub->final;
         if(!fit)
         {
-            mb->error = true;
+            ub->error = true;
         }
     }
 
-    return !mb->error;
+    return !ub->error;
 }
 
 // -------------------------------------------------------------------
 //                       PUBLIC IMPLEMENTATION
 // -------------------------------------------------------------------
-void ucdr_init_buffer(ucdrBuffer* mb, uint8_t* data, const uint32_t size)
+void ucdr_init_buffer(ucdrBuffer* ub, uint8_t* data, const uint32_t size)
 {
-    ucdr_init_buffer_offset(mb, data, size, 0U);
+    ucdr_init_buffer_offset(ub, data, size, 0U);
 }
 
-void ucdr_init_buffer_offset(ucdrBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset)
+void ucdr_init_buffer_offset(ucdrBuffer* ub, uint8_t* data, const uint32_t size, uint32_t offset)
 {
-    ucdr_init_buffer_offset_endian(mb, data, size, offset, UCDR_MACHINE_ENDIANNESS);
+    ucdr_init_buffer_offset_endian(ub, data, size, offset, UCDR_MACHINE_ENDIANNESS);
 }
 
-void ucdr_init_buffer_offset_endian(ucdrBuffer* mb, uint8_t* data, const uint32_t size, uint32_t offset, ucdrEndianness endianness)
+void ucdr_init_buffer_offset_endian(ucdrBuffer* ub, uint8_t* data, const uint32_t size, uint32_t offset, ucdrEndianness endianness)
 {
-    mb->init = data;
-    mb->final = mb->init + size;
-    mb->iterator = mb->init + offset;
-    mb->last_data_size = 0U;
-    mb->endianness = endianness;
-    mb->error = false;
+    ub->init = data;
+    ub->final = ub->init + size;
+    ub->iterator = ub->init + offset;
+    ub->last_data_size = 0U;
+    ub->endianness = endianness;
+    ub->error = false;
 }
 
 
-void ucdr_copy_buffer(ucdrBuffer* mb_dest, const ucdrBuffer* mb_source)
+void ucdr_copy_buffer(ucdrBuffer* ub_dest, const ucdrBuffer* ub_source)
 {
-    memcpy(mb_dest, mb_source, sizeof(ucdrBuffer));
+    memcpy(ub_dest, ub_source, sizeof(ucdrBuffer));
 }
 
-void ucdr_reset_buffer(ucdrBuffer* mb)
+void ucdr_reset_buffer(ucdrBuffer* ub)
 {
-    ucdr_reset_buffer_offset(mb, 0U);
+    ucdr_reset_buffer_offset(ub, 0U);
 }
 
-void ucdr_reset_buffer_offset(ucdrBuffer* mb, const uint32_t offset)
+void ucdr_reset_buffer_offset(ucdrBuffer* ub, const uint32_t offset)
 {
-    mb->iterator = mb->init + offset;
-    mb->last_data_size = 0U;
-    mb->error = false;
+    ub->iterator = ub->init + offset;
+    ub->last_data_size = 0U;
+    ub->error = false;
 }
 
-void ucdr_align_to(ucdrBuffer* mb, const uint32_t size)
+void ucdr_align_to(ucdrBuffer* ub, const uint32_t size)
 {
-    uint32_t offset = ucdr_buffer_alignment(mb, size);
-    mb->iterator += offset;
-    if(mb->iterator > mb->final)
+    uint32_t offset = ucdr_buffer_alignment(ub, size);
+    ub->iterator += offset;
+    if(ub->iterator > ub->final)
     {
-        mb->iterator = mb->final;
+        ub->iterator = ub->final;
     }
 
-    mb->last_data_size = size;
+    ub->last_data_size = size;
 }
 
 uint32_t ucdr_alignment(uint32_t current_alignment, const uint32_t data_size)
@@ -97,37 +97,37 @@ uint32_t ucdr_alignment(uint32_t current_alignment, const uint32_t data_size)
     return ((data_size - (current_alignment % data_size)) & (data_size - 1));
 }
 
-uint32_t ucdr_buffer_alignment(const ucdrBuffer* mb, const uint32_t data_size)
+uint32_t ucdr_buffer_alignment(const ucdrBuffer* ub, const uint32_t data_size)
 {
-    if(data_size > mb->last_data_size)
+    if(data_size > ub->last_data_size)
     {
-        return (data_size - ((uint32_t)(mb->iterator - mb->init) % data_size)) & (data_size - 1);
+        return (data_size - ((uint32_t)(ub->iterator - ub->init) % data_size)) & (data_size - 1);
     }
 
     return 0;
 }
 
-size_t ucdr_buffer_size(const ucdrBuffer* mb)
+size_t ucdr_buffer_size(const ucdrBuffer* ub)
 {
-    return (size_t)(mb->final - mb->init);
+    return (size_t)(ub->final - ub->init);
 }
 
-size_t ucdr_buffer_length(const ucdrBuffer* mb)
+size_t ucdr_buffer_length(const ucdrBuffer* ub)
 {
-    return (size_t)(mb->iterator - mb->init);
+    return (size_t)(ub->iterator - ub->init);
 }
 
-size_t ucdr_buffer_remaining(const ucdrBuffer* mb)
+size_t ucdr_buffer_remaining(const ucdrBuffer* ub)
 {
-    return (size_t)(mb->final - mb->iterator);
+    return (size_t)(ub->final - ub->iterator);
 }
 
-ucdrEndianness ucdr_buffer_endianness(const ucdrBuffer* mb)
+ucdrEndianness ucdr_buffer_endianness(const ucdrBuffer* ub)
 {
-    return mb->endianness;
+    return ub->endianness;
 }
 
-bool ucdr_buffer_has_error(const ucdrBuffer* mb)
+bool ucdr_buffer_has_error(const ucdrBuffer* ub)
 {
-    return mb->error;
+    return ub->error;
 }

--- a/src/c/common_internals.h
+++ b/src/c/common_internals.h
@@ -24,7 +24,7 @@ extern "C" {
 // -------------------------------------------------------------------
 //                     INTERNAL UTIL FUNCTIONS
 // -------------------------------------------------------------------
-bool ucdr_check_buffer(ucdrBuffer* mb, const uint32_t bytes);
+bool ucdr_check_buffer(ucdrBuffer* ub, const uint32_t bytes);
 
 #ifdef __cplusplus
 }

--- a/src/c/types/array.c
+++ b/src/c/types/array.c
@@ -24,395 +24,395 @@
 //                INTERNAL SERIALIZATION IMPLEMENTATION
 // -------------------------------------------------------------------
 
-bool ucdr_serialize_array_byte_1(ucdrBuffer* mb, const uint8_t* array, const uint32_t size)
+bool ucdr_serialize_array_byte_1(ucdrBuffer* ub, const uint8_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint8_t);
-    if(ucdr_check_buffer(mb, size))
+    if(ucdr_check_buffer(ub, size))
     {
-        memcpy(mb->iterator, array, size);
+        memcpy(ub->iterator, array, size);
 
-        mb->iterator += size;
-        mb->last_data_size = data_size;
+        ub->iterator += size;
+        ub->last_data_size = data_size;
     }
-    return !mb->error;
+    return !ub->error;
 }
 
-bool ucdr_serialize_array_byte_2(ucdrBuffer* mb, const ucdrEndianness endianness, const uint16_t* array, const uint32_t size)
+bool ucdr_serialize_array_byte_2(ucdrBuffer* ub, const ucdrEndianness endianness, const uint16_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t array_size = size * data_size;
-    uint32_t alignment = ucdr_buffer_alignment(mb, sizeof(uint16_t));
+    uint32_t alignment = ucdr_buffer_alignment(ub, sizeof(uint16_t));
 
-    if(ucdr_check_buffer(mb, alignment + array_size))
+    if(ucdr_check_buffer(ub, alignment + array_size))
     {
-        mb->iterator += alignment;
+        ub->iterator += alignment;
         if(UCDR_MACHINE_ENDIANNESS == endianness)
         {
-            memcpy(mb->iterator, array, array_size);
+            memcpy(ub->iterator, array, array_size);
 
-            mb->iterator += array_size;
-            mb->last_data_size = data_size;
+            ub->iterator += array_size;
+            ub->last_data_size = data_size;
         }
         else
         {
             for(uint32_t i = 0; i < size; i++)
             {
-                ucdr_serialize_byte_2(mb, endianness, array + i);
+                ucdr_serialize_byte_2(ub, endianness, array + i);
             }
         }
     }
-    return !mb->error;
+    return !ub->error;
 }
 
-bool ucdr_serialize_array_byte_4(ucdrBuffer* mb, const ucdrEndianness endianness, const uint32_t* array, const uint32_t size)
+bool ucdr_serialize_array_byte_4(ucdrBuffer* ub, const ucdrEndianness endianness, const uint32_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t array_size = size * data_size;
-    uint32_t alignment = ucdr_buffer_alignment(mb, sizeof(uint32_t));
+    uint32_t alignment = ucdr_buffer_alignment(ub, sizeof(uint32_t));
 
-    if(ucdr_check_buffer(mb, alignment + array_size))
+    if(ucdr_check_buffer(ub, alignment + array_size))
     {
-        mb->iterator += alignment;
+        ub->iterator += alignment;
 
         if(UCDR_MACHINE_ENDIANNESS == endianness)
         {
-            memcpy(mb->iterator, array, array_size);
-            mb->iterator += array_size;
-            mb->last_data_size = data_size;
+            memcpy(ub->iterator, array, array_size);
+            ub->iterator += array_size;
+            ub->last_data_size = data_size;
         }
         else
         {
             for(uint32_t i = 0; i < size; i++)
             {
-                ucdr_serialize_byte_4(mb, endianness, array + i);
+                ucdr_serialize_byte_4(ub, endianness, array + i);
             }
         }
     }
-    return !mb->error;
+    return !ub->error;
 }
 
-bool ucdr_serialize_array_byte_8(ucdrBuffer* mb, const ucdrEndianness endianness, const uint64_t* array, const uint32_t size)
+bool ucdr_serialize_array_byte_8(ucdrBuffer* ub, const ucdrEndianness endianness, const uint64_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t array_size = size * data_size;
-    uint32_t alignment = ucdr_buffer_alignment(mb, sizeof(uint64_t));
+    uint32_t alignment = ucdr_buffer_alignment(ub, sizeof(uint64_t));
 
-    if(ucdr_check_buffer(mb, alignment + array_size))
+    if(ucdr_check_buffer(ub, alignment + array_size))
     {
-        mb->iterator += alignment;
+        ub->iterator += alignment;
 
         if(UCDR_MACHINE_ENDIANNESS == endianness)
         {
-            memcpy(mb->iterator, array, array_size);
-            mb->iterator += array_size;
-            mb->last_data_size = data_size;
+            memcpy(ub->iterator, array, array_size);
+            ub->iterator += array_size;
+            ub->last_data_size = data_size;
         }
         else
         {
             for(uint32_t i = 0; i < size; i++)
             {
-                ucdr_serialize_byte_8(mb, endianness, array + i);
+                ucdr_serialize_byte_8(ub, endianness, array + i);
             }
         }
     }
-    return !mb->error;
+    return !ub->error;
 }
 
-bool ucdr_deserialize_array_byte_1(ucdrBuffer* mb, uint8_t* array, const uint32_t size)
+bool ucdr_deserialize_array_byte_1(ucdrBuffer* ub, uint8_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint8_t);
-    if(ucdr_check_buffer(mb, size))
+    if(ucdr_check_buffer(ub, size))
     {
-        memcpy(array, mb->iterator, size);
+        memcpy(array, ub->iterator, size);
 
-        mb->iterator += size;
-        mb->last_data_size = data_size;
+        ub->iterator += size;
+        ub->last_data_size = data_size;
     }
-    return !mb->error;
+    return !ub->error;
 }
 
-bool ucdr_deserialize_array_byte_2(ucdrBuffer* mb, const ucdrEndianness endianness, uint16_t* array, const uint32_t size)
+bool ucdr_deserialize_array_byte_2(ucdrBuffer* ub, const ucdrEndianness endianness, uint16_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint16_t);
     uint32_t array_size = size * data_size;
-    uint32_t alignment = ucdr_buffer_alignment(mb, sizeof(uint16_t));
+    uint32_t alignment = ucdr_buffer_alignment(ub, sizeof(uint16_t));
 
-    if(ucdr_check_buffer(mb, alignment + array_size))
+    if(ucdr_check_buffer(ub, alignment + array_size))
     {
-        mb->iterator += alignment;
+        ub->iterator += alignment;
 
         if(UCDR_MACHINE_ENDIANNESS == endianness)
         {
-            memcpy(array, mb->iterator, array_size);
-            mb->iterator += array_size;
-            mb->last_data_size = data_size;
+            memcpy(array, ub->iterator, array_size);
+            ub->iterator += array_size;
+            ub->last_data_size = data_size;
         }
         else
         {
             for(uint32_t i = 0; i < size; i++)
             {
-                ucdr_deserialize_byte_2(mb, endianness, array + i);
+                ucdr_deserialize_byte_2(ub, endianness, array + i);
             }
         }
     }
-    return !mb->error;
+    return !ub->error;
 }
 
-bool ucdr_deserialize_array_byte_4(ucdrBuffer* mb, const ucdrEndianness endianness, uint32_t* array, const uint32_t size)
+bool ucdr_deserialize_array_byte_4(ucdrBuffer* ub, const ucdrEndianness endianness, uint32_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint32_t);
     uint32_t array_size = size * data_size;
-    uint32_t alignment = ucdr_buffer_alignment(mb, sizeof(uint32_t));
+    uint32_t alignment = ucdr_buffer_alignment(ub, sizeof(uint32_t));
 
-    if(ucdr_check_buffer(mb, alignment + array_size))
+    if(ucdr_check_buffer(ub, alignment + array_size))
     {
-        mb->iterator += alignment;
+        ub->iterator += alignment;
 
         if(UCDR_MACHINE_ENDIANNESS == endianness)
         {
-            memcpy(array, mb->iterator, array_size);
-            mb->iterator += array_size;
-            mb->last_data_size = data_size;
+            memcpy(array, ub->iterator, array_size);
+            ub->iterator += array_size;
+            ub->last_data_size = data_size;
         }
         else
         {
             for(uint32_t i = 0; i < size; i++)
             {
-                ucdr_deserialize_byte_4(mb, endianness, array + i);
+                ucdr_deserialize_byte_4(ub, endianness, array + i);
             }
         }
     }
-    return !mb->error;
+    return !ub->error;
 }
 
-bool ucdr_deserialize_array_byte_8(ucdrBuffer* mb, const ucdrEndianness endianness, uint64_t* array, const uint32_t size)
+bool ucdr_deserialize_array_byte_8(ucdrBuffer* ub, const ucdrEndianness endianness, uint64_t* array, const uint32_t size)
 {
     uint32_t data_size = sizeof(uint64_t);
     uint32_t array_size = size * data_size;
-    uint32_t alignment = ucdr_buffer_alignment(mb, sizeof(uint64_t));
+    uint32_t alignment = ucdr_buffer_alignment(ub, sizeof(uint64_t));
 
-    if(ucdr_check_buffer(mb, alignment + array_size))
+    if(ucdr_check_buffer(ub, alignment + array_size))
     {
-        mb->iterator += alignment;
+        ub->iterator += alignment;
 
         if(UCDR_MACHINE_ENDIANNESS == endianness)
         {
-            memcpy(array, mb->iterator, array_size);
-            mb->iterator += array_size;
-            mb->last_data_size = data_size;
+            memcpy(array, ub->iterator, array_size);
+            ub->iterator += array_size;
+            ub->last_data_size = data_size;
         }
         else
         {
             for(uint32_t i = 0; i < size; i++)
             {
-                ucdr_deserialize_byte_8(mb, endianness, array + i);
+                ucdr_deserialize_byte_8(ub, endianness, array + i);
             }
         }
     }
-    return !mb->error;
+    return !ub->error;
 }
 
 // -------------------------------------------------------------------
 //              PUBLIC SERIALIZATION IMPLEMENTATIONS
 // -------------------------------------------------------------------
 
-bool ucdr_serialize_array_char(ucdrBuffer* mb, const char* array, const uint32_t size)
+bool ucdr_serialize_array_char(ucdrBuffer* ub, const char* array, const uint32_t size)
 {
-    return ucdr_serialize_array_byte_1(mb, (uint8_t*)array, size);
+    return ucdr_serialize_array_byte_1(ub, (uint8_t*)array, size);
 }
 
-bool ucdr_serialize_array_bool(ucdrBuffer* mb, const bool* array, const uint32_t size)
+bool ucdr_serialize_array_bool(ucdrBuffer* ub, const bool* array, const uint32_t size)
 {
-    return ucdr_serialize_array_byte_1(mb, (uint8_t*)array, size);
+    return ucdr_serialize_array_byte_1(ub, (uint8_t*)array, size);
 }
 
-bool ucdr_serialize_array_uint8_t(ucdrBuffer* mb, const uint8_t* array, const uint32_t size)
+bool ucdr_serialize_array_uint8_t(ucdrBuffer* ub, const uint8_t* array, const uint32_t size)
 {
-    return ucdr_serialize_array_byte_1(mb, array, size);
+    return ucdr_serialize_array_byte_1(ub, array, size);
 }
 
-bool ucdr_serialize_array_uint16_t(ucdrBuffer* mb, const uint16_t* array, const uint32_t size)
+bool ucdr_serialize_array_uint16_t(ucdrBuffer* ub, const uint16_t* array, const uint32_t size)
 {
-    return ucdr_serialize_array_byte_2(mb, mb->endianness, array, size);
+    return ucdr_serialize_array_byte_2(ub, ub->endianness, array, size);
 }
 
-bool ucdr_serialize_array_uint32_t(ucdrBuffer* mb, const uint32_t* array, const uint32_t size)
+bool ucdr_serialize_array_uint32_t(ucdrBuffer* ub, const uint32_t* array, const uint32_t size)
 {
-    return ucdr_serialize_array_byte_4(mb, mb->endianness, array, size);
+    return ucdr_serialize_array_byte_4(ub, ub->endianness, array, size);
 }
 
-bool ucdr_serialize_array_uint64_t(ucdrBuffer* mb, const uint64_t* array, const uint32_t size)
+bool ucdr_serialize_array_uint64_t(ucdrBuffer* ub, const uint64_t* array, const uint32_t size)
 {
-    return ucdr_serialize_array_byte_8(mb, mb->endianness, array, size);
+    return ucdr_serialize_array_byte_8(ub, ub->endianness, array, size);
 }
 
-bool ucdr_serialize_array_int8_t(ucdrBuffer* mb, const int8_t* array, const uint32_t size)
+bool ucdr_serialize_array_int8_t(ucdrBuffer* ub, const int8_t* array, const uint32_t size)
 {
-    return ucdr_serialize_array_byte_1(mb, (uint8_t*)array, size);
+    return ucdr_serialize_array_byte_1(ub, (uint8_t*)array, size);
 }
 
-bool ucdr_serialize_array_int16_t(ucdrBuffer* mb, const int16_t* array, const uint32_t size)
+bool ucdr_serialize_array_int16_t(ucdrBuffer* ub, const int16_t* array, const uint32_t size)
 {
-    return ucdr_serialize_array_byte_2(mb, mb->endianness, (uint16_t*)array, size);
+    return ucdr_serialize_array_byte_2(ub, ub->endianness, (uint16_t*)array, size);
 }
 
-bool ucdr_serialize_array_int32_t(ucdrBuffer* mb, const int32_t* array, const uint32_t size)
+bool ucdr_serialize_array_int32_t(ucdrBuffer* ub, const int32_t* array, const uint32_t size)
 {
-    return ucdr_serialize_array_byte_4(mb, mb->endianness, (uint32_t*)array, size);
+    return ucdr_serialize_array_byte_4(ub, ub->endianness, (uint32_t*)array, size);
 }
 
-bool ucdr_serialize_array_int64_t(ucdrBuffer* mb, const int64_t* array, const uint32_t size)
+bool ucdr_serialize_array_int64_t(ucdrBuffer* ub, const int64_t* array, const uint32_t size)
 {
-    return ucdr_serialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
+    return ucdr_serialize_array_byte_8(ub, ub->endianness, (uint64_t*)array, size);
 }
 
-bool ucdr_serialize_array_float(ucdrBuffer* mb, const float* array, const uint32_t size)
+bool ucdr_serialize_array_float(ucdrBuffer* ub, const float* array, const uint32_t size)
 {
-    return ucdr_serialize_array_byte_4(mb, mb->endianness, (uint32_t*)array, size);
+    return ucdr_serialize_array_byte_4(ub, ub->endianness, (uint32_t*)array, size);
 }
 
-bool ucdr_serialize_array_double(ucdrBuffer* mb, const double* array, const uint32_t size)
+bool ucdr_serialize_array_double(ucdrBuffer* ub, const double* array, const uint32_t size)
 {
-    return ucdr_serialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
+    return ucdr_serialize_array_byte_8(ub, ub->endianness, (uint64_t*)array, size);
 }
 
-bool ucdr_deserialize_array_char(ucdrBuffer* mb, char* array, const uint32_t size)
+bool ucdr_deserialize_array_char(ucdrBuffer* ub, char* array, const uint32_t size)
 {
-    return ucdr_deserialize_array_byte_1(mb, (uint8_t*)array, size);
+    return ucdr_deserialize_array_byte_1(ub, (uint8_t*)array, size);
 }
 
-bool ucdr_deserialize_array_bool(ucdrBuffer* mb, bool* array, const uint32_t size)
+bool ucdr_deserialize_array_bool(ucdrBuffer* ub, bool* array, const uint32_t size)
 {
-    return ucdr_deserialize_array_byte_1(mb, (uint8_t*)array, size);
+    return ucdr_deserialize_array_byte_1(ub, (uint8_t*)array, size);
 }
 
-bool ucdr_deserialize_array_uint8_t(ucdrBuffer* mb, uint8_t* array, const uint32_t size)
+bool ucdr_deserialize_array_uint8_t(ucdrBuffer* ub, uint8_t* array, const uint32_t size)
 {
-    return ucdr_deserialize_array_byte_1(mb, array, size);
+    return ucdr_deserialize_array_byte_1(ub, array, size);
 }
 
-bool ucdr_deserialize_array_uint16_t(ucdrBuffer* mb, uint16_t* array, const uint32_t size)
+bool ucdr_deserialize_array_uint16_t(ucdrBuffer* ub, uint16_t* array, const uint32_t size)
 {
-    return ucdr_deserialize_array_byte_2(mb, mb->endianness, array, size);
+    return ucdr_deserialize_array_byte_2(ub, ub->endianness, array, size);
 }
 
-bool ucdr_deserialize_array_uint32_t(ucdrBuffer* mb, uint32_t* array, const uint32_t size)
+bool ucdr_deserialize_array_uint32_t(ucdrBuffer* ub, uint32_t* array, const uint32_t size)
 {
-    return ucdr_deserialize_array_byte_4(mb, mb->endianness, array, size);
+    return ucdr_deserialize_array_byte_4(ub, ub->endianness, array, size);
 }
 
-bool ucdr_deserialize_array_uint64_t(ucdrBuffer* mb, uint64_t* array, const uint32_t size)
+bool ucdr_deserialize_array_uint64_t(ucdrBuffer* ub, uint64_t* array, const uint32_t size)
 {
-    return ucdr_deserialize_array_byte_8(mb, mb->endianness, array, size);
+    return ucdr_deserialize_array_byte_8(ub, ub->endianness, array, size);
 }
 
-bool ucdr_deserialize_array_int8_t(ucdrBuffer* mb, int8_t* array, const uint32_t size)
+bool ucdr_deserialize_array_int8_t(ucdrBuffer* ub, int8_t* array, const uint32_t size)
 {
-    return ucdr_deserialize_array_byte_1(mb, (uint8_t*)array, size);
+    return ucdr_deserialize_array_byte_1(ub, (uint8_t*)array, size);
 }
 
-bool ucdr_deserialize_array_int16_t(ucdrBuffer* mb, int16_t* array, const uint32_t size)
+bool ucdr_deserialize_array_int16_t(ucdrBuffer* ub, int16_t* array, const uint32_t size)
 {
-    return ucdr_deserialize_array_byte_2(mb, mb->endianness, (uint16_t*)array, size);
+    return ucdr_deserialize_array_byte_2(ub, ub->endianness, (uint16_t*)array, size);
 }
 
-bool ucdr_deserialize_array_int32_t(ucdrBuffer* mb, int32_t* array, const uint32_t size)
+bool ucdr_deserialize_array_int32_t(ucdrBuffer* ub, int32_t* array, const uint32_t size)
 {
-    return ucdr_deserialize_array_byte_4(mb, mb->endianness, (uint32_t*)array, size);
+    return ucdr_deserialize_array_byte_4(ub, ub->endianness, (uint32_t*)array, size);
 }
 
-bool ucdr_deserialize_array_int64_t(ucdrBuffer* mb, int64_t* array, const uint32_t size)
+bool ucdr_deserialize_array_int64_t(ucdrBuffer* ub, int64_t* array, const uint32_t size)
 {
-    return ucdr_deserialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
+    return ucdr_deserialize_array_byte_8(ub, ub->endianness, (uint64_t*)array, size);
 }
 
-bool ucdr_deserialize_array_float(ucdrBuffer* mb, float* array, const uint32_t size)
+bool ucdr_deserialize_array_float(ucdrBuffer* ub, float* array, const uint32_t size)
 {
-    return ucdr_deserialize_array_byte_4(mb, mb->endianness, (uint32_t*)array, size);
+    return ucdr_deserialize_array_byte_4(ub, ub->endianness, (uint32_t*)array, size);
 }
 
-bool ucdr_deserialize_array_double(ucdrBuffer* mb, double* array, const uint32_t size)
+bool ucdr_deserialize_array_double(ucdrBuffer* ub, double* array, const uint32_t size)
 {
-    return ucdr_deserialize_array_byte_8(mb, mb->endianness, (uint64_t*)array, size);
+    return ucdr_deserialize_array_byte_8(ub, ub->endianness, (uint64_t*)array, size);
 }
 
-bool ucdr_serialize_endian_array_uint16_t(ucdrBuffer* mb, const ucdrEndianness endianness, const uint16_t* array, const uint32_t size)
+bool ucdr_serialize_endian_array_uint16_t(ucdrBuffer* ub, const ucdrEndianness endianness, const uint16_t* array, const uint32_t size)
 {
-    return ucdr_serialize_array_byte_2(mb, endianness, array, size);
+    return ucdr_serialize_array_byte_2(ub, endianness, array, size);
 }
 
-bool ucdr_serialize_endian_array_uint32_t(ucdrBuffer* mb, const ucdrEndianness endianness, const uint32_t* array, const uint32_t size)
+bool ucdr_serialize_endian_array_uint32_t(ucdrBuffer* ub, const ucdrEndianness endianness, const uint32_t* array, const uint32_t size)
 {
-    return ucdr_serialize_array_byte_4(mb, endianness, array, size);
+    return ucdr_serialize_array_byte_4(ub, endianness, array, size);
 }
 
-bool ucdr_serialize_endian_array_uint64_t(ucdrBuffer* mb, const ucdrEndianness endianness, const uint64_t* array, const uint32_t size)
+bool ucdr_serialize_endian_array_uint64_t(ucdrBuffer* ub, const ucdrEndianness endianness, const uint64_t* array, const uint32_t size)
 {
-    return ucdr_serialize_array_byte_8(mb, endianness, array, size);
+    return ucdr_serialize_array_byte_8(ub, endianness, array, size);
 }
 
-bool ucdr_serialize_endian_array_int16_t(ucdrBuffer* mb, const ucdrEndianness endianness, const int16_t* array, const uint32_t size)
+bool ucdr_serialize_endian_array_int16_t(ucdrBuffer* ub, const ucdrEndianness endianness, const int16_t* array, const uint32_t size)
 {
-    return ucdr_serialize_array_byte_2(mb, endianness, (uint16_t*)array, size);
+    return ucdr_serialize_array_byte_2(ub, endianness, (uint16_t*)array, size);
 }
 
-bool ucdr_serialize_endian_array_int32_t(ucdrBuffer* mb, const ucdrEndianness endianness, const int32_t* array, const uint32_t size)
+bool ucdr_serialize_endian_array_int32_t(ucdrBuffer* ub, const ucdrEndianness endianness, const int32_t* array, const uint32_t size)
 {
-    return ucdr_serialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
+    return ucdr_serialize_array_byte_4(ub, endianness, (uint32_t*)array, size);
 }
 
-bool ucdr_serialize_endian_array_int64_t(ucdrBuffer* mb, const ucdrEndianness endianness, const int64_t* array, const uint32_t size)
+bool ucdr_serialize_endian_array_int64_t(ucdrBuffer* ub, const ucdrEndianness endianness, const int64_t* array, const uint32_t size)
 {
-    return ucdr_serialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
+    return ucdr_serialize_array_byte_8(ub, endianness, (uint64_t*)array, size);
 }
 
-bool ucdr_serialize_endian_array_float(ucdrBuffer* mb, const ucdrEndianness endianness, const float* array, const uint32_t size)
+bool ucdr_serialize_endian_array_float(ucdrBuffer* ub, const ucdrEndianness endianness, const float* array, const uint32_t size)
 {
-    return ucdr_serialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
+    return ucdr_serialize_array_byte_4(ub, endianness, (uint32_t*)array, size);
 }
 
-bool ucdr_serialize_endian_array_double(ucdrBuffer* mb, const ucdrEndianness endianness, const double* array, const uint32_t size)
+bool ucdr_serialize_endian_array_double(ucdrBuffer* ub, const ucdrEndianness endianness, const double* array, const uint32_t size)
 {
-    return ucdr_serialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
+    return ucdr_serialize_array_byte_8(ub, endianness, (uint64_t*)array, size);
 }
 
-bool ucdr_deserialize_endian_array_uint16_t(ucdrBuffer* mb, const ucdrEndianness endianness, uint16_t* array, const uint32_t size)
+bool ucdr_deserialize_endian_array_uint16_t(ucdrBuffer* ub, const ucdrEndianness endianness, uint16_t* array, const uint32_t size)
 {
-    return ucdr_deserialize_array_byte_2(mb, endianness, array, size);
+    return ucdr_deserialize_array_byte_2(ub, endianness, array, size);
 }
 
-bool ucdr_deserialize_endian_array_uint32_t(ucdrBuffer* mb, const ucdrEndianness endianness, uint32_t* array, const uint32_t size)
+bool ucdr_deserialize_endian_array_uint32_t(ucdrBuffer* ub, const ucdrEndianness endianness, uint32_t* array, const uint32_t size)
 {
-    return ucdr_deserialize_array_byte_4(mb, endianness, array, size);
+    return ucdr_deserialize_array_byte_4(ub, endianness, array, size);
 }
 
-bool ucdr_deserialize_endian_array_uint64_t(ucdrBuffer* mb, const ucdrEndianness endianness, uint64_t* array, const uint32_t size)
+bool ucdr_deserialize_endian_array_uint64_t(ucdrBuffer* ub, const ucdrEndianness endianness, uint64_t* array, const uint32_t size)
 {
-    return ucdr_deserialize_array_byte_8(mb, endianness, array, size);
+    return ucdr_deserialize_array_byte_8(ub, endianness, array, size);
 }
 
-bool ucdr_deserialize_endian_array_int16_t(ucdrBuffer* mb, const ucdrEndianness endianness, int16_t* array, const uint32_t size)
+bool ucdr_deserialize_endian_array_int16_t(ucdrBuffer* ub, const ucdrEndianness endianness, int16_t* array, const uint32_t size)
 {
-    return ucdr_deserialize_array_byte_2(mb, endianness, (uint16_t*)array, size);
+    return ucdr_deserialize_array_byte_2(ub, endianness, (uint16_t*)array, size);
 }
 
-bool ucdr_deserialize_endian_array_int32_t(ucdrBuffer* mb, const ucdrEndianness endianness, int32_t* array, const uint32_t size)
+bool ucdr_deserialize_endian_array_int32_t(ucdrBuffer* ub, const ucdrEndianness endianness, int32_t* array, const uint32_t size)
 {
-    return ucdr_deserialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
+    return ucdr_deserialize_array_byte_4(ub, endianness, (uint32_t*)array, size);
 }
 
-bool ucdr_deserialize_endian_array_int64_t(ucdrBuffer* mb, const ucdrEndianness endianness, int64_t* array, const uint32_t size)
+bool ucdr_deserialize_endian_array_int64_t(ucdrBuffer* ub, const ucdrEndianness endianness, int64_t* array, const uint32_t size)
 {
-    return ucdr_deserialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
+    return ucdr_deserialize_array_byte_8(ub, endianness, (uint64_t*)array, size);
 }
 
-bool ucdr_deserialize_endian_array_float(ucdrBuffer* mb, const ucdrEndianness endianness, float* array, const uint32_t size)
+bool ucdr_deserialize_endian_array_float(ucdrBuffer* ub, const ucdrEndianness endianness, float* array, const uint32_t size)
 {
-    return ucdr_deserialize_array_byte_4(mb, endianness, (uint32_t*)array, size);
+    return ucdr_deserialize_array_byte_4(ub, endianness, (uint32_t*)array, size);
 }
 
-bool ucdr_deserialize_endian_array_double(ucdrBuffer* mb, const ucdrEndianness endianness, double* array, const uint32_t size)
+bool ucdr_deserialize_endian_array_double(ucdrBuffer* ub, const ucdrEndianness endianness, double* array, const uint32_t size)
 {
-    return ucdr_deserialize_array_byte_8(mb, endianness, (uint64_t*)array, size);
+    return ucdr_deserialize_array_byte_8(ub, endianness, (uint64_t*)array, size);
 }
 

--- a/src/c/types/basic.c
+++ b/src/c/types/basic.c
@@ -23,405 +23,405 @@
 //                INTERNAL SERIALIZATION IMPLEMENTATION
 // -------------------------------------------------------------------
 
-bool ucdr_serialize_byte_1(ucdrBuffer* mb, const uint8_t* byte)
+bool ucdr_serialize_byte_1(ucdrBuffer* ub, const uint8_t* byte)
 {
     uint32_t data_size = sizeof(uint8_t);
-    if(ucdr_check_buffer(mb, data_size))
+    if(ucdr_check_buffer(ub, data_size))
     {
-        *mb->iterator = *byte;
+        *ub->iterator = *byte;
 
-        mb->iterator += data_size;
-        mb->last_data_size = data_size;
+        ub->iterator += data_size;
+        ub->last_data_size = data_size;
     }
-    return !mb->error;
+    return !ub->error;
 }
 
-bool ucdr_serialize_byte_2(ucdrBuffer* mb, const ucdrEndianness endianness, const uint16_t* bytes)
+bool ucdr_serialize_byte_2(ucdrBuffer* ub, const ucdrEndianness endianness, const uint16_t* bytes)
 {
     uint32_t data_size = sizeof(uint16_t);
-    uint32_t alignment = ucdr_buffer_alignment(mb, data_size);
+    uint32_t alignment = ucdr_buffer_alignment(ub, data_size);
 
-    if(ucdr_check_buffer(mb, alignment + data_size))
+    if(ucdr_check_buffer(ub, alignment + data_size))
     {
-        mb->iterator += alignment;
+        ub->iterator += alignment;
 
         if(UCDR_MACHINE_ENDIANNESS == endianness)
         {
-            memcpy(mb->iterator, bytes, data_size);
+            memcpy(ub->iterator, bytes, data_size);
         }
         else
         {
             uint8_t* bytes_pointer = (uint8_t*)bytes;
-            *mb->iterator = *(bytes_pointer + 1);
-            *(mb->iterator + 1) = *bytes_pointer;
+            *ub->iterator = *(bytes_pointer + 1);
+            *(ub->iterator + 1) = *bytes_pointer;
         }
 
-        mb->iterator += data_size;
-        mb->last_data_size = data_size;
+        ub->iterator += data_size;
+        ub->last_data_size = data_size;
     }
-    return !mb->error;
+    return !ub->error;
 }
 
-bool ucdr_serialize_byte_4(ucdrBuffer* mb, const ucdrEndianness endianness, const uint32_t* bytes)
+bool ucdr_serialize_byte_4(ucdrBuffer* ub, const ucdrEndianness endianness, const uint32_t* bytes)
 {
     uint32_t data_size = sizeof(uint32_t);
-    uint32_t alignment = ucdr_buffer_alignment(mb, data_size);
+    uint32_t alignment = ucdr_buffer_alignment(ub, data_size);
 
-    if(ucdr_check_buffer(mb, alignment + data_size))
+    if(ucdr_check_buffer(ub, alignment + data_size))
     {
-        mb->iterator += alignment;
+        ub->iterator += alignment;
 
         if(UCDR_MACHINE_ENDIANNESS == endianness)
         {
-            memcpy(mb->iterator, bytes, data_size);
+            memcpy(ub->iterator, bytes, data_size);
         }
         else
         {
             uint8_t* bytes_pointer = (uint8_t*)bytes;
-            *mb->iterator = *(bytes_pointer + 3);
-            *(mb->iterator + 1) = *(bytes_pointer + 2);
-            *(mb->iterator + 2) = *(bytes_pointer + 1);
-            *(mb->iterator + 3) = *bytes_pointer;
+            *ub->iterator = *(bytes_pointer + 3);
+            *(ub->iterator + 1) = *(bytes_pointer + 2);
+            *(ub->iterator + 2) = *(bytes_pointer + 1);
+            *(ub->iterator + 3) = *bytes_pointer;
         }
 
-        mb->iterator += data_size;
-        mb->last_data_size = data_size;
+        ub->iterator += data_size;
+        ub->last_data_size = data_size;
     }
-    return !mb->error;
+    return !ub->error;
 }
 
-bool ucdr_serialize_byte_8(ucdrBuffer* mb, const ucdrEndianness endianness, const uint64_t* bytes)
+bool ucdr_serialize_byte_8(ucdrBuffer* ub, const ucdrEndianness endianness, const uint64_t* bytes)
 {
     uint32_t data_size = sizeof(uint64_t);
-    uint32_t alignment = ucdr_buffer_alignment(mb, data_size);
+    uint32_t alignment = ucdr_buffer_alignment(ub, data_size);
 
-    if(ucdr_check_buffer(mb, alignment + data_size))
+    if(ucdr_check_buffer(ub, alignment + data_size))
     {
-        mb->iterator += alignment;
+        ub->iterator += alignment;
 
         if(UCDR_MACHINE_ENDIANNESS == endianness)
         {
-            memcpy(mb->iterator, bytes, data_size);
+            memcpy(ub->iterator, bytes, data_size);
         }
         else
         {
             uint8_t* bytes_pointer = (uint8_t*)bytes;
-            *mb->iterator = *(bytes_pointer + 7);
-            *(mb->iterator + 1) = *(bytes_pointer + 6);
-            *(mb->iterator + 2) = *(bytes_pointer + 5);
-            *(mb->iterator + 3) = *(bytes_pointer + 4);
-            *(mb->iterator + 4) = *(bytes_pointer + 3);
-            *(mb->iterator + 5) = *(bytes_pointer + 2);
-            *(mb->iterator + 6) = *(bytes_pointer + 1);
-            *(mb->iterator + 7) = *bytes_pointer;
+            *ub->iterator = *(bytes_pointer + 7);
+            *(ub->iterator + 1) = *(bytes_pointer + 6);
+            *(ub->iterator + 2) = *(bytes_pointer + 5);
+            *(ub->iterator + 3) = *(bytes_pointer + 4);
+            *(ub->iterator + 4) = *(bytes_pointer + 3);
+            *(ub->iterator + 5) = *(bytes_pointer + 2);
+            *(ub->iterator + 6) = *(bytes_pointer + 1);
+            *(ub->iterator + 7) = *bytes_pointer;
         }
 
-        mb->iterator += data_size;
-        mb->last_data_size = data_size;
+        ub->iterator += data_size;
+        ub->last_data_size = data_size;
     }
-    return !mb->error;
+    return !ub->error;
 }
 
-bool ucdr_deserialize_byte_1(ucdrBuffer* mb, uint8_t* byte)
+bool ucdr_deserialize_byte_1(ucdrBuffer* ub, uint8_t* byte)
 {
     uint32_t data_size = sizeof(uint8_t);
-    if(ucdr_check_buffer(mb, data_size))
+    if(ucdr_check_buffer(ub, data_size))
     {
-        *byte = *mb->iterator;
+        *byte = *ub->iterator;
 
-        mb->iterator += data_size;
-        mb->last_data_size = data_size;
+        ub->iterator += data_size;
+        ub->last_data_size = data_size;
     }
-    return !mb->error;
+    return !ub->error;
 }
 
-bool ucdr_deserialize_byte_2(ucdrBuffer* mb, const ucdrEndianness endianness, uint16_t* bytes)
+bool ucdr_deserialize_byte_2(ucdrBuffer* ub, const ucdrEndianness endianness, uint16_t* bytes)
 {
     uint32_t data_size = sizeof(uint16_t);
-    uint32_t alignment = ucdr_buffer_alignment(mb, data_size);
+    uint32_t alignment = ucdr_buffer_alignment(ub, data_size);
 
-    if(ucdr_check_buffer(mb, alignment + data_size))
+    if(ucdr_check_buffer(ub, alignment + data_size))
     {
-        mb->iterator += alignment;
+        ub->iterator += alignment;
 
         if(UCDR_MACHINE_ENDIANNESS == endianness)
         {
-            memcpy(bytes, mb->iterator, data_size);
+            memcpy(bytes, ub->iterator, data_size);
         }
         else
         {
             uint8_t* bytes_pointer = (uint8_t*)bytes;
-            *bytes_pointer = *(mb->iterator + 1);
-            *(bytes_pointer + 1) = *mb->iterator ;
+            *bytes_pointer = *(ub->iterator + 1);
+            *(bytes_pointer + 1) = *ub->iterator ;
         }
 
-        mb->iterator += data_size;
-        mb->last_data_size = data_size;
+        ub->iterator += data_size;
+        ub->last_data_size = data_size;
     }
-    return !mb->error;
+    return !ub->error;
 }
 
-bool ucdr_deserialize_byte_4(ucdrBuffer* mb, const ucdrEndianness endianness, uint32_t* bytes)
+bool ucdr_deserialize_byte_4(ucdrBuffer* ub, const ucdrEndianness endianness, uint32_t* bytes)
 {
     uint32_t data_size = sizeof(uint32_t);
-    uint32_t alignment = ucdr_buffer_alignment(mb, data_size);
+    uint32_t alignment = ucdr_buffer_alignment(ub, data_size);
 
-    if(ucdr_check_buffer(mb, alignment + data_size))
+    if(ucdr_check_buffer(ub, alignment + data_size))
     {
-        mb->iterator += alignment;
+        ub->iterator += alignment;
 
         if(UCDR_MACHINE_ENDIANNESS == endianness)
         {
-            memcpy(bytes, mb->iterator, data_size);
+            memcpy(bytes, ub->iterator, data_size);
         }
         else
         {
             uint8_t* bytes_pointer = (uint8_t*)bytes;
-            *bytes_pointer = *(mb->iterator + 3);
-            *(bytes_pointer + 1) = *(mb->iterator + 2);
-            *(bytes_pointer + 2) = *(mb->iterator + 1);
-            *(bytes_pointer + 3) = *mb->iterator;
+            *bytes_pointer = *(ub->iterator + 3);
+            *(bytes_pointer + 1) = *(ub->iterator + 2);
+            *(bytes_pointer + 2) = *(ub->iterator + 1);
+            *(bytes_pointer + 3) = *ub->iterator;
         }
 
-        mb->iterator += data_size;
-        mb->last_data_size = data_size;
+        ub->iterator += data_size;
+        ub->last_data_size = data_size;
     }
-    return !mb->error;
+    return !ub->error;
 }
 
-bool ucdr_deserialize_byte_8(ucdrBuffer* mb, const ucdrEndianness endianness, uint64_t* bytes)
+bool ucdr_deserialize_byte_8(ucdrBuffer* ub, const ucdrEndianness endianness, uint64_t* bytes)
 {
     uint32_t data_size = sizeof(uint64_t);
-    uint32_t alignment = ucdr_buffer_alignment(mb, data_size);
+    uint32_t alignment = ucdr_buffer_alignment(ub, data_size);
 
-    if(ucdr_check_buffer(mb, alignment + data_size))
+    if(ucdr_check_buffer(ub, alignment + data_size))
     {
-        mb->iterator += alignment;
+        ub->iterator += alignment;
 
         if(UCDR_MACHINE_ENDIANNESS == endianness)
         {
-            memcpy(bytes, mb->iterator, data_size);
+            memcpy(bytes, ub->iterator, data_size);
         }
         else
         {
             uint8_t* bytes_pointer = (uint8_t*)bytes;
-            *bytes_pointer = *(mb->iterator + 7);
-            *(bytes_pointer + 1) = *(mb->iterator + 6);
-            *(bytes_pointer + 2) = *(mb->iterator + 5);
-            *(bytes_pointer + 3) = *(mb->iterator + 4);
-            *(bytes_pointer + 4) = *(mb->iterator + 3);
-            *(bytes_pointer + 5) = *(mb->iterator + 2);
-            *(bytes_pointer + 6) = *(mb->iterator + 1);
-            *(bytes_pointer + 7) = *mb->iterator;
+            *bytes_pointer = *(ub->iterator + 7);
+            *(bytes_pointer + 1) = *(ub->iterator + 6);
+            *(bytes_pointer + 2) = *(ub->iterator + 5);
+            *(bytes_pointer + 3) = *(ub->iterator + 4);
+            *(bytes_pointer + 4) = *(ub->iterator + 3);
+            *(bytes_pointer + 5) = *(ub->iterator + 2);
+            *(bytes_pointer + 6) = *(ub->iterator + 1);
+            *(bytes_pointer + 7) = *ub->iterator;
         }
 
-        mb->iterator += data_size;
-        mb->last_data_size = data_size;
+        ub->iterator += data_size;
+        ub->last_data_size = data_size;
     }
-    return !mb->error;
+    return !ub->error;
 }
 
 // -------------------------------------------------------------------
 //                  PUBLIC SERIALIZATION IMPLEMENTATION
 // -------------------------------------------------------------------
 
-bool ucdr_serialize_char(ucdrBuffer* mb, const char value)
+bool ucdr_serialize_char(ucdrBuffer* ub, const char value)
 {
-    return ucdr_serialize_byte_1(mb, (uint8_t*)&value);
+    return ucdr_serialize_byte_1(ub, (uint8_t*)&value);
 }
 
-bool ucdr_serialize_bool(ucdrBuffer* mb, const bool value)
+bool ucdr_serialize_bool(ucdrBuffer* ub, const bool value)
 {
-    return ucdr_serialize_byte_1(mb, (uint8_t*)&value);
+    return ucdr_serialize_byte_1(ub, (uint8_t*)&value);
 }
 
-bool ucdr_serialize_uint8_t(ucdrBuffer* mb, const uint8_t value)
+bool ucdr_serialize_uint8_t(ucdrBuffer* ub, const uint8_t value)
 {
-    return ucdr_serialize_byte_1(mb, &value);
+    return ucdr_serialize_byte_1(ub, &value);
 }
 
-bool ucdr_serialize_uint16_t(ucdrBuffer* mb, const uint16_t value)
+bool ucdr_serialize_uint16_t(ucdrBuffer* ub, const uint16_t value)
 {
-    return ucdr_serialize_byte_2(mb, mb->endianness, &value);
+    return ucdr_serialize_byte_2(ub, ub->endianness, &value);
 }
 
-bool ucdr_serialize_uint32_t(ucdrBuffer* mb, const uint32_t value)
+bool ucdr_serialize_uint32_t(ucdrBuffer* ub, const uint32_t value)
 {
-    return ucdr_serialize_byte_4(mb, mb->endianness, &value);
+    return ucdr_serialize_byte_4(ub, ub->endianness, &value);
 }
 
-bool ucdr_serialize_uint64_t(ucdrBuffer* mb, const uint64_t value)
+bool ucdr_serialize_uint64_t(ucdrBuffer* ub, const uint64_t value)
 {
-    return ucdr_serialize_byte_8(mb, mb->endianness, &value);
+    return ucdr_serialize_byte_8(ub, ub->endianness, &value);
 }
 
-bool ucdr_serialize_int8_t(ucdrBuffer* mb, const int8_t value)
+bool ucdr_serialize_int8_t(ucdrBuffer* ub, const int8_t value)
 {
-    return ucdr_serialize_byte_1(mb, (uint8_t*)&value);
+    return ucdr_serialize_byte_1(ub, (uint8_t*)&value);
 }
 
-bool ucdr_serialize_int16_t(ucdrBuffer* mb, const int16_t value)
+bool ucdr_serialize_int16_t(ucdrBuffer* ub, const int16_t value)
 {
-    return ucdr_serialize_byte_2(mb, mb->endianness, (uint16_t*)&value);
+    return ucdr_serialize_byte_2(ub, ub->endianness, (uint16_t*)&value);
 }
 
-bool ucdr_serialize_int32_t(ucdrBuffer* mb, const int32_t value)
+bool ucdr_serialize_int32_t(ucdrBuffer* ub, const int32_t value)
 {
-    return ucdr_serialize_byte_4(mb, mb->endianness, (uint32_t*)&value);
+    return ucdr_serialize_byte_4(ub, ub->endianness, (uint32_t*)&value);
 }
 
-bool ucdr_serialize_int64_t(ucdrBuffer* mb, const int64_t value)
+bool ucdr_serialize_int64_t(ucdrBuffer* ub, const int64_t value)
 {
-    return ucdr_serialize_byte_8(mb, mb->endianness, (uint64_t*)&value);
+    return ucdr_serialize_byte_8(ub, ub->endianness, (uint64_t*)&value);
 }
 
-bool ucdr_serialize_float(ucdrBuffer* mb, const float value)
+bool ucdr_serialize_float(ucdrBuffer* ub, const float value)
 {
-    return ucdr_serialize_byte_4(mb, mb->endianness, (uint32_t*)&value);
+    return ucdr_serialize_byte_4(ub, ub->endianness, (uint32_t*)&value);
 }
 
-bool ucdr_serialize_double(ucdrBuffer* mb, const double value)
+bool ucdr_serialize_double(ucdrBuffer* ub, const double value)
 {
-    return ucdr_serialize_byte_8(mb, mb->endianness, (uint64_t*)&value);
+    return ucdr_serialize_byte_8(ub, ub->endianness, (uint64_t*)&value);
 }
 
-bool ucdr_deserialize_char(ucdrBuffer* mb, char* value)
+bool ucdr_deserialize_char(ucdrBuffer* ub, char* value)
 {
-    return ucdr_deserialize_byte_1(mb, (uint8_t*)value);
+    return ucdr_deserialize_byte_1(ub, (uint8_t*)value);
 }
 
-bool ucdr_deserialize_bool(ucdrBuffer* mb, bool* value)
+bool ucdr_deserialize_bool(ucdrBuffer* ub, bool* value)
 {
-    return ucdr_deserialize_byte_1(mb, (uint8_t*)value);
+    return ucdr_deserialize_byte_1(ub, (uint8_t*)value);
 }
 
-bool ucdr_deserialize_uint8_t(ucdrBuffer* mb, uint8_t* value)
+bool ucdr_deserialize_uint8_t(ucdrBuffer* ub, uint8_t* value)
 {
-    return ucdr_deserialize_byte_1(mb, value);
+    return ucdr_deserialize_byte_1(ub, value);
 }
 
-bool ucdr_deserialize_uint16_t(ucdrBuffer* mb, uint16_t* value)
+bool ucdr_deserialize_uint16_t(ucdrBuffer* ub, uint16_t* value)
 {
-    return ucdr_deserialize_byte_2(mb, mb->endianness, value);
+    return ucdr_deserialize_byte_2(ub, ub->endianness, value);
 }
 
-bool ucdr_deserialize_uint32_t(ucdrBuffer* mb, uint32_t* value)
+bool ucdr_deserialize_uint32_t(ucdrBuffer* ub, uint32_t* value)
 {
-    return ucdr_deserialize_byte_4(mb, mb->endianness, value);
+    return ucdr_deserialize_byte_4(ub, ub->endianness, value);
 }
 
-bool ucdr_deserialize_uint64_t(ucdrBuffer* mb, uint64_t* value)
+bool ucdr_deserialize_uint64_t(ucdrBuffer* ub, uint64_t* value)
 {
-    return ucdr_deserialize_byte_8(mb, mb->endianness, value);
+    return ucdr_deserialize_byte_8(ub, ub->endianness, value);
 }
 
-bool ucdr_deserialize_int8_t(ucdrBuffer* mb, int8_t* value)
+bool ucdr_deserialize_int8_t(ucdrBuffer* ub, int8_t* value)
 {
-    return ucdr_deserialize_byte_1(mb, (uint8_t*)value);
+    return ucdr_deserialize_byte_1(ub, (uint8_t*)value);
 }
 
-bool ucdr_deserialize_int16_t(ucdrBuffer* mb, int16_t* value)
+bool ucdr_deserialize_int16_t(ucdrBuffer* ub, int16_t* value)
 {
-    return ucdr_deserialize_byte_2(mb, mb->endianness, (uint16_t*)value);
+    return ucdr_deserialize_byte_2(ub, ub->endianness, (uint16_t*)value);
 }
 
-bool ucdr_deserialize_int32_t(ucdrBuffer* mb, int32_t* value)
+bool ucdr_deserialize_int32_t(ucdrBuffer* ub, int32_t* value)
 {
-    return ucdr_deserialize_byte_4(mb, mb->endianness, (uint32_t*)value);
+    return ucdr_deserialize_byte_4(ub, ub->endianness, (uint32_t*)value);
 }
 
-bool ucdr_deserialize_int64_t(ucdrBuffer* mb, int64_t* value)
+bool ucdr_deserialize_int64_t(ucdrBuffer* ub, int64_t* value)
 {
-    return ucdr_deserialize_byte_8(mb, mb->endianness, (uint64_t*)value);
+    return ucdr_deserialize_byte_8(ub, ub->endianness, (uint64_t*)value);
 }
 
-bool ucdr_deserialize_float(ucdrBuffer* mb, float* value)
+bool ucdr_deserialize_float(ucdrBuffer* ub, float* value)
 {
-    return ucdr_deserialize_byte_4(mb, mb->endianness, (uint32_t*)value);
+    return ucdr_deserialize_byte_4(ub, ub->endianness, (uint32_t*)value);
 }
 
-bool ucdr_deserialize_double(ucdrBuffer* mb, double* value)
+bool ucdr_deserialize_double(ucdrBuffer* ub, double* value)
 {
-    return ucdr_deserialize_byte_8(mb, mb->endianness, (uint64_t*)value);
+    return ucdr_deserialize_byte_8(ub, ub->endianness, (uint64_t*)value);
 }
 
-bool ucdr_serialize_endian_uint16_t(ucdrBuffer* mb, const ucdrEndianness endianness, const uint16_t value)
+bool ucdr_serialize_endian_uint16_t(ucdrBuffer* ub, const ucdrEndianness endianness, const uint16_t value)
 {
-    return ucdr_serialize_byte_2(mb, endianness, &value);
+    return ucdr_serialize_byte_2(ub, endianness, &value);
 }
 
-bool ucdr_serialize_endian_uint32_t(ucdrBuffer* mb, const ucdrEndianness endianness, const uint32_t value)
+bool ucdr_serialize_endian_uint32_t(ucdrBuffer* ub, const ucdrEndianness endianness, const uint32_t value)
 {
-    return ucdr_serialize_byte_4(mb, endianness, &value);
+    return ucdr_serialize_byte_4(ub, endianness, &value);
 }
 
-bool ucdr_serialize_endian_uint64_t(ucdrBuffer* mb, const ucdrEndianness endianness, const uint64_t value)
+bool ucdr_serialize_endian_uint64_t(ucdrBuffer* ub, const ucdrEndianness endianness, const uint64_t value)
 {
-    return ucdr_serialize_byte_8(mb, endianness, &value);
+    return ucdr_serialize_byte_8(ub, endianness, &value);
 }
 
-bool ucdr_serialize_endian_int16_t(ucdrBuffer* mb, const ucdrEndianness endianness, const int16_t value)
+bool ucdr_serialize_endian_int16_t(ucdrBuffer* ub, const ucdrEndianness endianness, const int16_t value)
 {
-    return ucdr_serialize_byte_2(mb, endianness, (uint16_t*)&value);
+    return ucdr_serialize_byte_2(ub, endianness, (uint16_t*)&value);
 }
 
-bool ucdr_serialize_endian_int32_t(ucdrBuffer* mb, const ucdrEndianness endianness, const int32_t value)
+bool ucdr_serialize_endian_int32_t(ucdrBuffer* ub, const ucdrEndianness endianness, const int32_t value)
 {
-    return ucdr_serialize_byte_4(mb, endianness, (uint32_t*)&value);
+    return ucdr_serialize_byte_4(ub, endianness, (uint32_t*)&value);
 }
 
-bool ucdr_serialize_endian_int64_t(ucdrBuffer* mb, const ucdrEndianness endianness, const int64_t value)
+bool ucdr_serialize_endian_int64_t(ucdrBuffer* ub, const ucdrEndianness endianness, const int64_t value)
 {
-    return ucdr_serialize_byte_8(mb, endianness, (uint64_t*)&value);
+    return ucdr_serialize_byte_8(ub, endianness, (uint64_t*)&value);
 }
 
-bool ucdr_serialize_endian_float(ucdrBuffer* mb, const ucdrEndianness endianness, const float value)
+bool ucdr_serialize_endian_float(ucdrBuffer* ub, const ucdrEndianness endianness, const float value)
 {
-    return ucdr_serialize_byte_4(mb, endianness, (uint32_t*)&value);
+    return ucdr_serialize_byte_4(ub, endianness, (uint32_t*)&value);
 }
 
-bool ucdr_serialize_endian_double(ucdrBuffer* mb, const ucdrEndianness endianness, const double value)
+bool ucdr_serialize_endian_double(ucdrBuffer* ub, const ucdrEndianness endianness, const double value)
 {
-    return ucdr_serialize_byte_8(mb, endianness, (uint64_t*)&value);
+    return ucdr_serialize_byte_8(ub, endianness, (uint64_t*)&value);
 }
 
-bool ucdr_deserialize_endian_uint16_t(ucdrBuffer* mb, const ucdrEndianness endianness, uint16_t* value)
+bool ucdr_deserialize_endian_uint16_t(ucdrBuffer* ub, const ucdrEndianness endianness, uint16_t* value)
 {
-    return ucdr_deserialize_byte_2(mb, endianness, value);
+    return ucdr_deserialize_byte_2(ub, endianness, value);
 }
 
-bool ucdr_deserialize_endian_uint32_t(ucdrBuffer* mb, const ucdrEndianness endianness, uint32_t* value)
+bool ucdr_deserialize_endian_uint32_t(ucdrBuffer* ub, const ucdrEndianness endianness, uint32_t* value)
 {
-    return ucdr_deserialize_byte_4(mb, endianness, value);
+    return ucdr_deserialize_byte_4(ub, endianness, value);
 }
 
-bool ucdr_deserialize_endian_uint64_t(ucdrBuffer* mb, const ucdrEndianness endianness, uint64_t* value)
+bool ucdr_deserialize_endian_uint64_t(ucdrBuffer* ub, const ucdrEndianness endianness, uint64_t* value)
 {
-    return ucdr_deserialize_byte_8(mb, endianness, value);
+    return ucdr_deserialize_byte_8(ub, endianness, value);
 }
 
-bool ucdr_deserialize_endian_int16_t(ucdrBuffer* mb, const ucdrEndianness endianness, int16_t* value)
+bool ucdr_deserialize_endian_int16_t(ucdrBuffer* ub, const ucdrEndianness endianness, int16_t* value)
 {
-    return ucdr_deserialize_byte_2(mb, endianness, (uint16_t*)value);
+    return ucdr_deserialize_byte_2(ub, endianness, (uint16_t*)value);
 }
 
-bool ucdr_deserialize_endian_int32_t(ucdrBuffer* mb, const ucdrEndianness endianness, int32_t* value)
+bool ucdr_deserialize_endian_int32_t(ucdrBuffer* ub, const ucdrEndianness endianness, int32_t* value)
 {
-    return ucdr_deserialize_byte_4(mb, endianness, (uint32_t*)value);
+    return ucdr_deserialize_byte_4(ub, endianness, (uint32_t*)value);
 }
 
-bool ucdr_deserialize_endian_int64_t(ucdrBuffer* mb, const ucdrEndianness endianness, int64_t* value)
+bool ucdr_deserialize_endian_int64_t(ucdrBuffer* ub, const ucdrEndianness endianness, int64_t* value)
 {
-    return ucdr_deserialize_byte_8(mb, endianness, (uint64_t*)value);
+    return ucdr_deserialize_byte_8(ub, endianness, (uint64_t*)value);
 }
 
-bool ucdr_deserialize_endian_float(ucdrBuffer* mb, const ucdrEndianness endianness, float* value)
+bool ucdr_deserialize_endian_float(ucdrBuffer* ub, const ucdrEndianness endianness, float* value)
 {
-    return ucdr_deserialize_byte_4(mb, endianness, (uint32_t*)value);
+    return ucdr_deserialize_byte_4(ub, endianness, (uint32_t*)value);
 }
 
-bool ucdr_deserialize_endian_double(ucdrBuffer* mb, const ucdrEndianness endianness, double* value)
+bool ucdr_deserialize_endian_double(ucdrBuffer* ub, const ucdrEndianness endianness, double* value)
 {
-    return ucdr_deserialize_byte_8(mb, endianness, (uint64_t*)value);
+    return ucdr_deserialize_byte_8(ub, endianness, (uint64_t*)value);
 }
 

--- a/src/c/types/sequence.c
+++ b/src/c/types/sequence.c
@@ -22,307 +22,307 @@
 // -------------------------------------------------------------------
 //                INTERNAL UTIL IMPLEMENTATION
 // -------------------------------------------------------------------
-static inline void ucdr_deserialize_sequence_header(ucdrBuffer* mb, ucdrEndianness endianness, uint32_t capacity, uint32_t* size)
+static inline void ucdr_deserialize_sequence_header(ucdrBuffer* ub, ucdrEndianness endianness, uint32_t capacity, uint32_t* size)
 {
-    ucdr_deserialize_endian_uint32_t(mb, endianness, size);
+    ucdr_deserialize_endian_uint32_t(ub, endianness, size);
     if(*size > capacity)
     {
-        mb->error = true;
+        ub->error = true;
     }
 }
 
 // -------------------------------------------------------------------
 //                INTERNAL SERIALIZATION IMPLEMENTATION
 // -------------------------------------------------------------------
-bool ucdr_serialize_sequence_byte_1(ucdrBuffer* mb, ucdrEndianness endianness, const uint8_t* array, const uint32_t size)
+bool ucdr_serialize_sequence_byte_1(ucdrBuffer* ub, ucdrEndianness endianness, const uint8_t* array, const uint32_t size)
 {
-    ucdr_serialize_endian_uint32_t(mb, endianness, size);
-    return ucdr_serialize_array_byte_1(mb, array, size);
+    ucdr_serialize_endian_uint32_t(ub, endianness, size);
+    return ucdr_serialize_array_byte_1(ub, array, size);
 }
 
-bool ucdr_serialize_sequence_byte_2(ucdrBuffer* mb, ucdrEndianness endianness, const uint16_t* array, const uint32_t size)
+bool ucdr_serialize_sequence_byte_2(ucdrBuffer* ub, ucdrEndianness endianness, const uint16_t* array, const uint32_t size)
 {
-    ucdr_serialize_endian_uint32_t(mb, endianness, size);
-    return ucdr_serialize_array_byte_2(mb, endianness, array, size);
+    ucdr_serialize_endian_uint32_t(ub, endianness, size);
+    return ucdr_serialize_array_byte_2(ub, endianness, array, size);
 }
 
-bool ucdr_serialize_sequence_byte_4(ucdrBuffer* mb, ucdrEndianness endianness, const uint32_t* array, const uint32_t size)
+bool ucdr_serialize_sequence_byte_4(ucdrBuffer* ub, ucdrEndianness endianness, const uint32_t* array, const uint32_t size)
 {
-    ucdr_serialize_endian_uint32_t(mb, endianness, size);
-    return ucdr_serialize_array_byte_4(mb, endianness, array, size);
+    ucdr_serialize_endian_uint32_t(ub, endianness, size);
+    return ucdr_serialize_array_byte_4(ub, endianness, array, size);
 }
 
-bool ucdr_serialize_sequence_byte_8(ucdrBuffer* mb, ucdrEndianness endianness, const uint64_t* array, const uint32_t size)
+bool ucdr_serialize_sequence_byte_8(ucdrBuffer* ub, ucdrEndianness endianness, const uint64_t* array, const uint32_t size)
 {
-    ucdr_serialize_endian_uint32_t(mb, endianness, size);
-    return ucdr_serialize_array_byte_8(mb, endianness, array, size);
+    ucdr_serialize_endian_uint32_t(ub, endianness, size);
+    return ucdr_serialize_array_byte_8(ub, endianness, array, size);
 }
 
-bool ucdr_deserialize_sequence_byte_1(ucdrBuffer* mb, ucdrEndianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
+bool ucdr_deserialize_sequence_byte_1(ucdrBuffer* ub, ucdrEndianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    ucdr_deserialize_sequence_header(mb, endianness, array_capacity, size);
-    return ucdr_deserialize_array_byte_1(mb, array, *size);
+    ucdr_deserialize_sequence_header(ub, endianness, array_capacity, size);
+    return ucdr_deserialize_array_byte_1(ub, array, *size);
 }
 
-bool ucdr_deserialize_sequence_byte_2(ucdrBuffer* mb, ucdrEndianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
+bool ucdr_deserialize_sequence_byte_2(ucdrBuffer* ub, ucdrEndianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    ucdr_deserialize_sequence_header(mb, endianness, array_capacity, size);
-    return ucdr_deserialize_array_byte_2(mb, endianness, array, *size);
+    ucdr_deserialize_sequence_header(ub, endianness, array_capacity, size);
+    return ucdr_deserialize_array_byte_2(ub, endianness, array, *size);
 }
 
-bool ucdr_deserialize_sequence_byte_4(ucdrBuffer* mb, ucdrEndianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
+bool ucdr_deserialize_sequence_byte_4(ucdrBuffer* ub, ucdrEndianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    ucdr_deserialize_sequence_header(mb, endianness, array_capacity, size);
-    return ucdr_deserialize_array_byte_4(mb, endianness, array, *size);
+    ucdr_deserialize_sequence_header(ub, endianness, array_capacity, size);
+    return ucdr_deserialize_array_byte_4(ub, endianness, array, *size);
 }
 
-bool ucdr_deserialize_sequence_byte_8(ucdrBuffer* mb, ucdrEndianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
+bool ucdr_deserialize_sequence_byte_8(ucdrBuffer* ub, ucdrEndianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    ucdr_deserialize_sequence_header(mb, endianness, array_capacity, size);
-    return ucdr_deserialize_array_byte_8(mb, endianness, array, *size);
+    ucdr_deserialize_sequence_header(ub, endianness, array_capacity, size);
+    return ucdr_deserialize_array_byte_8(ub, endianness, array, *size);
 }
 
 // -------------------------------------------------------------------
 //              PUBLIC SERIALIZATION IMPLEMENTATIONS
 // -------------------------------------------------------------------
 
-bool ucdr_serialize_sequence_char(ucdrBuffer* mb, const char* array, const uint32_t size)
+bool ucdr_serialize_sequence_char(ucdrBuffer* ub, const char* array, const uint32_t size)
 {
-    return ucdr_serialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, size);
+    return ucdr_serialize_sequence_byte_1(ub, ub->endianness, (uint8_t*)array, size);
 }
 
-bool ucdr_serialize_sequence_bool(ucdrBuffer* mb, const bool* array, const uint32_t size)
+bool ucdr_serialize_sequence_bool(ucdrBuffer* ub, const bool* array, const uint32_t size)
 {
-    return ucdr_serialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, size);
+    return ucdr_serialize_sequence_byte_1(ub, ub->endianness, (uint8_t*)array, size);
 }
 
-bool ucdr_serialize_sequence_uint8_t(ucdrBuffer* mb, const uint8_t* array, const uint32_t size)
+bool ucdr_serialize_sequence_uint8_t(ucdrBuffer* ub, const uint8_t* array, const uint32_t size)
 {
-    return ucdr_serialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, size);
+    return ucdr_serialize_sequence_byte_1(ub, ub->endianness, (uint8_t*)array, size);
 }
 
-bool ucdr_serialize_sequence_uint16_t(ucdrBuffer* mb, const uint16_t* array, const uint32_t size)
+bool ucdr_serialize_sequence_uint16_t(ucdrBuffer* ub, const uint16_t* array, const uint32_t size)
 {
-    return ucdr_serialize_sequence_byte_2(mb, mb->endianness, (uint16_t*)array, size);
+    return ucdr_serialize_sequence_byte_2(ub, ub->endianness, (uint16_t*)array, size);
 }
 
-bool ucdr_serialize_sequence_uint32_t(ucdrBuffer* mb, const uint32_t* array, const uint32_t size)
+bool ucdr_serialize_sequence_uint32_t(ucdrBuffer* ub, const uint32_t* array, const uint32_t size)
 {
-    return ucdr_serialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, size);
+    return ucdr_serialize_sequence_byte_4(ub, ub->endianness, (uint32_t*)array, size);
 }
 
-bool ucdr_serialize_sequence_uint64_t(ucdrBuffer* mb, const uint64_t* array, const uint32_t size)
+bool ucdr_serialize_sequence_uint64_t(ucdrBuffer* ub, const uint64_t* array, const uint32_t size)
 {
-    return ucdr_serialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, size);
+    return ucdr_serialize_sequence_byte_8(ub, ub->endianness, (uint64_t*)array, size);
 }
 
-bool ucdr_serialize_sequence_int8_t(ucdrBuffer* mb, const int8_t* array, const uint32_t size)
+bool ucdr_serialize_sequence_int8_t(ucdrBuffer* ub, const int8_t* array, const uint32_t size)
 {
-    return ucdr_serialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, size);
+    return ucdr_serialize_sequence_byte_1(ub, ub->endianness, (uint8_t*)array, size);
 }
 
-bool ucdr_serialize_sequence_int16_t(ucdrBuffer* mb, const int16_t* array, const uint32_t size)
+bool ucdr_serialize_sequence_int16_t(ucdrBuffer* ub, const int16_t* array, const uint32_t size)
 {
-    return ucdr_serialize_sequence_byte_2(mb, mb->endianness, (uint16_t*)array, size);
+    return ucdr_serialize_sequence_byte_2(ub, ub->endianness, (uint16_t*)array, size);
 }
 
-bool ucdr_serialize_sequence_int32_t(ucdrBuffer* mb, const int32_t* array, const uint32_t size)
+bool ucdr_serialize_sequence_int32_t(ucdrBuffer* ub, const int32_t* array, const uint32_t size)
 {
-    return ucdr_serialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, size);
+    return ucdr_serialize_sequence_byte_4(ub, ub->endianness, (uint32_t*)array, size);
 }
 
-bool ucdr_serialize_sequence_int64_t(ucdrBuffer* mb, const int64_t* array, const uint32_t size)
+bool ucdr_serialize_sequence_int64_t(ucdrBuffer* ub, const int64_t* array, const uint32_t size)
 {
-    return ucdr_serialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, size);
+    return ucdr_serialize_sequence_byte_8(ub, ub->endianness, (uint64_t*)array, size);
 }
 
-bool ucdr_serialize_sequence_float(ucdrBuffer* mb, const float* array, const uint32_t size)
+bool ucdr_serialize_sequence_float(ucdrBuffer* ub, const float* array, const uint32_t size)
 {
-    return ucdr_serialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, size);
+    return ucdr_serialize_sequence_byte_4(ub, ub->endianness, (uint32_t*)array, size);
 }
 
-bool ucdr_serialize_sequence_double(ucdrBuffer* mb, const double* array, const uint32_t size)
+bool ucdr_serialize_sequence_double(ucdrBuffer* ub, const double* array, const uint32_t size)
 {
-    return ucdr_serialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, size);
+    return ucdr_serialize_sequence_byte_8(ub, ub->endianness, (uint64_t*)array, size);
 }
 
-bool ucdr_deserialize_sequence_char(ucdrBuffer* mb, char* array, const uint32_t array_capacity, uint32_t* size)
+bool ucdr_deserialize_sequence_char(ucdrBuffer* ub, char* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return ucdr_deserialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, array_capacity, size);
+    return ucdr_deserialize_sequence_byte_1(ub, ub->endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool ucdr_deserialize_sequence_bool(ucdrBuffer* mb, bool* array, const uint32_t array_capacity, uint32_t* size)
+bool ucdr_deserialize_sequence_bool(ucdrBuffer* ub, bool* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return ucdr_deserialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, array_capacity, size);
+    return ucdr_deserialize_sequence_byte_1(ub, ub->endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool ucdr_deserialize_sequence_uint8_t(ucdrBuffer* mb, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
+bool ucdr_deserialize_sequence_uint8_t(ucdrBuffer* ub, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return ucdr_deserialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, array_capacity, size);
+    return ucdr_deserialize_sequence_byte_1(ub, ub->endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool ucdr_deserialize_sequence_uint16_t(ucdrBuffer* mb, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
+bool ucdr_deserialize_sequence_uint16_t(ucdrBuffer* ub, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return ucdr_deserialize_sequence_byte_2(mb, mb->endianness, (uint16_t*)array, array_capacity, size);
+    return ucdr_deserialize_sequence_byte_2(ub, ub->endianness, (uint16_t*)array, array_capacity, size);
 }
 
-bool ucdr_deserialize_sequence_uint32_t(ucdrBuffer* mb, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
+bool ucdr_deserialize_sequence_uint32_t(ucdrBuffer* ub, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return ucdr_deserialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, array_capacity, size);
+    return ucdr_deserialize_sequence_byte_4(ub, ub->endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool ucdr_deserialize_sequence_uint64_t(ucdrBuffer* mb, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
+bool ucdr_deserialize_sequence_uint64_t(ucdrBuffer* ub, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return ucdr_deserialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, array_capacity, size);
+    return ucdr_deserialize_sequence_byte_8(ub, ub->endianness, (uint64_t*)array, array_capacity, size);
 }
 
-bool ucdr_deserialize_sequence_int8_t(ucdrBuffer* mb, int8_t* array, const uint32_t array_capacity, uint32_t* size)
+bool ucdr_deserialize_sequence_int8_t(ucdrBuffer* ub, int8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return ucdr_deserialize_sequence_byte_1(mb, mb->endianness, (uint8_t*)array, array_capacity, size);
+    return ucdr_deserialize_sequence_byte_1(ub, ub->endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool ucdr_deserialize_sequence_int16_t(ucdrBuffer* mb, int16_t* array, const uint32_t array_capacity, uint32_t* size)
+bool ucdr_deserialize_sequence_int16_t(ucdrBuffer* ub, int16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return ucdr_deserialize_sequence_byte_2(mb, mb->endianness, (uint16_t*)array, array_capacity, size);
+    return ucdr_deserialize_sequence_byte_2(ub, ub->endianness, (uint16_t*)array, array_capacity, size);
 }
 
-bool ucdr_deserialize_sequence_int32_t(ucdrBuffer* mb, int32_t* array, const uint32_t array_capacity, uint32_t* size)
+bool ucdr_deserialize_sequence_int32_t(ucdrBuffer* ub, int32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return ucdr_deserialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, array_capacity, size);
+    return ucdr_deserialize_sequence_byte_4(ub, ub->endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool ucdr_deserialize_sequence_int64_t(ucdrBuffer* mb, int64_t* array, const uint32_t array_capacity, uint32_t* size)
+bool ucdr_deserialize_sequence_int64_t(ucdrBuffer* ub, int64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return ucdr_deserialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, array_capacity, size);
+    return ucdr_deserialize_sequence_byte_8(ub, ub->endianness, (uint64_t*)array, array_capacity, size);
 }
 
-bool ucdr_deserialize_sequence_float(ucdrBuffer* mb, float* array, const uint32_t array_capacity, uint32_t* size)
+bool ucdr_deserialize_sequence_float(ucdrBuffer* ub, float* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return ucdr_deserialize_sequence_byte_4(mb, mb->endianness, (uint32_t*)array, array_capacity, size);
+    return ucdr_deserialize_sequence_byte_4(ub, ub->endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool ucdr_deserialize_sequence_double(ucdrBuffer* mb, double* array, const uint32_t array_capacity, uint32_t* size)
+bool ucdr_deserialize_sequence_double(ucdrBuffer* ub, double* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return ucdr_deserialize_sequence_byte_8(mb, mb->endianness, (uint64_t*)array, array_capacity, size);
+    return ucdr_deserialize_sequence_byte_8(ub, ub->endianness, (uint64_t*)array, array_capacity, size);
 }
 
-bool ucdr_serialize_endian_sequence_char(ucdrBuffer* mb, const ucdrEndianness endianness, const char* array, const uint32_t size)
+bool ucdr_serialize_endian_sequence_char(ucdrBuffer* ub, const ucdrEndianness endianness, const char* array, const uint32_t size)
 {
-    return ucdr_serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
+    return ucdr_serialize_sequence_byte_1(ub, endianness, (uint8_t*)array, size);
 }
 
-bool ucdr_serialize_endian_sequence_bool(ucdrBuffer* mb, const ucdrEndianness endianness, const bool* array, const uint32_t size)
+bool ucdr_serialize_endian_sequence_bool(ucdrBuffer* ub, const ucdrEndianness endianness, const bool* array, const uint32_t size)
 {
-    return ucdr_serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
+    return ucdr_serialize_sequence_byte_1(ub, endianness, (uint8_t*)array, size);
 }
 
-bool ucdr_serialize_endian_sequence_uint8_t(ucdrBuffer* mb, const ucdrEndianness endianness, const uint8_t* array, const uint32_t size)
+bool ucdr_serialize_endian_sequence_uint8_t(ucdrBuffer* ub, const ucdrEndianness endianness, const uint8_t* array, const uint32_t size)
 {
-    return ucdr_serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
+    return ucdr_serialize_sequence_byte_1(ub, endianness, (uint8_t*)array, size);
 }
 
-bool ucdr_serialize_endian_sequence_uint16_t(ucdrBuffer* mb, const ucdrEndianness endianness, const uint16_t* array, const uint32_t size)
+bool ucdr_serialize_endian_sequence_uint16_t(ucdrBuffer* ub, const ucdrEndianness endianness, const uint16_t* array, const uint32_t size)
 {
-    return ucdr_serialize_sequence_byte_2(mb, endianness, (uint16_t*)array, size);
+    return ucdr_serialize_sequence_byte_2(ub, endianness, (uint16_t*)array, size);
 }
 
-bool ucdr_serialize_endian_sequence_uint32_t(ucdrBuffer* mb, const ucdrEndianness endianness, const uint32_t* array, const uint32_t size)
+bool ucdr_serialize_endian_sequence_uint32_t(ucdrBuffer* ub, const ucdrEndianness endianness, const uint32_t* array, const uint32_t size)
 {
-    return ucdr_serialize_sequence_byte_4(mb, endianness, (uint32_t*)array, size);
+    return ucdr_serialize_sequence_byte_4(ub, endianness, (uint32_t*)array, size);
 }
 
-bool ucdr_serialize_endian_sequence_uint64_t(ucdrBuffer* mb, const ucdrEndianness endianness, const uint64_t* array, const uint32_t size)
+bool ucdr_serialize_endian_sequence_uint64_t(ucdrBuffer* ub, const ucdrEndianness endianness, const uint64_t* array, const uint32_t size)
 {
-    return ucdr_serialize_sequence_byte_8(mb, endianness, (uint64_t*)array, size);
+    return ucdr_serialize_sequence_byte_8(ub, endianness, (uint64_t*)array, size);
 }
 
-bool ucdr_serialize_endian_sequence_int8_t(ucdrBuffer* mb, const ucdrEndianness endianness, const int8_t* array, const uint32_t size)
+bool ucdr_serialize_endian_sequence_int8_t(ucdrBuffer* ub, const ucdrEndianness endianness, const int8_t* array, const uint32_t size)
 {
-    return ucdr_serialize_sequence_byte_1(mb, endianness, (uint8_t*)array, size);
+    return ucdr_serialize_sequence_byte_1(ub, endianness, (uint8_t*)array, size);
 }
 
-bool ucdr_serialize_endian_sequence_int16_t(ucdrBuffer* mb, const ucdrEndianness endianness, const int16_t* array, const uint32_t size)
+bool ucdr_serialize_endian_sequence_int16_t(ucdrBuffer* ub, const ucdrEndianness endianness, const int16_t* array, const uint32_t size)
 {
-    return ucdr_serialize_sequence_byte_2(mb, endianness, (uint16_t*)array, size);
+    return ucdr_serialize_sequence_byte_2(ub, endianness, (uint16_t*)array, size);
 }
 
-bool ucdr_serialize_endian_sequence_int32_t(ucdrBuffer* mb, const ucdrEndianness endianness, const int32_t* array, const uint32_t size)
+bool ucdr_serialize_endian_sequence_int32_t(ucdrBuffer* ub, const ucdrEndianness endianness, const int32_t* array, const uint32_t size)
 {
-    return ucdr_serialize_sequence_byte_4(mb, endianness, (uint32_t*)array, size);
+    return ucdr_serialize_sequence_byte_4(ub, endianness, (uint32_t*)array, size);
 }
 
-bool ucdr_serialize_endian_sequence_int64_t(ucdrBuffer* mb, const ucdrEndianness endianness, const int64_t* array, const uint32_t size)
+bool ucdr_serialize_endian_sequence_int64_t(ucdrBuffer* ub, const ucdrEndianness endianness, const int64_t* array, const uint32_t size)
 {
-    return ucdr_serialize_sequence_byte_8(mb, endianness, (uint64_t*)array, size);
+    return ucdr_serialize_sequence_byte_8(ub, endianness, (uint64_t*)array, size);
 }
 
-bool ucdr_serialize_endian_sequence_float(ucdrBuffer* mb, const ucdrEndianness endianness, const float* array, const uint32_t size)
+bool ucdr_serialize_endian_sequence_float(ucdrBuffer* ub, const ucdrEndianness endianness, const float* array, const uint32_t size)
 {
-    return ucdr_serialize_sequence_byte_4(mb, endianness, (uint32_t*)array, size);
+    return ucdr_serialize_sequence_byte_4(ub, endianness, (uint32_t*)array, size);
 }
 
-bool ucdr_serialize_endian_sequence_double(ucdrBuffer* mb, const ucdrEndianness endianness, const double* array, const uint32_t size)
+bool ucdr_serialize_endian_sequence_double(ucdrBuffer* ub, const ucdrEndianness endianness, const double* array, const uint32_t size)
 {
-    return ucdr_serialize_sequence_byte_8(mb, endianness, (uint64_t*)array, size);
+    return ucdr_serialize_sequence_byte_8(ub, endianness, (uint64_t*)array, size);
 }
 
-bool ucdr_deserialize_endian_sequence_char(ucdrBuffer* mb, const ucdrEndianness endianness, char* array, const uint32_t array_capacity, uint32_t* size)
+bool ucdr_deserialize_endian_sequence_char(ucdrBuffer* ub, const ucdrEndianness endianness, char* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return ucdr_deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
+    return ucdr_deserialize_sequence_byte_1(ub, endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool ucdr_deserialize_endian_sequence_bool(ucdrBuffer* mb, const ucdrEndianness endianness, bool* array, const uint32_t array_capacity, uint32_t* size)
+bool ucdr_deserialize_endian_sequence_bool(ucdrBuffer* ub, const ucdrEndianness endianness, bool* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return ucdr_deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
+    return ucdr_deserialize_sequence_byte_1(ub, endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool ucdr_deserialize_endian_sequence_uint8_t(ucdrBuffer* mb, const ucdrEndianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
+bool ucdr_deserialize_endian_sequence_uint8_t(ucdrBuffer* ub, const ucdrEndianness endianness, uint8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return ucdr_deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
+    return ucdr_deserialize_sequence_byte_1(ub, endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool ucdr_deserialize_endian_sequence_uint16_t(ucdrBuffer* mb, const ucdrEndianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
+bool ucdr_deserialize_endian_sequence_uint16_t(ucdrBuffer* ub, const ucdrEndianness endianness, uint16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return ucdr_deserialize_sequence_byte_2(mb, endianness, (uint16_t*)array, array_capacity, size);
+    return ucdr_deserialize_sequence_byte_2(ub, endianness, (uint16_t*)array, array_capacity, size);
 }
 
-bool ucdr_deserialize_endian_sequence_uint32_t(ucdrBuffer* mb, const ucdrEndianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
+bool ucdr_deserialize_endian_sequence_uint32_t(ucdrBuffer* ub, const ucdrEndianness endianness, uint32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return ucdr_deserialize_sequence_byte_4(mb, endianness, (uint32_t*)array, array_capacity, size);
+    return ucdr_deserialize_sequence_byte_4(ub, endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool ucdr_deserialize_endian_sequence_uint64_t(ucdrBuffer* mb, const ucdrEndianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
+bool ucdr_deserialize_endian_sequence_uint64_t(ucdrBuffer* ub, const ucdrEndianness endianness, uint64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return ucdr_deserialize_sequence_byte_8(mb, endianness, (uint64_t*)array, array_capacity, size);
+    return ucdr_deserialize_sequence_byte_8(ub, endianness, (uint64_t*)array, array_capacity, size);
 }
 
-bool ucdr_deserialize_endian_sequence_int8_t(ucdrBuffer* mb, const ucdrEndianness endianness, int8_t* array, const uint32_t array_capacity, uint32_t* size)
+bool ucdr_deserialize_endian_sequence_int8_t(ucdrBuffer* ub, const ucdrEndianness endianness, int8_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return ucdr_deserialize_sequence_byte_1(mb, endianness, (uint8_t*)array, array_capacity, size);
+    return ucdr_deserialize_sequence_byte_1(ub, endianness, (uint8_t*)array, array_capacity, size);
 }
 
-bool ucdr_deserialize_endian_sequence_int16_t(ucdrBuffer* mb, const ucdrEndianness endianness, int16_t* array, const uint32_t array_capacity, uint32_t* size)
+bool ucdr_deserialize_endian_sequence_int16_t(ucdrBuffer* ub, const ucdrEndianness endianness, int16_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return ucdr_deserialize_sequence_byte_2(mb, endianness, (uint16_t*)array, array_capacity, size);
+    return ucdr_deserialize_sequence_byte_2(ub, endianness, (uint16_t*)array, array_capacity, size);
 }
 
-bool ucdr_deserialize_endian_sequence_int32_t(ucdrBuffer* mb, const ucdrEndianness endianness, int32_t* array, const uint32_t array_capacity, uint32_t* size)
+bool ucdr_deserialize_endian_sequence_int32_t(ucdrBuffer* ub, const ucdrEndianness endianness, int32_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return ucdr_deserialize_sequence_byte_4(mb, endianness, (uint32_t*)array, array_capacity, size);
+    return ucdr_deserialize_sequence_byte_4(ub, endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool ucdr_deserialize_endian_sequence_int64_t(ucdrBuffer* mb, const ucdrEndianness endianness, int64_t* array, const uint32_t array_capacity, uint32_t* size)
+bool ucdr_deserialize_endian_sequence_int64_t(ucdrBuffer* ub, const ucdrEndianness endianness, int64_t* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return ucdr_deserialize_sequence_byte_8(mb, endianness, (uint64_t*)array, array_capacity, size);
+    return ucdr_deserialize_sequence_byte_8(ub, endianness, (uint64_t*)array, array_capacity, size);
 }
 
-bool ucdr_deserialize_endian_sequence_float(ucdrBuffer* mb, const ucdrEndianness endianness, float* array, const uint32_t array_capacity, uint32_t* size)
+bool ucdr_deserialize_endian_sequence_float(ucdrBuffer* ub, const ucdrEndianness endianness, float* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return ucdr_deserialize_sequence_byte_4(mb, endianness, (uint32_t*)array, array_capacity, size);
+    return ucdr_deserialize_sequence_byte_4(ub, endianness, (uint32_t*)array, array_capacity, size);
 }
 
-bool ucdr_deserialize_endian_sequence_double(ucdrBuffer* mb, const ucdrEndianness endianness, double* array, const uint32_t array_capacity, uint32_t* size)
+bool ucdr_deserialize_endian_sequence_double(ucdrBuffer* ub, const ucdrEndianness endianness, double* array, const uint32_t array_capacity, uint32_t* size)
 {
-    return ucdr_deserialize_sequence_byte_8(mb, endianness, (uint64_t*)array, array_capacity, size);
+    return ucdr_deserialize_sequence_byte_8(ub, endianness, (uint64_t*)array, array_capacity, size);
 }
 

--- a/src/c/types/string.c
+++ b/src/c/types/string.c
@@ -22,24 +22,24 @@
 //              PUBLIC SERIALIZATION IMPLEMENTATIONS
 // -------------------------------------------------------------------
 
-bool ucdr_serialize_string(ucdrBuffer* mb, const char* string)
+bool ucdr_serialize_string(ucdrBuffer* ub, const char* string)
 {
-    return ucdr_serialize_sequence_char(mb, string, (uint32_t)strlen(string) + 1);
+    return ucdr_serialize_sequence_char(ub, string, (uint32_t)strlen(string) + 1);
 }
 
-bool ucdr_deserialize_string(ucdrBuffer* mb, char* string, const uint32_t string_capacity)
+bool ucdr_deserialize_string(ucdrBuffer* ub, char* string, const uint32_t string_capacity)
 {
     uint32_t length;
-    return ucdr_deserialize_sequence_char(mb, string, string_capacity, &length);
+    return ucdr_deserialize_sequence_char(ub, string, string_capacity, &length);
 }
 
-bool ucdr_serialize_endian_string(ucdrBuffer* mb, ucdrEndianness endianness, const char* string)
+bool ucdr_serialize_endian_string(ucdrBuffer* ub, ucdrEndianness endianness, const char* string)
 {
-    return ucdr_serialize_endian_sequence_char(mb, endianness, string, (uint32_t)strlen(string) + 1);
+    return ucdr_serialize_endian_sequence_char(ub, endianness, string, (uint32_t)strlen(string) + 1);
 }
 
-bool ucdr_deserialize_endian_string(ucdrBuffer* mb, ucdrEndianness endianness, char* string, const uint32_t string_capacity)
+bool ucdr_deserialize_endian_string(ucdrBuffer* ub, ucdrEndianness endianness, char* string, const uint32_t string_capacity)
 {
     uint32_t length;
-    return ucdr_deserialize_endian_sequence_char(mb, endianness, string, string_capacity, &length);
+    return ucdr_deserialize_endian_sequence_char(ub, endianness, string, string_capacity, &length);
 }


### PR DESCRIPTION
Modified the variable names `mb` to `ub` due to a previous refactor struct name `MicroBuffer` to `ucdrBuffer`.