### PR TITLE
Only add -wsign-conversion if supported

### DIFF
--- a/cmake/common/check_configuration.cmake
+++ b/cmake/common/check_configuration.cmake
@@ -126,7 +126,6 @@ function(set_common_compile_options target)
             -Wunused
             $<$<COMPILE_LANGUAGE:CXX>:-Woverloaded-virtual>
             -Wconversion
-            -Wsign-conversion
             $<$<CXX_COMPILER_ID:GNU>:-Wlogical-op>
             $<$<AND:$<CXX_COMPILER_ID:GNU>,$<COMPILE_LANGUAGE:CXX>>:-Wuseless-cast>
             $<$<COMPILE_LANGUAGE:CXX>:-Wold-style-cast>
@@ -135,6 +134,7 @@ function(set_common_compile_options target)
             $<$<OR:$<AND:$<CXX_COMPILER_ID:GNU>,$<NOT:$<VERSION_LESS:$<CXX_COMPILER_VERSION>,6.0.0>>>,$<AND:$<C_COMPILER_ID:GNU>,$<NOT:$<VERSION_LESS:$<C_COMPILER_VERSION>,6.0.0>>>>:-Wduplicated-cond>
             $<$<OR:$<AND:$<CXX_COMPILER_ID:GNU>,$<NOT:$<VERSION_LESS:$<CXX_COMPILER_VERSION>,7.0.0>>>,$<AND:$<C_COMPILER_ID:GNU>,$<NOT:$<VERSION_LESS:$<C_COMPILER_VERSION>,7.0.0>>>>:-Wrestrict>
             $<$<OR:$<AND:$<CXX_COMPILER_ID:GNU>,$<NOT:$<VERSION_LESS:$<CXX_COMPILER_VERSION>,4.6.0>>>,$<AND:$<C_COMPILER_ID:GNU>,$<NOT:$<VERSION_LESS:$<C_COMPILER_VERSION>,4.6.0>>>>:-Wdouble-promotion>
+            $<$<OR:$<AND:$<CXX_COMPILER_ID:GNU>,$<NOT:$<VERSION_LESS:$<CXX_COMPILER_VERSION>,4.3.0>>>,$<AND:$<C_COMPILER_ID:GNU>,$<NOT:$<VERSION_LESS:$<C_COMPILER_VERSION>,4.3.0>>>>:-Wsign-conversion>
             )
     endif()
 endfunction()


### PR DESCRIPTION
Context: #65.

This is the same platform.

No impact for any compiler newer than `4.3.0`.
