### PR TITLE
CMake SOVERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,8 @@ set_common_compile_options(${PROJECT_NAME})
 set_target_properties(${PROJECT_NAME} PROPERTIES
     VERSION
         ${PROJECT_VERSION}
+    SOVERSION
+        ${PROJECT_VERSION_MAYOR}.${PROJECT_VERSION_MINOR}
     C_STANDARD
         99
     C_STANDARD_REQUIRED


### PR DESCRIPTION
This pull request sets the CMake SOVERSION to VERSION_MAYOR.VERSION_MINOR in order to avoid compatibility errors due to API changes in minor releases.