### PR TITLE
Refs #4103. Clean MicroCDR

### DIFF
--- a/include/ucdr/common.h
+++ b/include/ucdr/common.h
@@ -42,7 +42,7 @@ typedef struct ucdrBuffer
     uint8_t *iterator;
 
     ucdrEndianness endianness;
-    uint32_t last_data_size;
+    uint8_t last_data_size;
 
     bool error;
 
@@ -56,18 +56,18 @@ UCDRDLLAPI extern const ucdrEndianness UCDR_MACHINE_ENDIANNESS;
 // ------------------------------------------------
 //              Main library functions
 // ------------------------------------------------
-UCDRDLLAPI void ucdr_init_buffer                     (ucdrBuffer* ub, uint8_t* data, const uint32_t size);
-UCDRDLLAPI void ucdr_init_buffer_offset              (ucdrBuffer* ub, uint8_t* data, const uint32_t size, uint32_t offset);
-UCDRDLLAPI void ucdr_init_buffer_offset_endian       (ucdrBuffer* ub, uint8_t* data, const uint32_t size, uint32_t offset, ucdrEndianness endianness);
+UCDRDLLAPI void ucdr_init_buffer                     (ucdrBuffer* ub, uint8_t* data, size_t size);
+UCDRDLLAPI void ucdr_init_buffer_offset              (ucdrBuffer* ub, uint8_t* data, size_t size, size_t offset);
+UCDRDLLAPI void ucdr_init_buffer_offset_endian       (ucdrBuffer* ub, uint8_t* data, size_t size, size_t offset, ucdrEndianness endianness);
 UCDRDLLAPI void ucdr_copy_buffer                     (ucdrBuffer* ub_dest, const ucdrBuffer* ub_source);
 UCDRDLLAPI void ucdr_set_on_full_buffer_callback     (ucdrBuffer* ub, OnFullBuffer on_full_buffer, void* args);
 
 UCDRDLLAPI void ucdr_reset_buffer        (ucdrBuffer* ub);
-UCDRDLLAPI void ucdr_reset_buffer_offset (ucdrBuffer* ub, const uint32_t offset);
+UCDRDLLAPI void ucdr_reset_buffer_offset (ucdrBuffer* ub, size_t offset);
 
-UCDRDLLAPI void     ucdr_align_to         (ucdrBuffer* ub, const uint32_t alignment);
-UCDRDLLAPI uint32_t ucdr_alignment        (uint32_t buffer_position, const uint32_t data_size);
-UCDRDLLAPI uint32_t ucdr_buffer_alignment (const ucdrBuffer* ub, const uint32_t data_size);
+UCDRDLLAPI void   ucdr_align_to         (ucdrBuffer* ub, size_t alignment);
+UCDRDLLAPI size_t ucdr_alignment        (size_t buffer_position, size_t data_size);
+UCDRDLLAPI size_t ucdr_buffer_alignment (const ucdrBuffer* ub, size_t data_size);
 
 UCDRDLLAPI size_t         ucdr_buffer_size       (const ucdrBuffer* ub);
 UCDRDLLAPI size_t         ucdr_buffer_length     (const ucdrBuffer* ub);

