### PR TITLE
Origin/Offset [7903]

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,18 @@ As *MicroCDR* uses a static buffer, that means the user has to provide a defined
 ## API functions
 
 ```c
-void ucdr_init_buffer        (ucdrBuffer* ub, uint8_t* data, size_t size);
-void ucdr_init_buffer_offset (ucdrBuffer* ub, uint8_t* data, size_t size, size_t offset);
+void ucdr_init_buffer                       (ucdrBuffer* ub, uint8_t* data, size_t size);
+void ucdr_init_buffer_origin                (ucdrBuffer* ub, uint8_t* data, size_t size, size_t origin);
+void ucdr_init_buffer_origin_offset         (ucdrBuffer* ub, uint8_t* data, size_t size, size_t origin, size_t offset);
+void ucdr_init_buffer_origin_offset_endian  (ucdrBuffer* ub, uint8_t* data, size_t size, size_t origin, size_t offset, ucdrEndianness endianness);
 ```
 Initialize a `ucdrBuffer` structure, the main struct of *MicroCDR*.
-- `ub`: the `ucdrBuffer` struct
+- `ub`: the `ucdrBuffer` struct.
 - `data`: the buffer that the `ucdrBuffer` will use.
 - `size`: the size of the buffer that the `ucdrBuffer` will use.
+- `origin`: the origin of the XCDR stream.
 - `offset`: where the serialization/deserialization will start.
+- `endianness`: the endianness of the XCDR stream.
 Initially, the serialization/deserialization starts at the beginning of the buffer.
 
 ---
@@ -72,6 +76,16 @@ void ucdr_copy_buffer (ucdrBuffer* ub_dest, const ucdrBuffer* ub_source);
 Copy a `ucdrBuffer` structure data to another `ucdrBuffer` structure.
 - `ub_dest`: the destination `ucdrBuffer` struct.
 - `ub_source`: the origin initialized `ucdrBuffer` struct.
+
+---
+
+```c
+void ucdr_set_on_full_buffer_callback (ucdrBuffer* ub, OnFullBuffer on_full_buffer, void* args);
+```
+Sets the `on_full_buffer` callback which will be called each time the buffer arises its end.
+- `ub`: the `ucdrBuffer` struct.
+- `on_full_buffer`: the callcack.
+- `args`: the argument passes to the callback.
 
 ---
 
@@ -114,6 +128,15 @@ Returns the alignment necessary to serialize/deserialize a type with `data_size`
 
 - `ub`: the `ucdrBuffer` struct to ask the alignment.
 - `data_size`: the bytes of the data that you are asking for.
