### PR TITLE
Isolated install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ option(UCDR_SUPERBUILD "Enable superbuild compilation." ON)
 option(UCDR_BUILD_TESTS "Build tests." OFF)
 option(UCDR_BUILD_EXAMPLES "Build examples." OFF)
 option(UCDR_PIC "Control Position Independent Code." ON)
+option(UCDR_ISOLATED_INSTALL "Install the project into a separated folder with version control." ON)
 option(BUILD_SHARED_LIBS "Control shared/static library building." OFF)
 
 option(UCDR_BUILD_CI_TESTS "Build CI test cases." OFF)
@@ -31,16 +32,6 @@ if(UCDR_BUILD_CI_TESTS)
     set(UCDR_BUILD_TESTS ON)
 endif()
 
-include(GNUInstallDirs)
-set(BIN_INSTALL_DIR     ${CMAKE_INSTALL_BINDIR}     CACHE PATH "Installation directory for binaries")
-set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR} CACHE PATH "Installation directory for C headers")
-set(LIB_INSTALL_DIR     ${CMAKE_INSTALL_LIBDIR}     CACHE PATH "Installation directory for libraries")
-set(DATA_INSTALL_DIR    ${CMAKE_INSTALL_DATADIR}    CACHE PATH "Installation directory for data")
-if(WIN32)
-    set(LICENSE_INSTALL_DIR . CACHE PATH "Installation directory for licenses")
-else()
-    set(LICENSE_INSTALL_DIR ${DATA_INSTALL_DIR}/${PROJECT_NAME} CACHE PATH "Installation directory for licenses")
-endif()
 set(CONFIG_BIG_ENDIANNESS OFF CACHE BOOL "Set the machine endianness to big endianness (default: little endianness).")
 
 # Set CMAKE_BUILD_TYPE to Release by default.
@@ -79,6 +70,24 @@ endif()
 include(${PROJECT_SOURCE_DIR}/cmake/common/check_configuration.cmake)
 if(MSVC OR MSVC_IDE)
     check_msvc_arch()
+endif()
+
+###############################################################################
+# Set install directories
+###############################################################################
+if(UCDR_ISOLATED_INSTALL)
+    set(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/${PROJECT_NAME}-${PROJECT_VERSION}")
+endif()
+
+include(GNUInstallDirs)
+set(BIN_INSTALL_DIR     ${CMAKE_INSTALL_BINDIR}     CACHE PATH "Installation directory for binaries")
+set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR} CACHE PATH "Installation directory for C headers")
+set(LIB_INSTALL_DIR     ${CMAKE_INSTALL_LIBDIR}     CACHE PATH "Installation directory for libraries")
+set(DATA_INSTALL_DIR    ${CMAKE_INSTALL_DATADIR}    CACHE PATH "Installation directory for data")
+if(WIN32)
+    set(LICENSE_INSTALL_DIR . CACHE PATH "Installation directory for licenses")
+else()
+    set(LICENSE_INSTALL_DIR ${DATA_INSTALL_DIR}/${PROJECT_NAME} CACHE PATH "Installation directory for licenses")
 endif()
 
 ###############################################################################

--- a/ci/linux/CMakeLists.txt
+++ b/ci/linux/CMakeLists.txt
@@ -34,13 +34,13 @@ if(_have_c_fprofile_abs_path)
     set(_c_flags "${_c_flags} -fprofile-abs-path")
 endif()
 
-ExternalProject_Add(microcdr
+ExternalProject_Add(microcdr_isolated
     SOURCE_DIR
         ${CMAKE_CURRENT_SOURCE_DIR}/../../
     BINARY_DIR
         ${PROJECT_BINARY_DIR}/microcdr-build
     INSTALL_DIR
-        ${PROJECT_BINARY_DIR}/temp_install
+        ${PROJECT_BINARY_DIR}/temp_install/isolated
     TEST_AFTER_INSTALL
         TRUE
     TEST_COMMAND
@@ -58,4 +58,33 @@ ExternalProject_Add(microcdr
         -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
         -DUCDR_BUILD_CI_TESTS:BOOL=ON
         -DGTEST_INDIVIDUAL:BOOL=ON
+    )
+
+ExternalProject_Add(microcdr_non_isolated
+    SOURCE_DIR
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../
+    BINARY_DIR
+        ${PROJECT_BINARY_DIR}/microcdr-build
+    INSTALL_DIR
+        ${PROJECT_BINARY_DIR}/temp_install/non_isolated
+    TEST_AFTER_INSTALL
+        TRUE
+    BUILD_COMMAND
+        ""
+    TEST_COMMAND
+        COMMAND ${CMAKE_CTEST_COMMAND} -VV -T Test -R "test-case*"
+    CMAKE_CACHE_ARGS
+        -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
+        -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
+        -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+        -DCMAKE_C_FLAGS:STRING=${_c_flags}
+        -DCMAKE_CXX_FLAGS:STRING=${_cxx_flags}
+        -DCMAKE_EXE_LINKER_FLAGS:STRING=${_exe_linker_flags}
+        -DCMAKE_SHARED_LINKER_FLAGS:STRING=${_shared_linker_flags}
+        -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+        -DUCDR_BUILD_CI_TESTS:BOOL=ON
+        -DUCDR_ISOLATED_INSTALL:BOOL=OFF
+        -DGTEST_INDIVIDUAL:BOOL=ON
+    DEPENDS
+        microcdr_isolated
     )

--- a/cmake/SuperBuild.cmake
+++ b/cmake/SuperBuild.cmake
@@ -35,10 +35,9 @@ if(UCDR_BUILD_TESTS)
             PREFIX
                 ${PROJECT_BINARY_DIR}/googletest
             INSTALL_DIR
-                ${PROJECT_BINARY_DIR}/temp_install
+                ${PROJECT_BINARY_DIR}/temp_install/googletest
             CMAKE_ARGS
                 -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
-                -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                 $<$<PLATFORM_ID:Windows>:-Dgtest_force_shared_crt:BOOL=ON>
             BUILD_COMMAND
                 COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config Release --target install
@@ -46,8 +45,8 @@ if(UCDR_BUILD_TESTS)
             INSTALL_COMMAND
                 ""
             )
-        set(GTEST_ROOT ${PROJECT_BINARY_DIR}/temp_install CACHE PATH "" FORCE)
-        set(GMOCK_ROOT ${PROJECT_BINARY_DIR}/temp_install CACHE PATH "" FORCE)
+        set(GTEST_ROOT ${PROJECT_BINARY_DIR}/temp_install/googletest CACHE PATH "" FORCE)
+        set(GMOCK_ROOT ${PROJECT_BINARY_DIR}/temp_install/googletest CACHE PATH "" FORCE)
         list(APPEND _deps googletest)
     endif()
 endif()


### PR DESCRIPTION
This pull request adds the `UCDR_ISOLATED_INSTALL` flag that generated installation, i.e., the project is installed into a separated folder with a version control numeration.