--- a/include/ucdr/types/array.h
+++ b/include/ucdr/types/array.h
@@ -25,12 +25,12 @@ extern "C" {
 //                         DECLARATION MACROS
 // -------------------------------------------------------------------
 #define UCDR_ARRAY_SERIALIZE_DECLARATION(SUFFIX, TYPE) \
-    UCDRDLLAPI bool ucdr_serialize_array ## SUFFIX(ucdrBuffer* ub, const TYPE* array, const uint32_t size); \
-    UCDRDLLAPI bool ucdr_serialize_endian_array ## SUFFIX(ucdrBuffer* ub, ucdrEndianness endianness, const TYPE* array, const uint32_t size); \
+    UCDRDLLAPI bool ucdr_serialize_array ## SUFFIX(ucdrBuffer* ub, const TYPE* array, size_t size); \
+    UCDRDLLAPI bool ucdr_serialize_endian_array ## SUFFIX(ucdrBuffer* ub, ucdrEndianness endianness, const TYPE* array, size_t size); \
 
 #define UCDR_ARRAY_DESERIALIZE_DECLARATION(SUFFIX, TYPE) \
-    UCDRDLLAPI bool ucdr_deserialize_array ## SUFFIX(ucdrBuffer* ub, TYPE* array, const uint32_t size); \
-    UCDRDLLAPI bool ucdr_deserialize_endian_array ## SUFFIX(ucdrBuffer* ub, ucdrEndianness endianness, TYPE* array, const uint32_t size); \
+    UCDRDLLAPI bool ucdr_deserialize_array ## SUFFIX(ucdrBuffer* ub, TYPE* array, size_t size); \
+    UCDRDLLAPI bool ucdr_deserialize_endian_array ## SUFFIX(ucdrBuffer* ub, ucdrEndianness endianness, TYPE* array, size_t size); \
 
 #define UCDR_ARRAY_DECLARATIONS(SUFFIX, TYPE) \
     UCDR_ARRAY_SERIALIZE_DECLARATION(SUFFIX, TYPE) \

--- a/include/ucdr/types/basic.h
+++ b/include/ucdr/types/basic.h
@@ -25,8 +25,8 @@ extern "C" {
 //                         DECLARATION MACROS
 // -------------------------------------------------------------------
 #define UCDR_BASIC_TYPE_SERIALIZE_DECLARATION(SUFFIX, TYPE) \
-    UCDRDLLAPI bool ucdr_serialize ## SUFFIX(ucdrBuffer* ub, const TYPE value); \
-    UCDRDLLAPI bool ucdr_serialize_endian ## SUFFIX(ucdrBuffer* ub, ucdrEndianness endianness, const TYPE value); \
+    UCDRDLLAPI bool ucdr_serialize ## SUFFIX(ucdrBuffer* ub, TYPE value); \
+    UCDRDLLAPI bool ucdr_serialize_endian ## SUFFIX(ucdrBuffer* ub, ucdrEndianness endianness, TYPE value); \
 
 #define UCDR_BASIC_TYPE_DESERIALIZE_DECLARATION(SUFFIX, TYPE) \
     UCDRDLLAPI bool ucdr_deserialize ## SUFFIX(ucdrBuffer* ub, TYPE* value); \

--- a/include/ucdr/types/sequence.h
+++ b/include/ucdr/types/sequence.h
@@ -25,12 +25,12 @@ extern "C" {
 //                         DECLARATION MACROS
 // -------------------------------------------------------------------
 #define UCDR_SEQUENCE_SERIALIZE_DECLARATION(SUFFIX, TYPE) \
-    UCDRDLLAPI bool ucdr_serialize_sequence ## SUFFIX(ucdrBuffer* ub, const TYPE* array, const uint32_t size); \
-    UCDRDLLAPI bool ucdr_serialize_endian_sequence ## SUFFIX(ucdrBuffer* ub, ucdrEndianness endianness, const TYPE* array, const uint32_t size); \
+    UCDRDLLAPI bool ucdr_serialize_sequence ## SUFFIX(ucdrBuffer* ub, const TYPE* array, uint32_t size); \
+    UCDRDLLAPI bool ucdr_serialize_endian_sequence ## SUFFIX(ucdrBuffer* ub, ucdrEndianness endianness, const TYPE* array, uint32_t size); \
 
 #define UCDR_SEQUENCE_DESERIALIZE_DECLARATION(SUFFIX, TYPE) \
-    UCDRDLLAPI bool ucdr_deserialize_sequence ## SUFFIX(ucdrBuffer* ub, TYPE* array, const uint32_t array_capacity, uint32_t* size); \
-    UCDRDLLAPI bool ucdr_deserialize_endian_sequence ## SUFFIX(ucdrBuffer* ub, ucdrEndianness endianness, TYPE* array, const uint32_t array_capacity, uint32_t* size); \
+    UCDRDLLAPI bool ucdr_deserialize_sequence ## SUFFIX(ucdrBuffer* ub, TYPE* array, size_t array_capacity, uint32_t* size); \
+    UCDRDLLAPI bool ucdr_deserialize_endian_sequence ## SUFFIX(ucdrBuffer* ub, ucdrEndianness endianness, TYPE* array, size_t array_capacity, uint32_t* size); \
 
 #define UCDR_SEQUENCE_DECLARATIONS(SUFFIX, TYPE) \
     UCDR_SEQUENCE_SERIALIZE_DECLARATION(SUFFIX, TYPE) \

--- a/include/ucdr/types/sequence.h
+++ b/include/ucdr/types/sequence.h
@@ -25,12 +25,12 @@ extern "C" {
 //                         DECLARATION MACROS
 // -------------------------------------------------------------------
 #define UCDR_SEQUENCE_SERIALIZE_DECLARATION(SUFFIX, TYPE) \
-    UCDRDLLAPI bool ucdr_serialize_sequence ## SUFFIX(ucdrBuffer* ub, const TYPE* array, uint32_t size); \
-    UCDRDLLAPI bool ucdr_serialize_endian_sequence ## SUFFIX(ucdrBuffer* ub, ucdrEndianness endianness, const TYPE* array, uint32_t size); \
+    UCDRDLLAPI bool ucdr_serialize_sequence ## SUFFIX(ucdrBuffer* ub, const TYPE* array, uint32_t length); \
+    UCDRDLLAPI bool ucdr_serialize_endian_sequence ## SUFFIX(ucdrBuffer* ub, ucdrEndianness endianness, const TYPE* array, uint32_t length); \
 
 #define UCDR_SEQUENCE_DESERIALIZE_DECLARATION(SUFFIX, TYPE) \
-    UCDRDLLAPI bool ucdr_deserialize_sequence ## SUFFIX(ucdrBuffer* ub, TYPE* array, size_t array_capacity, uint32_t* size); \
-    UCDRDLLAPI bool ucdr_deserialize_endian_sequence ## SUFFIX(ucdrBuffer* ub, ucdrEndianness endianness, TYPE* array, size_t array_capacity, uint32_t* size); \
+    UCDRDLLAPI bool ucdr_deserialize_sequence ## SUFFIX(ucdrBuffer* ub, TYPE* array, size_t array_capacity, uint32_t* length); \
+    UCDRDLLAPI bool ucdr_deserialize_endian_sequence ## SUFFIX(ucdrBuffer* ub, ucdrEndianness endianness, TYPE* array, size_t array_capacity, uint32_t* length); \
 
 #define UCDR_SEQUENCE_DECLARATIONS(SUFFIX, TYPE) \
     UCDR_SEQUENCE_SERIALIZE_DECLARATION(SUFFIX, TYPE) \

--- a/include/ucdr/types/string.h
+++ b/include/ucdr/types/string.h
@@ -29,10 +29,10 @@ extern "C" {
 // -------------------------------------------------------------------
 
 UCDRDLLAPI bool ucdr_serialize_string(ucdrBuffer* ub, const char* string);
-UCDRDLLAPI bool ucdr_deserialize_string(ucdrBuffer* ub, char* string, const uint32_t string_capacity);
-
 UCDRDLLAPI bool ucdr_serialize_endian_string(ucdrBuffer* ub, ucdrEndianness endianness, const char* string);
-UCDRDLLAPI bool ucdr_deserialize_endian_string(ucdrBuffer* ub, ucdrEndianness endianness, char* string, const uint32_t string_capacity);
+
+UCDRDLLAPI bool ucdr_deserialize_string(ucdrBuffer* ub, char* string, size_t string_capacity);
+UCDRDLLAPI bool ucdr_deserialize_endian_string(ucdrBuffer* ub, ucdrEndianness endianness, char* string, size_t string_capacity);
 
 #ifdef __cplusplus
 }

--- a/src/c/common_internal.h
+++ b/src/c/common_internal.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _SRC_COMMON_INTERNALS_H_
-#define _SRC_COMMON_INTERNALS_H_
+#ifndef _SRC_COMMON_INTERNAL_H_
+#define _SRC_COMMON_INTERNAL_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -24,12 +24,12 @@ extern "C" {
 // -------------------------------------------------------------------
 //                     INTERNAL UTIL FUNCTIONS
 // -------------------------------------------------------------------
-bool     ucdr_check_buffer_available_for(ucdrBuffer* ub, const uint32_t bytes);
-bool     ucdr_check_final_buffer_behavior(ucdrBuffer* ub, const uint32_t bytes);
-uint32_t ucdr_check_final_buffer_behavior_array(ucdrBuffer* ub, const uint32_t bytes, const uint32_t data_size);
+bool     ucdr_check_buffer_available_for(ucdrBuffer* ub, size_t bytes);
+bool     ucdr_check_final_buffer_behavior(ucdrBuffer* ub, size_t bytes);
+size_t   ucdr_check_final_buffer_behavior_array(ucdrBuffer* ub, size_t bytes, size_t data_size);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif //_SRC_COMMON_INTERNALS_H_
+#endif //_SRC_COMMON_INTERNAL_H_

--- a/src/c/types/array.c
+++ b/src/c/types/array.c
@@ -14,17 +14,17 @@
 
 #include <ucdr/types/array.h>
 #include <ucdr/types/basic.h>
-#include "../common_internals.h"
+#include "../common_internal.h"
 
 #include <string.h>
 
-static void ucdr_array_to_buffer(ucdrBuffer* ub, const uint8_t* array, const uint32_t size, const uint32_t data_size);
-static void ucdr_buffer_to_array(ucdrBuffer* ub, uint8_t* array, const uint32_t size, const uint32_t data_size);
+static void ucdr_array_to_buffer(ucdrBuffer* ub, const uint8_t* array, size_t size, size_t data_size);
+static void ucdr_buffer_to_array(ucdrBuffer* ub, uint8_t* array, size_t size, size_t data_size);
 
 // -------------------------------------------------------------------
 //                         SERIALIZE MACROS
 // -------------------------------------------------------------------
-void ucdr_array_to_buffer(ucdrBuffer* ub, const uint8_t* array, const uint32_t size, const uint32_t data_size)
+void ucdr_array_to_buffer(ucdrBuffer* ub, const uint8_t* array, size_t size, size_t data_size)
 {
     if(ucdr_check_buffer_available_for(ub, size))
     {
@@ -33,8 +33,8 @@ void ucdr_array_to_buffer(ucdrBuffer* ub, const uint8_t* array, const uint32_t s
     }
     else
     {
-        uint32_t remaining_size = size;
-        uint32_t serialization_size;
+        size_t remaining_size = size;
+        size_t serialization_size;
         while(0 < (serialization_size = ucdr_check_final_buffer_behavior_array(ub, remaining_size, data_size)))
         {
             memcpy(ub->iterator, array + (size - remaining_size), serialization_size);
@@ -42,10 +42,10 @@ void ucdr_array_to_buffer(ucdrBuffer* ub, const uint8_t* array, const uint32_t s
             ub->iterator += serialization_size;
         }
     }
-    ub->last_data_size = data_size;
+    ub->last_data_size = (uint8_t)data_size;
 }
 
-void ucdr_buffer_to_array(ucdrBuffer* ub, uint8_t* array, const uint32_t size, const uint32_t data_size)
+void ucdr_buffer_to_array(ucdrBuffer* ub, uint8_t* array, size_t size, size_t data_size)
 {
     if(ucdr_check_buffer_available_for(ub, size))
     {
@@ -54,8 +54,8 @@ void ucdr_buffer_to_array(ucdrBuffer* ub, uint8_t* array, const uint32_t size, c
     }
     else
     {
-        uint32_t remaining_size = size;
-        uint32_t deserialization_size;
+        size_t remaining_size = size;
+        size_t deserialization_size;
         while(0 < (deserialization_size = ucdr_check_final_buffer_behavior_array(ub, remaining_size, data_size)))
         {
             memcpy(array + (size - remaining_size), ub->iterator, deserialization_size);
@@ -63,7 +63,7 @@ void ucdr_buffer_to_array(ucdrBuffer* ub, uint8_t* array, const uint32_t size, c
             ub->iterator += deserialization_size;
         }
     }
-    ub->last_data_size = data_size;
+    ub->last_data_size = (uint8_t)data_size;
 }
 
 #define UCDR_SERIALIZE_ARRAY_BYTE_1(TYPE, ENDIAN) \
@@ -72,7 +72,7 @@ void ucdr_buffer_to_array(ucdrBuffer* ub, uint8_t* array, const uint32_t size, c
     return !ub->error;
 
 #define UCDR_SERIALIZE_ARRAY_BYTE_N(TYPE, TYPE_SIZE, ENDIAN) \
-    ub->iterator += ucdr_buffer_alignment(ub, (uint32_t)TYPE_SIZE); \
+    ub->iterator += ucdr_buffer_alignment(ub, TYPE_SIZE); \
     if(UCDR_MACHINE_ENDIANNESS == ENDIAN) \
     { \
         ucdr_array_to_buffer(ub, (uint8_t*)array, size * TYPE_SIZE, TYPE_SIZE); \
@@ -91,11 +91,11 @@ void ucdr_buffer_to_array(ucdrBuffer* ub, uint8_t* array, const uint32_t size, c
 #define UCDR_SERIALIZE_ARRAY_BYTE_8(TYPE, ENDIAN) UCDR_SERIALIZE_ARRAY_BYTE_N(TYPE, 8, ENDIAN)
 
 #define UCDR_SERIALIZE_ARRAY_DEFINITION(SUFFIX, TYPE, TYPE_SIZE) \
-    bool ucdr_serialize_array ## SUFFIX(ucdrBuffer* ub, const TYPE * array, const uint32_t size) \
+    bool ucdr_serialize_array ## SUFFIX(ucdrBuffer* ub, const TYPE* array, size_t size) \
     { \
         UCDR_SERIALIZE_ARRAY_BYTE_ ## TYPE_SIZE(TYPE, ub->endianness) \
     } \
-    bool ucdr_serialize_endian_array ## SUFFIX(ucdrBuffer* ub, const ucdrEndianness endianness, const TYPE * array, const uint32_t size) \
+    bool ucdr_serialize_endian_array ## SUFFIX(ucdrBuffer* ub, const ucdrEndianness endianness, const TYPE* array, size_t size) \
     { \
         UCDR_SERIALIZE_ARRAY_BYTE_ ## TYPE_SIZE(TYPE, endianness) \
     } \
@@ -109,7 +109,7 @@ void ucdr_buffer_to_array(ucdrBuffer* ub, uint8_t* array, const uint32_t size, c
     return !ub->error;
 
 #define UCDR_DESERIALIZE_ARRAY_BYTE_N(TYPE, TYPE_SIZE, ENDIAN) \
-    ub->iterator += ucdr_buffer_alignment(ub, (uint32_t)TYPE_SIZE); \
+    ub->iterator += ucdr_buffer_alignment(ub, TYPE_SIZE); \
     if(UCDR_MACHINE_ENDIANNESS == ENDIAN) \
     { \
         ucdr_buffer_to_array(ub, (uint8_t*)array, size * TYPE_SIZE, TYPE_SIZE); \
@@ -128,11 +128,11 @@ void ucdr_buffer_to_array(ucdrBuffer* ub, uint8_t* array, const uint32_t size, c
 #define UCDR_DESERIALIZE_ARRAY_BYTE_8(TYPE, ENDIAN) UCDR_DESERIALIZE_ARRAY_BYTE_N(TYPE, 8, ENDIAN)
 
 #define UCDR_DESERIALIZE_ARRAY_DEFINITION(SUFFIX, TYPE, TYPE_SIZE) \
-    bool ucdr_deserialize_array ## SUFFIX(ucdrBuffer* ub, TYPE * array, const uint32_t size) \
+    bool ucdr_deserialize_array ## SUFFIX(ucdrBuffer* ub, TYPE* array, size_t size) \
     { \
         UCDR_DESERIALIZE_ARRAY_BYTE_ ## TYPE_SIZE(TYPE, ub->endianness) \
     } \
-    bool ucdr_deserialize_endian_array ## SUFFIX(ucdrBuffer* ub, const ucdrEndianness endianness, TYPE * array, const uint32_t size) \
+    bool ucdr_deserialize_endian_array ## SUFFIX(ucdrBuffer* ub, ucdrEndianness endianness, TYPE* array, size_t size) \
     { \
         UCDR_DESERIALIZE_ARRAY_BYTE_ ## TYPE_SIZE(TYPE, endianness) \
     }

--- a/src/c/types/basic.c
+++ b/src/c/types/basic.c
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <ucdr/types/basic.h>
-#include "../common_internals.h"
+#include "../common_internal.h"
 
 #include <string.h>
 
@@ -22,7 +22,7 @@
 // -------------------------------------------------------------------
 #define UCDR_SERIALIZE_BYTE_1(TYPE, ENDIAN) \
     (void)ENDIAN; \
-    if(ucdr_check_final_buffer_behavior(ub, (uint32_t)1)) \
+    if(ucdr_check_final_buffer_behavior(ub, 1)) \
     { \
         *ub->iterator = (uint8_t)value; \
         ub->iterator += 1; \
@@ -31,19 +31,19 @@
     return !ub->error;
 
 #define UCDR_SERIALIZE_BYTE_2_CORE() \
-    uint8_t* bytes_pointer = (uint8_t*)&value; \
+    const uint8_t* bytes_pointer = (uint8_t*)&value; \
     *ub->iterator = *(bytes_pointer + 1); \
     *(ub->iterator + 1) = *bytes_pointer;
 
 #define UCDR_SERIALIZE_BYTE_4_CORE() \
-    uint8_t* bytes_pointer = (uint8_t*)&value; \
+    const uint8_t* bytes_pointer = (uint8_t*)&value; \
     *ub->iterator = *(bytes_pointer + 3); \
     *(ub->iterator + 1) = *(bytes_pointer + 2); \
     *(ub->iterator + 2) = *(bytes_pointer + 1); \
     *(ub->iterator + 3) = *bytes_pointer;
 
 #define UCDR_SERIALIZE_BYTE_8_CORE() \
-    uint8_t* bytes_pointer = (uint8_t*)&value; \
+    const uint8_t* bytes_pointer = (uint8_t*)&value; \
     *ub->iterator = *(bytes_pointer + 7); \
     *(ub->iterator + 1) = *(bytes_pointer + 6); \
     *(ub->iterator + 2) = *(bytes_pointer + 5); \
@@ -54,12 +54,12 @@
     *(ub->iterator + 7) = *bytes_pointer;
 
 #define UCDR_SERIALIZE_BYTE_N(TYPE, SIZE, ENDIAN) \
-    ub->iterator += ucdr_buffer_alignment(ub, (uint32_t)SIZE); \
-    if(ucdr_check_final_buffer_behavior(ub, (uint32_t)SIZE)) \
+    ub->iterator += ucdr_buffer_alignment(ub, SIZE); \
+    if(ucdr_check_final_buffer_behavior(ub, SIZE)) \
     { \
         if(UCDR_MACHINE_ENDIANNESS == ENDIAN) \
         { \
-            memcpy(ub->iterator, (void*)&value, (size_t)SIZE); \
+            memcpy(ub->iterator, (void*)&value, SIZE); \
         } \
         else \
         { \
@@ -75,11 +75,11 @@
 #define UCDR_SERIALIZE_BYTE_8(TYPE, ENDIAN) UCDR_SERIALIZE_BYTE_N(TYPE, 8, ENDIAN)
 
 #define UCDR_BASIC_TYPE_SERIALIZE_DEFINITION(SUFFIX, TYPE, SIZE) \
-    bool ucdr_serialize ## SUFFIX(ucdrBuffer* ub, const TYPE value) \
+    bool ucdr_serialize ## SUFFIX(ucdrBuffer* ub, TYPE value) \
     { \
         UCDR_SERIALIZE_BYTE_ ## SIZE(TYPE, ub->endianness) \
     } \
-    bool ucdr_serialize_endian ## SUFFIX(ucdrBuffer* ub, const ucdrEndianness endianness, const TYPE value) \
+    bool ucdr_serialize_endian ## SUFFIX(ucdrBuffer* ub, ucdrEndianness endianness, TYPE value) \
     { \
         UCDR_SERIALIZE_BYTE_ ## SIZE(TYPE, endianness) \
     }
@@ -89,11 +89,11 @@
 // -------------------------------------------------------------------
 #define UCDR_DESERIALIZE_BYTE_1(TYPE, ENDIAN) \
     (void)ENDIAN; \
-    if(ucdr_check_final_buffer_behavior(ub, (uint32_t)1)) \
+    if(ucdr_check_final_buffer_behavior(ub, 1)) \
     { \
         *value = (TYPE)*ub->iterator; \
-        ub->iterator += (uint32_t)1; \
-        ub->last_data_size = (uint32_t)1; \
+        ub->iterator += 1; \
+        ub->last_data_size = 1; \
     } \
     return !ub->error;
 
@@ -121,19 +121,19 @@
     *(bytes_pointer + 7) = *ub->iterator;
 
 #define UCDR_DESERIALIZE_BYTE_N(TYPE, SIZE, ENDIAN) \
-    ub->iterator += ucdr_buffer_alignment(ub, (uint32_t)SIZE); \
-    if(ucdr_check_final_buffer_behavior(ub, (uint32_t)SIZE)) \
+    ub->iterator += ucdr_buffer_alignment(ub, SIZE); \
+    if(ucdr_check_final_buffer_behavior(ub, SIZE)) \
     { \
         if(UCDR_MACHINE_ENDIANNESS == ENDIAN) \
         { \
-            memcpy((void*)value, ub->iterator, (size_t)SIZE); \
+            memcpy((void*)value, ub->iterator, SIZE); \
         } \
         else \
         { \
             UCDR_DESERIALIZE_BYTE_ ## SIZE ## _CORE() \
         } \
-        ub->iterator += (uint32_t)SIZE; \
-        ub->last_data_size = (uint32_t)SIZE; \
+        ub->iterator += SIZE; \
+        ub->last_data_size = SIZE; \
     } \
     return !ub->error;
 
@@ -146,7 +146,7 @@
     { \
         UCDR_DESERIALIZE_BYTE_ ## SIZE(TYPE, ub->endianness) \
     } \
-    bool ucdr_deserialize_endian ## SUFFIX(ucdrBuffer* ub, const ucdrEndianness endianness, TYPE* value) \
+    bool ucdr_deserialize_endian ## SUFFIX(ucdrBuffer* ub, ucdrEndianness endianness, TYPE* value) \
     { \
         UCDR_DESERIALIZE_BYTE_ ## SIZE(TYPE, endianness) \
     }

--- a/src/c/types/sequence.c
+++ b/src/c/types/sequence.c
@@ -16,15 +16,15 @@
 #include <ucdr/types/array.h>
 #include <ucdr/types/sequence.h>
 
-static void ucdr_deserialize_sequence_header(ucdrBuffer* ub, ucdrEndianness endianness, size_t capacity, uint32_t* size);
+static void ucdr_deserialize_sequence_header(ucdrBuffer* ub, ucdrEndianness endianness, size_t capacity, uint32_t* length);
 
 // -------------------------------------------------------------------
 //                INTERNAL UTIL IMPLEMENTATION
 // -------------------------------------------------------------------
-inline void ucdr_deserialize_sequence_header(ucdrBuffer* ub, ucdrEndianness endianness, size_t capacity, uint32_t* size)
+inline void ucdr_deserialize_sequence_header(ucdrBuffer* ub, ucdrEndianness endianness, size_t capacity, uint32_t* length)
 {
-    ucdr_deserialize_endian_uint32_t(ub, endianness, size);
-    if(*size > capacity)
+    ucdr_deserialize_endian_uint32_t(ub, endianness, length);
+    if(*length > capacity)
     {
         ub->error = true;
     }
@@ -34,30 +34,30 @@ inline void ucdr_deserialize_sequence_header(ucdrBuffer* ub, ucdrEndianness endi
 //                    SERIALIZE MACROS
 // -------------------------------------------------------------------
 #define UCDR_SEQUENCE_SERIALIZE_DEFINITION(SUFFIX, TYPE, SIZE) \
-    bool ucdr_serialize_sequence ## SUFFIX(ucdrBuffer* ub, const TYPE* array, uint32_t size) \
+    bool ucdr_serialize_sequence ## SUFFIX(ucdrBuffer* ub, const TYPE* array, uint32_t length) \
     { \
-        ucdr_serialize_endian_uint32_t(ub, ub->endianness, size); \
-        return ucdr_serialize_endian_array ## SUFFIX(ub, ub->endianness, array, size); \
+        ucdr_serialize_endian_uint32_t(ub, ub->endianness, length); \
+        return ucdr_serialize_endian_array ## SUFFIX(ub, ub->endianness, array, length); \
     } \
-    bool ucdr_serialize_endian_sequence ## SUFFIX(ucdrBuffer* ub, ucdrEndianness endianness, const TYPE* array, uint32_t size) \
+    bool ucdr_serialize_endian_sequence ## SUFFIX(ucdrBuffer* ub, ucdrEndianness endianness, const TYPE* array, uint32_t length) \
     { \
-        ucdr_serialize_endian_uint32_t(ub, endianness, size); \
-        return ucdr_serialize_endian_array ## SUFFIX(ub, endianness, array, size); \
+        ucdr_serialize_endian_uint32_t(ub, endianness, length); \
+        return ucdr_serialize_endian_array ## SUFFIX(ub, endianness, array, length); \
     } \
 
 // -------------------------------------------------------------------
 //                    DESERIALIZE MACROS
 // -------------------------------------------------------------------
 #define UCDR_SEQUENCE_DESERIALIZE_DEFINITION(SUFFIX, TYPE, SIZE) \
-    bool ucdr_deserialize_sequence ## SUFFIX(ucdrBuffer* ub, TYPE* array, size_t array_capacity, uint32_t* size) \
+    bool ucdr_deserialize_sequence ## SUFFIX(ucdrBuffer* ub, TYPE* array, size_t array_capacity, uint32_t* length) \
     { \
-        ucdr_deserialize_sequence_header(ub, ub->endianness, array_capacity, size); \
-        return ucdr_deserialize_endian_array ## SUFFIX(ub, ub->endianness, array, *size); \
+        ucdr_deserialize_sequence_header(ub, ub->endianness, array_capacity, length); \
+        return ucdr_deserialize_endian_array ## SUFFIX(ub, ub->endianness, array, *length); \
     } \
-    bool ucdr_deserialize_endian_sequence ## SUFFIX(ucdrBuffer* ub, ucdrEndianness endianness, TYPE* array, size_t array_capacity, uint32_t* size) \
+    bool ucdr_deserialize_endian_sequence ## SUFFIX(ucdrBuffer* ub, ucdrEndianness endianness, TYPE* array, size_t array_capacity, uint32_t* length) \
     { \
-        ucdr_deserialize_sequence_header(ub, endianness, array_capacity, size); \
-        return ucdr_deserialize_endian_array ## SUFFIX(ub, endianness, array, *size); \
+        ucdr_deserialize_sequence_header(ub, endianness, array_capacity, length); \
+        return ucdr_deserialize_endian_array ## SUFFIX(ub, endianness, array, *length); \
     } \
 
 // -------------------------------------------------------------------

--- a/src/c/types/sequence.c
+++ b/src/c/types/sequence.c
@@ -16,10 +16,12 @@
 #include <ucdr/types/array.h>
 #include <ucdr/types/sequence.h>
 
+static void ucdr_deserialize_sequence_header(ucdrBuffer* ub, ucdrEndianness endianness, size_t capacity, uint32_t* size);
+
 // -------------------------------------------------------------------
 //                INTERNAL UTIL IMPLEMENTATION
 // -------------------------------------------------------------------
-static inline void ucdr_deserialize_sequence_header(ucdrBuffer* ub, ucdrEndianness endianness, uint32_t capacity, uint32_t* size)
+inline void ucdr_deserialize_sequence_header(ucdrBuffer* ub, ucdrEndianness endianness, size_t capacity, uint32_t* size)
 {
     ucdr_deserialize_endian_uint32_t(ub, endianness, size);
     if(*size > capacity)
@@ -32,12 +34,12 @@ static inline void ucdr_deserialize_sequence_header(ucdrBuffer* ub, ucdrEndianne
 //                    SERIALIZE MACROS
 // -------------------------------------------------------------------
 #define UCDR_SEQUENCE_SERIALIZE_DEFINITION(SUFFIX, TYPE, SIZE) \
-    bool ucdr_serialize_sequence ## SUFFIX(ucdrBuffer* ub, const TYPE* array, const uint32_t size) \
+    bool ucdr_serialize_sequence ## SUFFIX(ucdrBuffer* ub, const TYPE* array, uint32_t size) \
     { \
         ucdr_serialize_endian_uint32_t(ub, ub->endianness, size); \
         return ucdr_serialize_endian_array ## SUFFIX(ub, ub->endianness, array, size); \
     } \
-    bool ucdr_serialize_endian_sequence ## SUFFIX(ucdrBuffer* ub, const ucdrEndianness endianness, const TYPE* array, const uint32_t size) \
+    bool ucdr_serialize_endian_sequence ## SUFFIX(ucdrBuffer* ub, ucdrEndianness endianness, const TYPE* array, uint32_t size) \
     { \
         ucdr_serialize_endian_uint32_t(ub, endianness, size); \
         return ucdr_serialize_endian_array ## SUFFIX(ub, endianness, array, size); \
@@ -47,12 +49,12 @@ static inline void ucdr_deserialize_sequence_header(ucdrBuffer* ub, ucdrEndianne
 //                    DESERIALIZE MACROS
 // -------------------------------------------------------------------
 #define UCDR_SEQUENCE_DESERIALIZE_DEFINITION(SUFFIX, TYPE, SIZE) \
-    bool ucdr_deserialize_sequence ## SUFFIX(ucdrBuffer* ub, TYPE* array, const uint32_t array_capacity, uint32_t* size) \
+    bool ucdr_deserialize_sequence ## SUFFIX(ucdrBuffer* ub, TYPE* array, size_t array_capacity, uint32_t* size) \
     { \
         ucdr_deserialize_sequence_header(ub, ub->endianness, array_capacity, size); \
         return ucdr_deserialize_endian_array ## SUFFIX(ub, ub->endianness, array, *size); \
     } \
-    bool ucdr_deserialize_endian_sequence ## SUFFIX(ucdrBuffer* ub, const ucdrEndianness endianness, TYPE* array, const uint32_t array_capacity, uint32_t* size) \
+    bool ucdr_deserialize_endian_sequence ## SUFFIX(ucdrBuffer* ub, ucdrEndianness endianness, TYPE* array, size_t array_capacity, uint32_t* size) \
     { \
         ucdr_deserialize_sequence_header(ub, endianness, array_capacity, size); \
         return ucdr_deserialize_endian_array ## SUFFIX(ub, endianness, array, *size); \

--- a/src/c/types/string.c
+++ b/src/c/types/string.c
@@ -27,18 +27,18 @@ bool ucdr_serialize_string(ucdrBuffer* ub, const char* string)
     return ucdr_serialize_sequence_char(ub, string, (uint32_t)strlen(string) + 1);
 }
 
-bool ucdr_deserialize_string(ucdrBuffer* ub, char* string, const uint32_t string_capacity)
-{
-    uint32_t length;
-    return ucdr_deserialize_sequence_char(ub, string, string_capacity, &length);
-}
-
 bool ucdr_serialize_endian_string(ucdrBuffer* ub, ucdrEndianness endianness, const char* string)
 {
     return ucdr_serialize_endian_sequence_char(ub, endianness, string, (uint32_t)strlen(string) + 1);
 }
 
-bool ucdr_deserialize_endian_string(ucdrBuffer* ub, ucdrEndianness endianness, char* string, const uint32_t string_capacity)
+bool ucdr_deserialize_string(ucdrBuffer* ub, char* string, size_t string_capacity)
+{
+    uint32_t length;
+    return ucdr_deserialize_sequence_char(ub, string, string_capacity, &length);
+}
+
+bool ucdr_deserialize_endian_string(ucdrBuffer* ub, ucdrEndianness endianness, char* string, size_t string_capacity)
 {
     uint32_t length;
     return ucdr_deserialize_endian_sequence_char(ub, endianness, string, string_capacity, &length);


### PR DESCRIPTION
- Removed `const` in API function value parameters
- Added `size_t` when it refers to sizes. (`uint32_t` is keept only when the standard forces to use it)
- Added const to internal locar variables into the function stack.
- *intenrals* file boy *internal*
- sequence parameter name `size` by `length`