+---
+
+```c
+void ucdr_advance_buffer(const ucdrBuffer* ub, size_t size);
+```
+Advances the XCDR stream `size` bytes without de/serialization involved.
+
+- `ub`: the `ucdrBuffer` struct to ask the alignment.
+- `size`: the bytes to advance.
 ---
 
 ```c

--- a/include/ucdr/microcdr.h
+++ b/include/ucdr/microcdr.h
@@ -45,6 +45,9 @@ typedef struct ucdrBuffer
     uint8_t *final;
     uint8_t *iterator;
 
+    size_t origin;
+    size_t offset;
+
     ucdrEndianness endianness;
     uint8_t last_data_size;
 

--- a/include/ucdr/microcdr.h
+++ b/include/ucdr/microcdr.h
@@ -71,6 +71,7 @@ UCDRDLLAPI void ucdr_reset_buffer_offset (ucdrBuffer* ub, size_t offset);
 UCDRDLLAPI void   ucdr_align_to         (ucdrBuffer* ub, size_t alignment);
 UCDRDLLAPI size_t ucdr_alignment        (size_t buffer_position, size_t data_size);
 UCDRDLLAPI size_t ucdr_buffer_alignment (const ucdrBuffer* ub, size_t data_size);
+UCDRDLLAPI void   ucdr_advance_buffer   (ucdrBuffer* ub, size_t size);
 
 UCDRDLLAPI size_t         ucdr_buffer_size       (const ucdrBuffer* ub);
 UCDRDLLAPI size_t         ucdr_buffer_length     (const ucdrBuffer* ub);

--- a/include/ucdr/microcdr.h
+++ b/include/ucdr/microcdr.h
@@ -62,11 +62,12 @@ typedef struct ucdrBuffer
 //                 Main functions
 // ------------------------------------------------
 
-UCDRDLLAPI void ucdr_init_buffer                     (ucdrBuffer* ub, uint8_t* data, size_t size);
-UCDRDLLAPI void ucdr_init_buffer_offset              (ucdrBuffer* ub, uint8_t* data, size_t size, size_t offset);
-UCDRDLLAPI void ucdr_init_buffer_offset_endian       (ucdrBuffer* ub, uint8_t* data, size_t size, size_t offset, ucdrEndianness endianness);
-UCDRDLLAPI void ucdr_copy_buffer                     (ucdrBuffer* ub_dest, const ucdrBuffer* ub_source);
-UCDRDLLAPI void ucdr_set_on_full_buffer_callback     (ucdrBuffer* ub, OnFullBuffer on_full_buffer, void* args);
+UCDRDLLAPI void ucdr_init_buffer                        (ucdrBuffer* ub, uint8_t* data, size_t size);
+UCDRDLLAPI void ucdr_init_buffer_origin                 (ucdrBuffer* ub, uint8_t* data, size_t size, size_t origin);
+UCDRDLLAPI void ucdr_init_buffer_origin_offset          (ucdrBuffer* ub, uint8_t* data, size_t size, size_t origin, size_t offset);
+UCDRDLLAPI void ucdr_init_buffer_origin_offset_endian   (ucdrBuffer* ub, uint8_t* data, size_t size, size_t origin, size_t offset, ucdrEndianness endianness);
+UCDRDLLAPI void ucdr_copy_buffer                        (ucdrBuffer* ub_dest, const ucdrBuffer* ub_source);
+UCDRDLLAPI void ucdr_set_on_full_buffer_callback        (ucdrBuffer* ub, OnFullBuffer on_full_buffer, void* args);
 
 UCDRDLLAPI void ucdr_reset_buffer        (ucdrBuffer* ub);
 UCDRDLLAPI void ucdr_reset_buffer_offset (ucdrBuffer* ub, size_t offset);

--- a/src/c/common.c
+++ b/src/c/common.c
@@ -64,23 +64,46 @@ void ucdr_set_on_full_buffer_callback(ucdrBuffer* ub, OnFullBuffer on_full_buffe
 // -------------------------------------------------------------------
 //                       PUBLIC IMPLEMENTATION
 // -------------------------------------------------------------------
-void ucdr_init_buffer(ucdrBuffer* ub, uint8_t* data, size_t size)
+void ucdr_init_buffer(
+        ucdrBuffer* ub,
+        uint8_t* data,
+        size_t size)
 {
-    ucdr_init_buffer_offset(ub, data, size, 0u);
+    ucdr_init_buffer_origin(ub, data, size, 0u);
 }
 
-void ucdr_init_buffer_offset(ucdrBuffer* ub, uint8_t* data, size_t size, size_t offset)
+void ucdr_init_buffer_origin(
+        ucdrBuffer* ub,
+        uint8_t* data,
+        size_t size,
+        size_t origin)
 {
-    ucdr_init_buffer_offset_endian(ub, data, size, offset, UCDR_MACHINE_ENDIANNESS);
+    ucdr_init_buffer_origin_offset(ub, data, size, origin, 0u);
 }
 
-void ucdr_init_buffer_offset_endian(ucdrBuffer* ub, uint8_t* data, size_t size, size_t offset, ucdrEndianness endianness)
+void ucdr_init_buffer_origin_offset(
+        ucdrBuffer* ub,
+        uint8_t* data,
+        size_t size,
+        size_t origin,
+        size_t offset)
+{
+    ucdr_init_buffer_origin_offset_endian(ub, data, size, origin, offset, UCDR_MACHINE_ENDIANNESS);
+}
+
+void ucdr_init_buffer_origin_offset_endian(
+        ucdrBuffer* ub,
+        uint8_t* data,
+        size_t size,
+        size_t origin,
+        size_t offset,
+        ucdrEndianness endianness)
 {
     ub->init = data;
     ub->final = ub->init + size;
     ub->iterator = ub->init + offset;
-    ub->origin = 0u;
-    ub->offset = 0u;
+    ub->origin = origin;
+    ub->offset = origin + offset;
     ub->endianness = endianness;
     ub->last_data_size = 0u;
     ub->error = false;

--- a/src/c/common.c
+++ b/src/c/common.c
@@ -130,6 +130,25 @@ size_t ucdr_buffer_alignment(const ucdrBuffer* ub, size_t data_size)
     return 0;
 }
 
+void ucdr_advance_buffer(ucdrBuffer* ub, size_t size)
+{
+    if (ucdr_check_buffer_available_for(ub, size))
+    {
+        ub->iterator += size;
+    }
+    else
+    {
+        size_t remaining_size = size;
+        size_t serialization_size;
+        while(0 < (serialization_size = ucdr_check_final_buffer_behavior_array(ub, remaining_size, 1)))
+        {
+            remaining_size -= serialization_size;
+            ub->iterator += serialization_size;
+        }
+    }
+    ub->last_data_size = 1;
+}
+
 size_t ucdr_buffer_size(const ucdrBuffer* ub)
 {
     return (size_t)(ub->final - ub->init);

--- a/src/c/common.c
+++ b/src/c/common.c
@@ -160,6 +160,7 @@ void ucdr_advance_buffer(ucdrBuffer* ub, size_t size)
     if (ucdr_check_buffer_available_for(ub, size))
     {
         ub->iterator += size;
+        ub->offset += size;
     }
     else
     {
@@ -169,6 +170,7 @@ void ucdr_advance_buffer(ucdrBuffer* ub, size_t size)
         {
             remaining_size -= serialization_size;
             ub->iterator += serialization_size;
+            ub->offset += serialization_size;
         }
     }
     ub->last_data_size = 1;

--- a/src/c/types/array.c
+++ b/src/c/types/array.c
@@ -28,6 +28,7 @@ void ucdr_array_to_buffer(ucdrBuffer* ub, const uint8_t* array, size_t size, siz
     {
         memcpy(ub->iterator, array, size);
         ub->iterator += size;
+        ub->offset += size;
     }
     else
     {
@@ -38,6 +39,7 @@ void ucdr_array_to_buffer(ucdrBuffer* ub, const uint8_t* array, size_t size, siz
             memcpy(ub->iterator, array + (size - remaining_size), serialization_size);
             remaining_size -= serialization_size;
             ub->iterator += serialization_size;
+            ub->offset += serialization_size;
         }
     }
     ub->last_data_size = (uint8_t)data_size;
@@ -49,6 +51,7 @@ void ucdr_buffer_to_array(ucdrBuffer* ub, uint8_t* array, size_t size, size_t da
     {
         memcpy(array, ub->iterator, size);
         ub->iterator += size;
+        ub->offset += size;
     }
     else
     {
@@ -59,6 +62,7 @@ void ucdr_buffer_to_array(ucdrBuffer* ub, uint8_t* array, size_t size, size_t da
             memcpy(array + (size - remaining_size), ub->iterator, deserialization_size);
             remaining_size -= deserialization_size;
             ub->iterator += deserialization_size;
+            ub->offset += deserialization_size;
         }
     }
     ub->last_data_size = (uint8_t)data_size;
@@ -70,7 +74,9 @@ void ucdr_buffer_to_array(ucdrBuffer* ub, uint8_t* array, size_t size, size_t da
     return !ub->error;
 
 #define UCDR_SERIALIZE_ARRAY_BYTE_N(TYPE, TYPE_SIZE, ENDIAN) \
-    ub->iterator += ucdr_buffer_alignment(ub, TYPE_SIZE); \
+    size_t alignment = ucdr_buffer_alignment(ub, TYPE_SIZE); \
+    ub->iterator += alignment; \
+    ub->offset += alignment; \
     if(UCDR_MACHINE_ENDIANNESS == ENDIAN) \
     { \
         ucdr_array_to_buffer(ub, (uint8_t*)array, size * TYPE_SIZE, TYPE_SIZE); \
@@ -107,7 +113,9 @@ void ucdr_buffer_to_array(ucdrBuffer* ub, uint8_t* array, size_t size, size_t da
     return !ub->error;
 
 #define UCDR_DESERIALIZE_ARRAY_BYTE_N(TYPE, TYPE_SIZE, ENDIAN) \
-    ub->iterator += ucdr_buffer_alignment(ub, TYPE_SIZE); \
+    size_t alignment = ucdr_buffer_alignment(ub, TYPE_SIZE); \
+    ub->iterator += alignment; \
+    ub->offset += alignment; \
     if(UCDR_MACHINE_ENDIANNESS == ENDIAN) \
     { \
         ucdr_buffer_to_array(ub, (uint8_t*)array, size * TYPE_SIZE, TYPE_SIZE); \

--- a/src/c/types/basic.c
+++ b/src/c/types/basic.c
@@ -25,6 +25,7 @@
     { \
         *ub->iterator = (uint8_t)value; \
         ub->iterator += 1; \
+        ub->offset += 1; \
         ub->last_data_size = 1; \
     } \
     return !ub->error;
@@ -53,7 +54,9 @@
     *(ub->iterator + 7) = *bytes_pointer;
 
 #define UCDR_SERIALIZE_BYTE_N(TYPE, SIZE, ENDIAN) \
-    ub->iterator += ucdr_buffer_alignment(ub, SIZE); \
+    size_t alignment = ucdr_buffer_alignment(ub, SIZE); \
+    ub->iterator += alignment; \
+    ub->offset += alignment; \
     if(ucdr_check_final_buffer_behavior(ub, SIZE)) \
     { \
         if(UCDR_MACHINE_ENDIANNESS == ENDIAN) \
@@ -65,6 +68,7 @@
             UCDR_SERIALIZE_BYTE_ ## SIZE ## _CORE() \
         } \
         ub->iterator += SIZE; \
+        ub->offset += SIZE; \
         ub->last_data_size = SIZE; \
     } \
     return !ub->error;
@@ -92,6 +96,7 @@
     { \
         *value = (TYPE)*ub->iterator; \
         ub->iterator += 1; \
+        ub->offset += 1; \
         ub->last_data_size = 1; \
     } \
     return !ub->error;
@@ -120,7 +125,9 @@
     *(bytes_pointer + 7) = *ub->iterator;
 
 #define UCDR_DESERIALIZE_BYTE_N(TYPE, SIZE, ENDIAN) \
-    ub->iterator += ucdr_buffer_alignment(ub, SIZE); \
+    size_t alignment = ucdr_buffer_alignment(ub, SIZE); \
+    ub->iterator += alignment; \
+    ub->offset += alignment; \
     if(ucdr_check_final_buffer_behavior(ub, SIZE)) \
     { \
         if(UCDR_MACHINE_ENDIANNESS == ENDIAN) \
@@ -132,6 +139,7 @@
             UCDR_DESERIALIZE_BYTE_ ## SIZE ## _CORE() \
         } \
         ub->iterator += SIZE; \
+        ub->offset += SIZE; \
         ub->last_data_size = SIZE; \
     } \
     return !ub->error;


### PR DESCRIPTION
This PR adds the XCDR `origin` and `offset` concepts.
They are useful in case of fragmentation due to they allow keeping the alignment of the XCDR stream.